### PR TITLE
Fixed memory leak when StatsD is disabled

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -44,8 +44,8 @@ __all__ = [
 stats = None
 
 if not config.ENABLE_STATSD:
-    from unittest import mock
-    stats = mock.MagicMock()
+    from . import fake_statsd
+    stats = fake_statsd.DummyConnection()
 else:
     stats = aiomeasures.StatsD(config.STATSD_SERVER)
 

--- a/server/fake_statsd.py
+++ b/server/fake_statsd.py
@@ -1,0 +1,27 @@
+
+
+class DummyConnection:
+    def __init__(self):
+        pass
+
+    class timer:
+        def __init__(self, a):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, a, b, c):
+            pass
+
+    def gauge(self, a, b, delta=False):
+        pass
+
+    def incr(self, a):
+        pass
+
+    class unit:
+        def __init__(self):
+            pass
+
+

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from server import ServerContext
 from server.protocol import QDataStreamProtocol
+from server import fake_statsd
 
 
 @pytest.fixture
@@ -44,3 +45,15 @@ def test_serverside_abort(loop, mock_context, mock_server):
     yield from asyncio.sleep(0.1)
 
     mock_server.on_connection_lost.assert_any_call()
+
+def test_server_fake_statsd():
+    dummy = fake_statsd.DummyConnection()
+    try:
+        with dummy.timer('a'):
+            dummy.incr('a')
+            dummy.gauge('a', 'b', delta=True)
+            unit = dummy.unit()
+
+    except:
+        pytest.fail("StatsD connection dummy raises exception when used")
+


### PR DESCRIPTION
Not sure fake_statsd.py is in the right place
nor named the right way!

This adds a dummy class to emulate statsD connection (magic.mock() creates a memory leak on the long run)