### PR TITLE
Send complete player information for the connecting user

### DIFF
--- a/server/player_service.py
+++ b/server/player_service.py
@@ -107,7 +107,7 @@ class PlayerService:
     def has_blacklisted_domain(self, email):
         # A valid email only has one @ anyway.
         domain = email.split("@")[1]
-        return len(self.blacklisted_email_domains.keys(domain[::-1])) != 0
+        return domain in self.blacklisted_email_domains
 
     def get_player(self, player_id):
         if player_id in self.players:
@@ -140,4 +140,4 @@ class PlayerService:
             rows = await cursor.fetchall()
             # Get list of reversed blacklisted domains (so we can (pre)suffix-match incoming emails
             # in sublinear time)
-            self.blacklisted_email_domains = marisa_trie.Trie(map(lambda x: x[0][::-1], rows))
+            self.blacklisted_email_domains = marisa_trie.Trie(map(lambda x: x[0], rows))

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -82,6 +82,12 @@ def test_server_valid_login(loop, lobby_server):
     yield from perform_login(proto, ('Dostya', 'vodka'))
     msg = yield from proto.read_message()
     assert msg == {'command': 'welcome',
+                   'me': {'country': '',
+                          'global_rating': [1500.0, 75.0],
+                          'id': 2,
+                          'ladder_rating': [1500.0, 75.0],
+                          'login': 'Dostya',
+                          'number_of_games': 2},
                    'id': 2,
                    'login': 'Dostya'}
     lobby_server.close()

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -178,15 +178,17 @@ async def test_register_disposable_email(mocker, lobbyconnection):
     lobbyconnection.generate_expiring_request.assert_not_called()
 
 
-async def test_register_non_disposable_email(mocker, lobbyconnection):
-    lobbyconnection.generate_expiring_request = mock.Mock()
+async def test_register_non_disposable_email(mocker, lobbyconnection: LobbyConnection):
+    lobbyconnection.generate_expiring_request = mock.Mock(return_value=('iv', 'ciphertext', 'verification_hex'))
+    lobbyconnection.player_service.has_blacklisted_domain.return_value = False
+
     await lobbyconnection.command_create_account({
         'login': 'Chris',
         'email': "chriskitching@linux.com",
         'password': "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"
     })
 
-    lobbyconnection.generate_expiring_request.assert_any_call()
+    assert lobbyconnection.generate_expiring_request.mock_calls
 
 def test_send_mod_list(mocker, lobbyconnection, mock_games):
     protocol = mocker.patch.object(lobbyconnection, 'protocol')


### PR DESCRIPTION
This removes a state from the client's state machine: it
previously had to handle having a half-initialised player, then
getting the real information later.

The client can now initialise itself properly with "me" on
welcome. It also knows that it will get this before it gets any
player_info objects about anyone else, which comes in handy.