### PR TITLE
Use `clan_tags` view of own database

### DIFF
--- a/server/player_service.py
+++ b/server/player_service.py
@@ -67,7 +67,7 @@ class PlayerService:
             try:
                 yield from cur.execute(
                     "SELECT `clan_tag` "
-                    "FROM `fafclans`.`clan_tags` "
+                    "FROM `clan_tags` "
                     "LEFT JOIN `fafclans`.players_list "
                     "ON `fafclans`.players_list.player_id = `fafclans`.`clan_tags`.player_id "
                     "WHERE `faf_id` = %s", player.id)


### PR DESCRIPTION
Use `clan_tags` view of own database
`fafclans` database is deprecated

Based on https://github.com/FAForever/db/pull/117