### PR TITLE
Add new game variable and related GPGNet-command `EnforceRating`

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -354,6 +354,9 @@ class GameConnection(GpgNetServerProtocol):
             elif command == 'JsonStats':
                 await self.game.report_army_stats(args[0])
 
+            elif command == 'EnforceRating':
+                self.game.enforce_rating = True
+
 
         except AuthenticationError as e:
             self.log.exception("Authentication error: {}".format(e))

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -11,7 +11,7 @@ class CustomGame(Game):
 
     async def rate_game(self):
         limit = len(self.players) * 60
-        if time.time() - self.launched_at < limit:
+        if not self.enforce_rating and time.time() - self.launched_at < limit:
             await self.mark_invalid(ValidityState.TOO_SHORT)
         if self.validity == ValidityState.VALID:
             new_ratings = self.compute_rating(rating='global')

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -125,6 +125,7 @@ class Game(BaseGame):
         self.game_mode = game_mode
         self.state = GameState.INITIALIZING
         self._connections = {}
+        self.enforce_rating = False
         self.gameOptions = {'FogOfWar': 'explored',
                             'GameSpeed': 'normal',
                             'Victory': Victory.from_gpgnet_string('demoralization'),

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,8 +2,9 @@ import asyncio
 from unittest import mock
 import pytest
 
-from server import LobbyConnection
-
+from server import GameStatsService, LobbyConnection
+from server.gameconnection import GameConnection, GameConnectionState
+from tests import CoroMock
 
 @pytest.fixture()
 def lobbythread():
@@ -29,6 +30,13 @@ def game_connection(request, game, loop, player_service, players, game_service, 
 
     request.addfinalizer(fin)
     return conn
+
+
+@pytest.fixture()
+def game_stats_service():
+    service = mock.Mock(spec=GameStatsService)
+    service.process_game_stats = CoroMock()
+    return service
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -1,23 +1,13 @@
-import logging
 from unittest import mock
-import asyncio
 
 import pytest
 import time
 
-from server import GameStatsService
 from server.games.game import GameState, ValidityState
 from server.games.custom_game import CustomGame
 from server.gameconnection import GameConnection, GameConnectionState
 from server.players import Player
-from tests import CoroMock
 
-
-@pytest.fixture()
-def game_stats_service():
-    service = mock.Mock(spec=GameStatsService)
-    service.process_game_stats = CoroMock()
-    return service
 
 @pytest.fixture()
 def game_connection(state=GameConnectionState.INITIALIZING, player=None):

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -1,0 +1,101 @@
+import logging
+from unittest import mock
+import asyncio
+
+import pytest
+import time
+
+from server import GameStatsService
+from server.games.game import GameState, ValidityState
+from server.games.custom_game import CustomGame
+from server.gameconnection import GameConnection, GameConnectionState
+from server.players import Player
+from tests import CoroMock
+
+
+@pytest.fixture()
+def game_stats_service():
+    service = mock.Mock(spec=GameStatsService)
+    service.process_game_stats = CoroMock()
+    return service
+
+@pytest.fixture()
+def game_connection(state=GameConnectionState.INITIALIZING, player=None):
+    gc = mock.create_autospec(spec=GameConnection)
+    gc.state = state
+    gc.player = player
+    return gc
+
+def add_connected_player(custom_game: CustomGame, player):
+    custom_game.game_service.player_service[player.id] = player
+    gc = game_connection(state=GameConnectionState.CONNECTED_TO_HOST, player=player)
+    custom_game.set_player_option(player.id, 'Army', 0)
+    custom_game.set_player_option(player.id, 'StartSpot', 0)
+    custom_game.set_player_option(player.id, 'Team', 0)
+    custom_game.set_player_option(player.id, 'Faction', 0)
+    custom_game.set_player_option(player.id, 'Color', 0)
+    custom_game.add_game_connection(gc)
+    return gc
+
+def add_connected_players(game: CustomGame, players):
+    """
+    Utility to add players with army and StartSpot indexed by a list
+    """
+    for army, player in enumerate(players):
+        add_connected_player(game, player)
+        game.set_player_option(player.id, 'Army', army)
+        game.set_player_option(player.id, 'StartSpot', army)
+        game.set_player_option(player.id, 'Team', army)
+        game.set_player_option(player.id, 'Faction', 0)
+        game.set_player_option(player.id, 'Color', 0)
+    game.host = players[0]
+
+async def test_rate_game_early_abort_no_enforce(game_service, game_stats_service):
+    custom_game = CustomGame(50, game_service, game_stats_service)
+    custom_game.state = GameState.LOBBY
+    players = [
+        Player(id=1, login='Dostya', global_rating=(1500, 500)),
+        Player(id=2, login='Rhiza', global_rating=(1500, 500)),
+    ]
+    add_connected_players(custom_game, players)
+    await custom_game.launch()
+    await custom_game.add_result(0, 1, 'VICTORY', 5)
+
+    custom_game.launched_at = time.time() - 60 # seconds
+
+    await custom_game.on_game_end()
+    assert custom_game.validity == ValidityState.TOO_SHORT
+
+async def test_rate_game_early_abort_with_enforce(game_service, game_stats_service):
+    custom_game = CustomGame(51, game_service, game_stats_service)
+    custom_game.state = GameState.LOBBY
+    players = [
+        Player(id=1, login='Dostya', global_rating=(1500, 500)),
+        Player(id=2, login='Rhiza', global_rating=(1500, 500)),
+    ]
+    add_connected_players(custom_game, players)
+    await custom_game.launch()
+    custom_game.enforce_rating = True
+    await custom_game.add_result(0, 1, 'VICTORY', 5)
+
+    custom_game.launched_at = time.time() - 60  # seconds
+
+    await custom_game.on_game_end()
+    assert custom_game.validity == ValidityState.VALID
+
+
+async def test_rate_game_late_abort_no_enforce(game_service, game_stats_service):
+    custom_game = CustomGame(45, game_service, game_stats_service)
+    custom_game.state = GameState.LOBBY
+    players = [
+        Player(id=1, login='Dostya', global_rating=(1500, 500)),
+        Player(id=2, login='Rhiza', global_rating=(1500, 500)),
+    ]
+    add_connected_players(custom_game, players)
+    await custom_game.launch()
+    await custom_game.add_result(0, 1, 'VICTORY', 5)
+
+    custom_game.launched_at = time.time() - 600 # seconds
+
+    await custom_game.on_game_end()
+    assert custom_game.validity == ValidityState.VALID

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -4,41 +4,10 @@ import pytest
 import time
 
 from server.games.game import GameState, ValidityState
-from server.games.custom_game import CustomGame
-from server.gameconnection import GameConnection, GameConnectionState
+from server.games import CustomGame
 from server.players import Player
+from tests.unit_tests.conftest import add_connected_players
 
-
-@pytest.fixture()
-def game_connection(state=GameConnectionState.INITIALIZING, player=None):
-    gc = mock.create_autospec(spec=GameConnection)
-    gc.state = state
-    gc.player = player
-    return gc
-
-def add_connected_player(custom_game: CustomGame, player):
-    custom_game.game_service.player_service[player.id] = player
-    gc = game_connection(state=GameConnectionState.CONNECTED_TO_HOST, player=player)
-    custom_game.set_player_option(player.id, 'Army', 0)
-    custom_game.set_player_option(player.id, 'StartSpot', 0)
-    custom_game.set_player_option(player.id, 'Team', 0)
-    custom_game.set_player_option(player.id, 'Faction', 0)
-    custom_game.set_player_option(player.id, 'Color', 0)
-    custom_game.add_game_connection(gc)
-    return gc
-
-def add_connected_players(game: CustomGame, players):
-    """
-    Utility to add players with army and StartSpot indexed by a list
-    """
-    for army, player in enumerate(players):
-        add_connected_player(game, player)
-        game.set_player_option(player.id, 'Army', army)
-        game.set_player_option(player.id, 'StartSpot', army)
-        game.set_player_option(player.id, 'Team', army)
-        game.set_player_option(player.id, 'Faction', 0)
-        game.set_player_option(player.id, 'Color', 0)
-    game.host = players[0]
 
 async def test_rate_game_early_abort_no_enforce(game_service, game_stats_service):
     custom_game = CustomGame(50, game_service, game_stats_service)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -1,24 +1,16 @@
 import logging
 from unittest import mock
-import asyncio
 
 import pytest
 import time
 
 from trueskill import Rating
 
-from server import GameStatsService
 from server.games.game import Game, GameState, GameError, VisibilityState
 from server.gameconnection import GameConnection, GameConnectionState
 from server.players import Player
 from tests import CoroMock
 
-
-@pytest.fixture()
-def game_stats_service():
-    service = mock.Mock(spec=GameStatsService)
-    service.process_game_stats = CoroMock()
-    return service
 
 @pytest.fixture()
 def game(game_service, game_stats_service):

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -126,3 +126,10 @@ async def test_json_stats(game_connection, game_stats_service, players, game):
     game_stats_service.process_game_stats = mock.Mock()
     await game_connection.handle_action('JsonStats', ['{"stats": {}}'])
     game.report_army_stats.assert_called_once_with('{"stats": {}}')
+
+
+async def test_handle_action_EnforceRating(game: Game, game_connection: GameConnection):
+    assert (False, game.enforce_rating)
+
+    await game_connection.handle_action('EnforceRating', [])
+    assert (True, game.enforce_rating)


### PR DESCRIPTION
Ignore too short games in custom games, when enforceRating is active
Complete new test set for custom game

Realted LUA code for game is here: https://github.com/FAForever/fa/pull/1323