### PR TITLE
Decrease cron data update interval

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -48,7 +48,7 @@ class GameService:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(asyncio.async(self.initialise_game_counter()))
         loop.run_until_complete(loop.create_task(self.update_data()))
-        self._update_cron = aiocron.crontab('0 * * * *', func=self.update_data)
+        self._update_cron = aiocron.crontab('*/10 * * * *', func=self.update_data)
 
     async def initialise_game_counter(self):
         async with db.db_pool.get() as conn:

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -23,7 +23,7 @@ class PlayerService:
 
         self.ladder_queue = None
         asyncio.get_event_loop().run_until_complete(asyncio.async(self.update_data()))
-        self._update_cron = aiocron.crontab('0 * * * *', func=self.update_data)
+        self._update_cron = aiocron.crontab('*/10 * * * *', func=self.update_data)
 
     def __len__(self):
         return len(self.players)


### PR DESCRIPTION
The server periodically fetches information like the list of featured
mods and the minimum client version from the database.

A sixty-minutes interval is not reasonable. This commit changes it to 10
minutes.

Fixes #280