### PR TITLE
Bugfix/rating not persisted

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -160,10 +160,11 @@ class Game(BaseGame):
         for army in self.armies:
             if army in self._results:
                 for result in self._results[army]:
-                    if result[2] != 'mutual_draw':
+                    if result[1] != 'mutual_draw':
                         return False
             else:
                 return False
+
         return True
 
     @property

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -318,7 +318,11 @@ class Game(BaseGame):
                 self._logger.info("Game finished normally")
 
                 for player in self._players_with_unsent_army_stats:
-                    await self._process_army_stats_for_player(player)
+                    try:
+                        await self._process_army_stats_for_player(player)
+                    except:
+                        self._logger.exception("Error when processing army_stats for %s", player)
+                        continue
 
                 if self.desyncs > 20:
                     await self.mark_invalid(ValidityState.TOO_MANY_DESYNCS)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -19,6 +19,16 @@ def game(loop, game_service, game_stats_service):
     yield game
     loop.run_until_complete(game.clear_data())
 
+@pytest.fixture
+def game_2p(game):
+    game.state = GameState.LOBBY
+    players = [
+        Player(id=1, login='Dostya', global_rating=(1500, 500)),
+        Player(id=2, login='Rhiza', global_rating=(1500, 500)),
+    ]
+    add_connected_players(game, players)
+    return game
+
 @pytest.fixture()
 def game_5p(game):
     game.state = GameState.LOBBY
@@ -224,9 +234,9 @@ async def test_initialized_game_not_allowed_to_end(game: Game):
 
     assert game.state is GameState.INITIALIZING
 
-async def test_game_ends_in_mutually_agreed_draw(game: Game, players):
-    await game.clear_data()
-    game.state = GameState.LIVE
+async def test_game_ends_in_mutually_agreed_draw(game_2p: Game, players):
+    game = game_2p
+    await game.launch()
     game.launched_at = time.time()-60*60
 
     await game.add_result(players.hosting, 0, 'mutual_draw', 0)


### PR DESCRIPTION
* Mutual draw was never triggered due to checking wrong index
* Add safety net around processing of stats if something goes wrong

Should be seen as general hardening of the code, not as a definite solution to the current rating problems (haven't seen any server logs of the latest problem)