### PR TITLE
Don't send games in the "closed" state to the client

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -183,8 +183,20 @@ class GameService:
 
     @property
     def open_games(self):
+        """
+        Return all games that meet the client's definition of "not closed".
+        Server game states are mapped to client game states as follows:
+
+            GameState.LOBBY: 'open',
+            GameState.LIVE: 'playing',
+            GameState.ENDED: 'closed',
+            GameState.INITIALIZING: 'closed',
+
+        The client ignores everything "closed". This property fetches all such not-closed games.
+        :return:
+        """
         return [game for game in self.games.values()
-                if game.state == GameState.LOBBY]
+                if game.state == GameState.LOBBY or game.state == GameState.LIVE]
 
     @property
     def all_games(self):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -370,7 +370,7 @@ Thanks,\n\
     def send_game_list(self):
         self.sendJSON({
             'command': 'game_info',
-            'games': [game.to_dict() for game in self.game_service.all_games]
+            'games': [game.to_dict() for game in self.game_service.open_games]
         })
 
     @asyncio.coroutine

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -142,7 +142,8 @@ def test_send_game_list(mocker, lobbyconnection, game_stats_service):
     games = mocker.patch.object(lobbyconnection, 'game_service')  # type: GameService
     game1, game2 = mock.create_autospec(Game(42, mock.Mock(), game_stats_service)),\
                    mock.create_autospec(Game(22, mock.Mock(), game_stats_service))
-    games.all_games = [game1, game2]
+
+    games.open_games = [game1, game2]
 
     lobbyconnection.send_game_list()
 


### PR DESCRIPTION
The client discards games in the ENDED or INITIALIZING states.
A recentish server change seems to have greatly increased the
number of such games (or perhaps simply changed how the server
is reporting them so the client is now being told about them).

Due to a stupidity in the client, this causes it to freeze for a
rather long time when it gets a huge pile of junk games dumped
on it on startup. We can save ourself some resources by not doing
so anyway, so let's do that.

We should also make the client not be stupid.

Fixes client/348 from the server direction.