### PR TITLE
Improve the way the server reports bans and login failures

### DIFF
--- a/tests/data/db-fixtures.sql
+++ b/tests/data/db-fixtures.sql
@@ -5,6 +5,11 @@ delete from login;
 insert into login (id, login, email, password) values (1, 'test', 'test@example.com', SHA2('test_password', 256));
 insert into login (id, login, email, password) values (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256));
 insert into login (id, login, email, password) values (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256));
+insert into login (id, login, email, password) values (4, 'banned', 'banned@example.com', SHA2('test_password', 256));
+
+-- Ban the test-banned user.
+delete from lobby_ban;
+insert into lobby_ban (idUser, reason, expires_at) values (4, "testing", NOW() + INTERVAL 100 YEAR);
 
 -- global rating
 delete from global_rating;
@@ -25,6 +30,7 @@ values
 -- UniqueID_exempt
 delete from uniqueid_exempt;
 insert into uniqueid_exempt (user_id, reason) values (1, 'Because test');
+insert into uniqueid_exempt (user_id, reason) values (4, 'Because test');
 
 -- Lobby version table
 delete from version_lobby;

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -71,8 +71,7 @@ async def test_server_invalid_login(loop, lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ('Cat', 'epic'))
     msg = await proto.read_message()
-    assert msg == {'command': 'authentication_failed',
-                   'text': 'Login not found or password incorrect. They are case sensitive.'}
+    assert msg == {'command': 'authentication_failed'}
     proto.close()
 
 @asyncio.coroutine


### PR DESCRIPTION
In order to avoid localisation issues, we should avoid sending
strings to show in the UI over the protocol.

Here, the global exception handler around all message handlers
that listens for login failures is moved into the login function.
Its behaviour is changed to not send a string to the client.
Bans now report deltas, not naive timezone-ignorant expiry dates.
Unit tests for bans and invalid passwords have been added.
