### PR TITLE
Pass argument along as apparently intended

### DIFF
--- a/src/abc/base_player.py
+++ b/src/abc/base_player.py
@@ -41,6 +41,6 @@ class BasePlayer():
     @faction.setter
     def faction(self, value):
         if isinstance(value, str):
-            self._faction = Faction.from_string()
+            self._faction = Faction.from_string(value)
         else:
             self._faction = value


### PR DESCRIPTION
Given the code was broken before, it might be unused. So perhaps it's better to remove it?