### PR TITLE
Feature/optional client update

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -687,7 +687,10 @@ Thanks,\n\
                     clean_version = clean_version.split('+')[0]
                 if semver.compare(versionDB, clean_version) > 0:
                     self.sendJSON(update_msg)
-                    return False
+                    if 'pre' in versionDB:
+                        return True
+                    else:
+                        return False
             except ValueError:
                 self.sendJSON(update_msg)
                 return False

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -62,7 +62,7 @@ class ServerContext:
         try:
             await connection.on_connection_made(protocol, Address(*stream_writer.get_extra_info('peername')))
             self.connections[connection] = protocol
-            server.stats.gauge('user.agents.None', 1, delta=True)
+            server.stats.gauge(connection.STATSD_USERAGENT_NONE, 1, delta=True)
             while True:
                 message = await protocol.read_message()
                 with server.stats.timer('connection.on_message_received'):
@@ -83,6 +83,9 @@ class ServerContext:
             self._logger.exception(ex)
         finally:
             del self.connections[connection]
-            server.stats.gauge('user.agents.{}'.format(connection.user_agent), -1, delta=True)
+            # decrement always, will decrement user_agents.None if connection.user_agent is None
+            server.stats.gauge(connection.STATSD_USERAGENT_SOME.format(connection.user_agent), -1, delta=True)
+            if connection.version is not None:
+                server.stats.gauge(connection.STATSD_USERAGENT_VERSION.format(connection.user_agent, connection.version.replace('.','_')), -1, delta=True)
             protocol.writer.close()
             await connection.on_connection_lost()


### PR DESCRIPTION
Make upgrade to 'pre' version optional - If an upgrade version contains the string 'pre', don't refuse to give an (older) client a login session