### PR TITLE
StatsD is now optional

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -25,6 +25,7 @@ from .player_service import PlayerService
 from .game_service import GameService
 from .ladder_service import LadderService
 from .control import init as run_control_server
+from unittest import mock
 
 __version__ = '0.9.17'
 __author__ = 'Chris Kitching, Dragonfire, Gael Honorez, Jeroen De Dauw, Crotalus, Michael Søndergaard, Michel Jung'
@@ -41,7 +42,9 @@ __all__ = [
     'protocol'
 ]
 
-stats = aiomeasures.StatsD(config.STATSD_SERVER)
+stats = mock.MagicMock()
+if config.ENABLE_STATSD:
+    stats = aiomeasures.StatsD(config.STATSD_SERVER)
 
 def run_lobby_server(address: (str, int),
                      player_service: PlayerService,

--- a/server/config.py
+++ b/server/config.py
@@ -18,6 +18,7 @@ logging.getLogger('aiomeasures').setLevel(logging.INFO)
 trueskill.setup(mu=1500, sigma=500, beta=240, tau=10, draw_probability=0.10)
 
 STATSD_SERVER = os.getenv('STATSD_SERVER', '127.0.0.1:8125')
+ENABLE_STATSD = os.getenv('ENABLE_STATSD', 'false').lower() == 'true'
 
 RULE_LINK = 'http://forums.faforever.com/forums/viewtopic.php?f=2&t=581#p5710'
 WIKI_LINK = 'http://wiki.faforever.com'


### PR DESCRIPTION
You can now disable statsD via an env/or the configuration file so that server set up is easier for testing.
It's replaced by a mock object when disabled.