### PR TITLE
Pseudocode of possible solution of lobby connections

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -218,10 +218,17 @@ class GameConnection(Subscribable, GpgNetServerProtocol):
                 yield from self.ConnectToHost(self.game.host.game_connection)
                 self._state = GameConnectionState.CONNECTED_TO_HOST
                 self.game.add_game_connection(self)
+                connections = []
                 for peer in self.game.connections:
                     if peer != self and peer.player != self.game.host:
-                        self.log.debug("{} connecting to {}".format(self.player, peer))
-                        asyncio.async(self.ConnectToPeer(peer))
+                        self.log.debug("Establish connection {} to {}".format(self.player, peer))
+                        connections.append(self.EstablishConnection(peer))
+
+                results = await asyncio.gather(*connections, return_Exceptions=true)
+                for r in results:
+                    # Connect by the results here
+
+
         except Exception as e:
             self.log.exception(e)
 
@@ -272,7 +279,6 @@ class GameConnection(Subscribable, GpgNetServerProtocol):
         Connect two peers
         :return: None
         """
-        connection, own_addr, peer_addr = yield from self.EstablishConnection(peer)
         if connection == ConnectivityState.PUBLIC or connection == ConnectivityState.STUN:
             self.send_ConnectToPeer(peer_addr,
                                     peer.player.login,


### PR DESCRIPTION
The current problem with the lobby is that ConnectToPeer on lobby side seems to block connections completely, even the NAT processing ones.

If we instead establish connections first before we start ordering everyone to connect to eachother we will fix the problem with ppl using proxy connections when they still are able to connect.

The code in this PR isn't complete, I don't have a python work-environment so can't test the actual changes either. 

Would be great if someone (@Sheeo ;)) could take a look at this, should be a quick change. What's needed is to be able to get the result from each EstablishConnection() to the later called ConnectToPeer. Either by putting that data on each peer object? Or maybe change the arguments of the function.

