### PR TITLE
Pin aiohttp==1.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 typing
 -f http://content.dev.faforever.com/wheel/
-aiohttp
+aiohttp==1.3.3
 aiomysql
 aiomeasures
 coveralls


### PR DESCRIPTION
aiohttp removed `aiohttp.post` in 1.4.4, need to pin until we can fix
it.

This is needed to make build work.