### PR TITLE
Fix #273 don't insert mapId = 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,12 @@ services:
 before_install:
   - sudo /etc/init.d/mysql stop
   - sudo apt-get update
-  - pushd db && ./setup_db.sh && popd
+  - pushd db
+  - docker build -t faf-db .
+  - docker run -d --name faf-db -e MYSQL_ROOT_PASSWORD=banana -p 3306:3306 faf-db
+  - until docker exec -i faf-db ./healthcheck.sh 2>/dev/null; do sleep 1; done
+  - docker exec -i faf-db mysql -uroot -pbanana faf < test-data.sql
+  - popd
   - python -m pip install coveralls
 
 install:
@@ -20,9 +25,7 @@ install:
   - docker build -t faf-server .
 
 script:
-  - docker run --name faf_server -it --link faf-db:db -e FAF_DB_PASSWORD=banana faf-server bash scripts/run_tests_with_coverage.sh
-  - docker cp faf_server:/code/.coverage .coverage
+  - docker run --name faf-server --link faf-db:db -e FAF_DB_PASSWORD=banana -e FAF_DB_NAME=faf faf-server bash scripts/run_tests_with_coverage.sh
+  - docker cp faf-server:/code/.coverage .coverage
   - sed -i.bak s#/code/#$(pwd)/#g .coverage
-  - cat .coverage
   - coveralls
-  - docker rm faf_server

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ master|develop
 
 Install [docker](https://www.docker.com).
 
-Follow the steps to get [faf-db](https://github.com/FAForever/db) setup, the following assumes the db container is called `faf-db` and the database is called `faf_test` and the root password ist `banana`.
+Follow the steps to get [faf-db](https://github.com/FAForever/db) setup, the following assumes the db container is called `faf-db` and the database is called `faf` and the root password ist `banana`.
 
 
 The server needs an RSA key to decode uniqueid messages, we've provided an example key in the repo as `faf-server.example.pem`. The server expects this to be named `faf-server.pem` at runtime, so first copy this

--- a/scripts/run_tests_with_coverage.sh
+++ b/scripts/run_tests_with_coverage.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-py.test --cov-report term-missing --cov=server
+py.test --cov-report term-missing --cov=server --mysql_database=faf

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -118,7 +118,7 @@ class Game(BaseGame):
         self.max_players = 12
         self.host = host
         self.name = name
-        self.map_id = 0
+        self.map_id = None
         self.map_file_path = 'maps/%s.zip' % map
         self.map_scenario_path = None
         self.password = None
@@ -569,7 +569,7 @@ class Game(BaseGame):
             # Determine if the map is blacklisted, and invalidate the game for ranking purposes if
             # so, and grab the map id at the same time.
             await cursor.execute("SELECT id, ranked FROM map_version "
-                                 "WHERE filename = %s", (self.map_file_path,))
+                                 "WHERE lower(filename) = lower(%s)", (self.map_file_path,))
             result = await cursor.fetchone()
             if result:
                 (self.map_id, ranked) = result


### PR DESCRIPTION
This most likely doesn't solve all issues of #273 but right now I really don't have time to dig into this.
As the DB field mapId is now nullable, we at least insert null instead of 0 now.

This should've been part of v0.6.1, unfortunately I wasn't aware of that I didn't merge it.