### PR TITLE
Filtering non-latin names

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -296,7 +296,7 @@ class GameConnection(GpgNetServerProtocol):
                                                   replace("'", '')
                     self.game.map_file_path = 'maps/{}.zip'.format(self.game.map_scenario_path.split('/')[2])
                 elif option_key == 'Title':
-                    self.game.name = option_value
+                    self.game.name = self.game.sanitize(option_value)
 
                 self._mark_dirty()
 

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -296,7 +296,7 @@ class GameConnection(GpgNetServerProtocol):
                                                   replace("'", '')
                     self.game.map_file_path = 'maps/{}.zip'.format(self.game.map_scenario_path.split('/')[2])
                 elif option_key == 'Title':
-                    self.game.name = self.game.sanitize(option_value)
+                    self.game.name = self.game.sanitize_name(option_value)
 
                 self._mark_dirty()
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -2,6 +2,7 @@ from enum import IntEnum, unique
 import logging
 import time
 import functools
+import re
 from collections import defaultdict
 import asyncio
 from typing import Union
@@ -122,7 +123,7 @@ class Game(BaseGame):
         self.visibility = VisibilityState.PUBLIC
         self.max_players = 12
         self.host = host
-        self.name = name
+        self.name = self.sanitize(name)
         self.map_id = None
         self.map_file_path = 'maps/%s.zip' % map
         self.map_scenario_path = None
@@ -662,6 +663,9 @@ class Game(BaseGame):
 
     def getGamemodVersion(self):
         return self.game_service.game_mode_versions[self.game_mode]
+
+    def sanitize(self, name):
+        return re.sub('[^\x20-\xFF]+', '_', name)
 
     async def mark_invalid(self, new_validity_state: ValidityState):
         self._logger.info("Marked as invalid because: %s", repr(new_validity_state))

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -43,7 +43,7 @@ class LadderService:
 
         # Host is player 1
         game.host = player1
-        game.name = str(player1.login + " Vs " + player2.login)
+        game.name = game.sanitize(str(player1.login + " Vs " + player2.login))
 
         game.set_player_option(player1.id, 'StartSpot', 1)
         game.set_player_option(player2.id, 'StartSpot', 2)

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -43,7 +43,7 @@ class LadderService:
 
         # Host is player 1
         game.host = player1
-        game.name = game.sanitize(str(player1.login + " Vs " + player2.login))
+        game.name = game.sanitize_name(str(player1.login + " Vs " + player2.login))
 
         game.set_player_option(player1.id, 'StartSpot', 1)
         game.set_player_option(player2.id, 'StartSpot', 2)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -408,7 +408,7 @@ async def test_on_game_end_calls_rate_game_with_two_players(game):
 async def test_name_sanitization(game):
     await game.clear_data()
     game.state = GameState.LOBBY
-    game.name = game.sanitize("卓☻иAâé~<1000")
+    game.name = game.sanitize_name("卓☻иAâé~<1000")
     try:
         game.name.encode('utf-16-be').decode('ascii')
     except UnicodeDecodeError:
@@ -440,7 +440,7 @@ async def test_to_dict(game, create_player):
         "visibility": VisibilityState.to_string(game.visibility),
         "password_protected": game.password is not None,
         "uid": game.id,
-        "title": game.sanitize(game.name),
+        "title": game.sanitize_name(game.name),
         "state": 'playing',
         "featured_mod": game.game_mode,
         "featured_mod_versions": game.getGamemodVersion(),

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -405,6 +405,16 @@ async def test_on_game_end_calls_rate_game_with_two_players(game):
 
     assert game.validity is ValidityState.VALID
 
+async def test_name_sanitization(game):
+    await game.clear_data()
+    game.state = GameState.LOBBY
+    game.name = game.sanitize("卓☻иAâé~<1000")
+    try:
+        game.name.encode('utf-16-be').decode('ascii')
+    except UnicodeDecodeError:
+        pass
+
+    assert(game.name == "_Aâé~<1000")
 
 async def test_to_dict(game, create_player):
     await game.clear_data()
@@ -430,7 +440,7 @@ async def test_to_dict(game, create_player):
         "visibility": VisibilityState.to_string(game.visibility),
         "password_protected": game.password is not None,
         "uid": game.id,
-        "title": game.name,
+        "title": game.sanitize(game.name),
         "state": 'playing',
         "featured_mod": game.game_mode,
         "featured_mod_versions": game.getGamemodVersion(),

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -124,7 +124,7 @@ async def test_handle_action_GameResult_calls_add_result(game, game_connection):
 
 async def test_handle_action_GameOption_change_name(game, game_connection):
     await game_connection.handle_action('GameOption', ['Title', 'All welcome'])
-    assert game.name == game.sanitize('All welcome')
+    assert game.name == game.sanitize_name('All welcome')
 
 async def test_json_stats(game_connection, game_stats_service, players, game):
     game_stats_service.process_game_stats = mock.Mock()

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -124,7 +124,7 @@ async def test_handle_action_GameResult_calls_add_result(game, game_connection):
 
 async def test_handle_action_GameOption_change_name(game, game_connection):
     await game_connection.handle_action('GameOption', ['Title', 'All welcome'])
-    assert game.name == 'All welcome'
+    assert game.name == game.sanitize('All welcome')
 
 async def test_json_stats(game_connection, game_stats_service, players, game):
     game_stats_service.process_game_stats = mock.Mock()


### PR DESCRIPTION
Prevents database errors on game renaming.
Client displaying of game names is not affected.