### PR TITLE
Unittest fixes

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -142,8 +142,11 @@ class Game(BaseGame):
         self._logger.debug("%s created", self)
         asyncio.get_event_loop().create_task(self.timeout_game())
 
+    async def sleep(self, n):
+        return await asyncio.sleep(n)
+
     async def timeout_game(self):
-        await asyncio.sleep(20)
+        self.sleep(20)
         if self.state == GameState.INITIALIZING:
             await self.on_game_end()
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -214,16 +214,18 @@ class Game(BaseGame):
     @property
     def is_even(self):
         teams = self.team_count()
-        if 1 in teams: # someone is without team, all teams need to be 1 player
+        if 1 in teams: # someone is in ffa team, all teams need to have 1 player
             c = 1
             teams.pop(1)
-        else: # all same as count of first team
-            try:
-                c = list(teams.values())[0]
-            except IndexError:
-                return True # no teams defined, consider this even
+        else:
+            n = len(teams)
+            if n <= 1: # 0 teams are considered even, single team not
+                return n == 0
 
-        for k, v in teams.items():
+            # all teams needs to have same count as the first
+            c = list(teams.values())[0]
+
+        for _, v in teams.items():
             if v != c:
                 return False
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -94,7 +94,7 @@ def add_connected_players(game: BaseGame, players):
         game.set_player_option(player.id, 'Color', 0)
     game.host = players[0]
 
-def add_players(gameobj: BaseGame, n: int):
+def add_players(gameobj: BaseGame, n: int, team: int=None):
     game = gameobj
     current = len(game.players)
     players = []
@@ -102,4 +102,9 @@ def add_players(gameobj: BaseGame, n: int):
         players.append(Player(id=i+1, login='Player '+str(i+1), global_rating=(1500, 500)))
 
     add_connected_players(game, players)
+
+    if team is not None:
+        for p in players:
+            game.set_player_option(p.id, 'Team', team)
+
     return players

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,8 +2,10 @@ from unittest import mock
 import pytest
 
 from server import GameStatsService, LobbyConnection
+from server.abc.base_game import BaseGame
 from server.games import Game
 from server.gameconnection import GameConnection, GameConnectionState
+from server.players import Player
 from tests import CoroMock
 
 @pytest.fixture()
@@ -79,7 +81,7 @@ def add_connected_player(game: Game, player):
     return gc
 
 
-def add_connected_players(game: Game, players):
+def add_connected_players(game: BaseGame, players):
     """
     Utility to add players with army and StartSpot indexed by a list
     """
@@ -92,3 +94,12 @@ def add_connected_players(game: Game, players):
         game.set_player_option(player.id, 'Color', 0)
     game.host = players[0]
 
+def add_players(gameobj: BaseGame, n: int):
+    game = gameobj
+    current = len(game.players)
+    players = []
+    for i in range(current, current+n):
+        players.append(Player(id=i+1, login='Player '+str(i+1), global_rating=(1500, 500)))
+
+    add_connected_players(game, players)
+    return players

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -162,9 +162,9 @@ async def test_game_end_when_no_more_connections(game: Game, mock_game_connectio
 
     game.on_game_end.assert_any_call()
 
-@patch('asyncio.sleep', return_value=None)
 async def test_game_marked_dirty_when_timed_out(game: Game):
     game.state = GameState.INITIALIZING
+    game.sleep = CoroMock()
     await game.timeout_game()
     assert game.state == GameState.ENDED
     assert game in game.game_service.dirty_games

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -8,7 +8,7 @@ import time
 from trueskill import Rating
 
 from server.games.game import Game, GameState, GameError, Victory, VisibilityState, ValidityState
-from server.games import LadderGame
+from server.games import CustomGame
 from server.gameconnection import GameConnection, GameConnectionState
 from server.players import Player
 from tests import CoroMock
@@ -17,6 +17,12 @@ from tests.unit_tests.conftest import mock_game_connection, add_players, add_con
 @pytest.yield_fixture
 def game(loop, game_service, game_stats_service):
     game = Game(42, game_service, game_stats_service)
+    yield game
+    loop.run_until_complete(game.clear_data())
+
+@pytest.yield_fixture
+def custom_game(loop, game_service, game_stats_service):
+    game = CustomGame(42, game_service, game_stats_service)
     yield game
     loop.run_until_complete(game.clear_data())
 
@@ -432,6 +438,7 @@ async def test_persist_results_called_with_two_players(game):
 
     await game.load_results()
     assert game.get_army_result(1) == 5
+
 
 
 def test_equality(game):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -99,6 +99,19 @@ async def test_uneven_teams_not_rated(game_service, game_stats_service, game_5p)
     await game.on_game_end()
     assert game.validity == ValidityState.UNEVEN_TEAMS_NOT_RANKED
 
+async def test_single_team_not_rated(game):
+    n_players = 4
+    game.state = GameState.LOBBY
+    add_players(game, n_players, team=2)
+
+    await game.launch()
+    game.launched_at = time.time()-60*20
+    for i in range(n_players):
+        await game.add_result(0, i+1, 'victory', 5)
+    await game.on_game_end()
+
+    assert game.validity is ValidityState.UNEVEN_TEAMS_NOT_RANKED
+
 def test_set_player_option(game, players, mock_game_connection):
     game.state = GameState.LOBBY
     mock_game_connection.player = players.hosting

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -468,6 +468,27 @@ async def test_report_army_stats_sends_stats_for_defeated_player(game: Game):
 
     game._game_stats_service.process_game_stats.assert_called_once_with(players[1], game, stats)
 
+async def test_partial_stats_not_affecting_rating_persistence(custom_game, event_service, achievement_service):
+    from server.stats.game_stats_service import GameStatsService
+    game = custom_game
+    game._game_stats_service = GameStatsService(event_service, achievement_service)
+    game.state = GameState.LOBBY
+    players = add_players(game, 2)
+    game.set_player_option(players[0].id, 'Team', 2)
+    game.set_player_option(players[1].id, 'Team', 3)
+    old_mean = players[0].global_rating[0]
+
+    await game.launch()
+    game.launched_at = time.time()-60*60
+    await game.add_result(0, 0, 'victory', 10)
+    await game.add_result(0, 1, 'defeat', -10)
+    await game.report_army_stats({'stats': {'Player 1': {}}})
+    await game.on_game_end()
+
+    assert game.validity is ValidityState.VALID
+    assert players[0].global_rating[0] > old_mean
+
+
 async def test_players_exclude_observers(game: Game):
     game.state = GameState.LOBBY
     players = add_players(game, 2)


### PR DESCRIPTION
* All players on same team is now considered uneven unless team 1 (ffa)
* Added help function add_players() which can add X players to a game
* Added test for CustomGame to assert that global mean value for a player is higher after a win.
* Added test to assert that mutual draw isn't triggered by only one player reporting it.
* Added test to ensure corrupted / missing stats doesn't prevent rating persistence
