### PR TITLE
276 potentially fix zombie games

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -128,6 +128,9 @@ class GameConnection(GpgNetServerProtocol):
             # followed by the rest of the players.
             elif player_state == PlayerState.JOINING:
                 await self.ConnectToHost(self.game.host.game_connection)
+                if self._state is GameConnectionState.ENDED: # We aborted while trying to connect
+                    return
+
                 self._state = GameConnectionState.CONNECTED_TO_HOST
                 self.game.add_game_connection(self)
                 for peer in self.game.connections:


### PR DESCRIPTION
It appears that in a scenario where a player leaves while we wait for the STUN connection, EstablishConnection ignores that and keeps trying to connect the player. If it succeeds, we add a GameConnection for a player that already left. We try to fix this behaviour here.