### PR TITLE
Send social info before games info

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -713,10 +713,6 @@ class LobbyConnection:
         self.player.friends = set(friends)
         self.player.foes = set(foes)
 
-        self.send_mod_list()
-        self.send_game_list()
-        self.send_tutorial_section()
-
         channels = []
         if self.player.mod:
             channels.append("#moderators")
@@ -726,6 +722,10 @@ class LobbyConnection:
 
         jsonToSend = {"command": "social", "autojoin": channels, "channels": channels, "friends": friends, "foes": foes, "power": permission_group}
         self.sendJSON(jsonToSend)
+
+        self.send_mod_list()
+        self.send_game_list()
+        self.send_tutorial_section()
 
     @timed
     def command_ask_session(self, message):


### PR DESCRIPTION
The information dump sent to the client after it logs in includes
friends and foes (`social` message) and currently hosted / running
games.

Sending the `social` message first means friend/foe information will be
available for the client so it can use it for coloring the hosted game
display.

Making this trivial change on the server avoids adding complex logic to
the client to update the display of games after social information is
received or holding back the display of games completely until that
point.

Fixes https://github.com/FAForever/client/issues/845