### PR TITLE
Prune unused gameType field from Game objects

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -169,7 +169,6 @@ class GameService:
             game = Game(**args)
         self.games[id] = game
 
-        self._logger.info("{} created".format(game))
         game.visibility = visibility
         game.password = password
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -118,7 +118,6 @@ class Game(BaseGame):
         self.map_scenario_path = None
         self.password = None
         self._players = []
-        self.gameType = 0
         self.AIs = {}
         self.desyncs = 0
         self.validity = ValidityState.VALID
@@ -662,7 +661,6 @@ class Game(BaseGame):
             "map_file_path": self.map_file_path,
             "host": self.host.login if self.host else '',
             "num_players": len(self.players),
-            "game_type": self.gameType,
             "max_players": self.max_players,
             "launched_at": self.launched_at,
             "teams": {

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -295,7 +295,6 @@ async def test_to_dict(game, create_player):
         "map_file_path": game.map_file_path,
         "host": game.host.login,
         "num_players": len(game.players),
-        "game_type": game.gameType,
         "max_players": game.max_players,
         "launched_at": game.launched_at,
         "teams": {


### PR DESCRIPTION
Not to be confused with the gameType field in the DB, which is
actually the victory condition. This particular field is always
zero.