### PR TITLE
[WIP] Army stats fix

### DIFF
--- a/server/stats/game_stats_service.py
+++ b/server/stats/game_stats_service.py
@@ -53,6 +53,8 @@ class GameStatsService:
         a_queue = []
         # Stores events to batch update
         e_queue = []
+        self._logger.debug('Army result for %s : %s ', player, army_result)
+
         survived = army_result[1] == 'victory'
         blueprint_stats = stats['blueprints']
         unit_stats = stats['units']


### PR DESCRIPTION
There seems to be shady stuff going on with that army_result
When put to 0 a lot of tests about achievements start failing, but somehow it doesn't feel so related. I wonder if those tests ran in the past or if they were simply skipped because of the way game_stats_service returns without exceptions when encountering weird results.