### PR TITLE
Reject new accounts from logging in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - docker run -d --name faf-db -e MYSQL_ROOT_PASSWORD=banana -p 3306:3306 faf-db
   - until docker exec -i faf-db ./healthcheck.sh 2>/dev/null; do sleep 1; done
   - docker exec -i faf-db mysql -uroot -pbanana faf < test-data.sql
+  - docker exec -i faf-db mysql -uroot -pbanana faf -e "select * from login;"
   - popd
   - python -m pip install coveralls
 


### PR DESCRIPTION
**Needs Testing**

This change rejects server logins (similarly to when a user is banned) if:

* User is not linked to steam **and**
* Account is not at least 24h old

This is intended as a first-line measure to defend against griefers mass-creating accounts to avoid bans, because these accounts can be found and banned before the 24h period is over.