### PR TITLE
Increase timeout for launching coop games

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -146,7 +146,9 @@ class Game(BaseGame):
         return await asyncio.sleep(n)
 
     async def timeout_game(self):
-        await self.sleep(20)
+        # coop takes longer to set up
+        tm = 30 if self.game_mode != 'coop' else 60
+        await self.sleep(tm)
         if self.state == GameState.INITIALIZING:
             await self.on_game_end()
 


### PR DESCRIPTION
Coop games just take longer to launch, 20s timeout is not enough.

There is a substantial number of people who can never host coop because anyone trying to join gets "Host has left the game" error. After debugging this with speed2 it turned out his games timed out.

> 20:50:11 < duk3luk3> why would coop take longer to host?
> 20:50:32 < icedreamer> It does
> 20:50:33 < speed2> dunno, updating more files? game loading more data?
> 20:50:47 < icedreamer> When I launch coop locally it takes nearly 5 times longer than launching normal
> 20:50:58 < icedreamer> Both launching from files on my SSD
> 20:51:07 < icedreamer> Normal FA takes <1s
> 20:51:21 < icedreamer> My coop shortcut takes at least 4 or 5s to launch up

Fixes: #197