### PR TITLE
Track and remember game (sim) end

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -61,6 +61,8 @@ class GameConnection(GpgNetServerProtocol):
 
         self.connectivity = self.lobby_connection.connectivity  # type: Connectivity
 
+        self.finished_sim = False
+
     @property
     def state(self):
         """
@@ -334,6 +336,14 @@ class GameConnection(GpgNetServerProtocol):
                                    ['score', 'defeat', 'victory', 'draw'])):
                         raise ValueError()  # pragma: no cover
                     result = result.split(' ')
+
+                    # This is the most common way for the player's sim to end
+                    # We should add a reliable message to lua in the future
+                    if result[0] in ['victory', 'draw'] and not self.finished_sim:
+                        self.finished_sim = True
+                        await self.game.check_sim_end()
+
+
                     await self.game.add_result(self.player, army, result[0], int(result[1]))
                 except (KeyError, ValueError):  # pragma: no cover
                     self.log.warn("Invalid result for %s reported: %s", army, result)

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -25,6 +25,7 @@ def game_connection(request, game, loop, player_service, players, game_service, 
     conn.player = players.hosting
     conn.game = game
     conn.lobby = mock.Mock(spec=LobbyConnection)
+    conn.finished_sim = False
 
     def fin():
         conn.abort()
@@ -38,6 +39,7 @@ def mock_game_connection(state=GameConnectionState.INITIALIZING, player=None):
     gc = mock.create_autospec(spec=GameConnection)
     gc.state = state
     gc.player = player
+    gc.finished_sim = False
     return gc
 
 

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -146,3 +146,17 @@ async def test_handle_action_TeamkillReport(game, game_connection):
         await cursor.execute("select game_id from teamkills where victim=2 and teamkiller=3 and game_id=%s and gametime=200", (game.id))
 
         assert (game.id,) == await cursor.fetchone()
+
+async def test_handle_action_GameResult_victory_ends_sim(game, game_connection):
+    game_connection.ConnectToHost = CoroMock()
+    await game_connection.handle_action('GameResult', [0, 'victory'])
+
+    assert game_connection.finished_sim
+    assert game.check_sim_end.called
+
+async def test_handle_action_GameResult_draw_ends_sim(game, game_connection):
+    game_connection.ConnectToHost = CoroMock()
+    await game_connection.handle_action('GameResult', [0, 'draw'])
+
+    assert game_connection.finished_sim
+    assert game.check_sim_end.called


### PR DESCRIPTION
Treat GameResult message in GameConnection as a signal that a player has
ended his sim. Track these ending sims in Game; once all remaining
GameConnections are marked as ended and the game is in a Live state,
mark the Game as (sim-wise) ended and set its end time.

Fixes #289.

Signed-off-by: Igor Kotrasinski <ik345186@students.mimuw.edu.pl>