### PR TITLE
re-enable VM-check for new UID

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -594,10 +594,10 @@ Thanks,\n\
                 SerialNumber = str(machine.get('SerialNumber', 0)).encode() # BIOS serial number
                 VolumeSerialNumber = str(machine.get('VolumeSerialNumber', 0)).encode() # https://www.raymond.cc/blog/changing-or-spoofing-hard-disk-hardware-serial-number-and-volume-id/
 
-                for i in machine.values() :
-                    low = i.lower()
-                    if "vmware" in low or "virtual" in low or "innotek" in low or "qemu" in low or "parallels" in low or "bochs" in low :
-                        return "VM"
+            for value in [Manufacturer, Name, SMBIOSBIOSVersion]:
+                low = value.lower()
+                if "vmware" in low or "virtual" in low or "innotek" in low or "qemu" in low or "parallels" in low or "bochs" in low :
+                    return "VM"
 
             m = hashlib.md5()
             m.update(UUID + mem_SerialNumber + DeviceID + Manufacturer + Name + ProcessorId + SMBIOSBIOSVersion + SerialNumber + VolumeSerialNumber)


### PR DESCRIPTION
This is a totally untested change to re-enable the VM check for the new uid implementation.