### PR TITLE
Call on_game_end when a game timeouts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ marisa-trie
 oauth2client
 git+https://github.com/FAForever/faftools.git@develop#egg=faftools
 pyopenssl
+mock

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -140,7 +140,7 @@ class Game(BaseGame):
 
     def timeout_game(self):
         if self.state == GameState.INITIALIZING:
-            self.state = GameState.ENDED
+            self.on_game_end()
 
     @property
     def armies(self):

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -136,11 +136,12 @@ class Game(BaseGame):
 
         self.mods = {}
         self._logger.info("{} created".format(self))
-        asyncio.get_event_loop().call_later(20, self.timeout_game)
+        asyncio.get_event_loop().create_task(self.timeout_game())
 
-    def timeout_game(self):
+    async def timeout_game(self):
+        await asyncio.sleep(20)
         if self.state == GameState.INITIALIZING:
-            self.on_game_end()
+            await self.on_game_end()
 
     @property
     def armies(self):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -91,6 +91,12 @@ async def test_game_end_when_no_more_connections(game: Game, mock_game_connectio
 
     game.on_game_end.assert_any_call()
 
+async def test_game_marked_dirty_when_timed_out(game: Game):
+    game.state = GameState.INITIALIZING
+    await game.timeout_game()
+    assert game.state == GameState.ENDED
+    assert game in game.game_service.dirty_games
+
 async def test_clear_slot(game: Game, mock_game_connection: GameConnection):
     game.state = GameState.LOBBY
     players = [

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -1,5 +1,6 @@
 import logging
 from unittest import mock
+from mock import patch
 
 import pytest
 import time
@@ -91,6 +92,7 @@ async def test_game_end_when_no_more_connections(game: Game, mock_game_connectio
 
     game.on_game_end.assert_any_call()
 
+@patch('asyncio.sleep', return_value=None)
 async def test_game_marked_dirty_when_timed_out(game: Game):
     game.state = GameState.INITIALIZING
     await game.timeout_game()


### PR DESCRIPTION
Games ending with timeout never seem to get marked dirty, thus never garbage collected?

Proposed fix for #142