### PR TITLE
Issue/#387 validate coop results before adding to leaderboard

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -516,7 +516,7 @@ class GameConnection(GpgNetServerProtocol):
         return "{}:{}".format(self.player.ip, self.player.game_port)
 
     def __str__(self):
-        return "GameConnection(Player({}),Game({}))".format(self.player, self.game)
+        return "GameConnection({}, {})".format(self.player, self.game)
 
 
 COMMAND_HANDLERS = {

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -316,7 +316,7 @@ class GameConnection(GpgNetServerProtocol):
                 self.game.mods = {}
 
         elif mode == "uids":
-            uids = args.split()
+            uids = str(args).split()
             self.game.mods = {uid: "Unknown sim mod" for uid in uids}
             async with db.db_pool.get() as conn:
                 cursor = await conn.cursor()
@@ -459,7 +459,15 @@ class GameConnection(GpgNetServerProtocol):
 
     async def handle_game_ended(self):
         """
-        Signals that the simulation has ended. This is currently unused
+        Signals that the simulation has ended. This is currently unused but
+        included for documentation purposes.
+        """
+        pass
+
+    async def handle_rehost(self):
+        """
+        Signals that the user has rehosted the game. This is currently unused but
+        included for documentation purposes.
         """
         pass
 
@@ -524,5 +532,6 @@ COMMAND_HANDLERS = {
     "JsonStats":            GameConnection.handle_json_stats,
     "EnforceRating":        GameConnection.handle_enforce_rating,
     "TeamkillReport":       GameConnection.handle_teamkill_report,
-    "GameEnded":            GameConnection.handle_game_ended
+    "GameEnded":            GameConnection.handle_game_ended,
+    "Rehost":               GameConnection.handle_rehost
 }

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -17,5 +17,5 @@ class CoopGame(Game):
             'TeamSpawn': 'fixed',
             'RevealedCivilians': 'No',
             'Difficulty': 3,
-            'Expansion': 'true'
+            'Expansion': 1
         })

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -8,7 +8,8 @@ class CoopGame(Game):
     init_mode = InitMode.NORMAL_LOBBY
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, game_mode='coop', **kwargs)
+        kwargs["game_mode"] = 'coop'
+        super().__init__(*args, **kwargs)
 
         self.validity = ValidityState.COOP_NOT_RANKED
         self.gameOptions.update({

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -1,6 +1,6 @@
 from server.abc.base_game import InitMode
 
-from .game import Game, ValidityState
+from .game import Game, ValidityState, Victory
 
 
 class CoopGame(Game):
@@ -8,6 +8,13 @@ class CoopGame(Game):
     init_mode = InitMode.NORMAL_LOBBY
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, game_mode='coop', **kwargs)
 
         self.validity = ValidityState.COOP_NOT_RANKED
+        self.gameOptions.update({
+            'Victory': Victory.SANDBOX,
+            'TeamSpawn': 'fixed',
+            'RevealedCivilians': 'No',
+            'Difficulty': 3,
+            'Expansion': 'true'
+        })

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -567,7 +567,7 @@ class Game(BaseGame):
             "RestrictedCategories": (0, ValidityState.BAD_UNIT_RESTRICTIONS),
             "TeamLock": ("locked", ValidityState.UNLOCKED_TEAMS)
         }
-        if self._validate_game_options(valid_options) is False:
+        if await self._validate_game_options(valid_options) is False:
             return
 
         if self.game_mode in ('faf', 'ladder1v1'):
@@ -598,7 +598,7 @@ class Game(BaseGame):
             "Difficulty": (3, ValidityState.UNEVEN_TEAMS_NOT_RANKED),
             "Expansion": ("true", ValidityState.UNEVEN_TEAMS_NOT_RANKED),
         }
-        self._validate_game_options(valid_options)
+        await self._validate_game_options(valid_options)
 
     async def _validate_faf_game_settings(self):
         """
@@ -611,7 +611,7 @@ class Game(BaseGame):
         valid_options = {
             "Victory": (Victory.DEMORALIZATION, ValidityState.WRONG_VICTORY_CONDITION)
         }
-        self._validate_game_options(valid_options)
+        await self._validate_game_options(valid_options)
 
     async def launch(self):
         """

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -257,6 +257,20 @@ class Game(BaseGame):
         return True
 
     def team_count(self):
+        """
+        Returns a dictionary containing team ids and their respective number of
+        players.
+        Example:
+            Team 1 has 2 players
+            Team 2 has 3 players
+            team 3 has 1 player
+            Return value is:
+            {
+                1: 2,
+                2: 3,
+                3: 1
+            }
+        """
         teams = defaultdict(int)
         for player in self.players:
             teams[self.get_player_option(player.id, 'Team')] += 1

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -237,38 +237,27 @@ class Game(BaseGame):
         return len(self.AIs) > 0
 
     @property
-    def is_even(self) -> bool:
+    def is_even(self):
         teams = self.team_count()
-        if len(teams) < 2:
-            return False
-        team_member_counts = list(teams.values())
+        if 1 in teams: # someone is in ffa team, all teams need to have 1 player
+            c = 1
+            teams.pop(1)
+        else:
+            n = len(teams)
+            if n <= 1: # 0 teams are considered even, single team not
+                return n == 0
 
-        # Make sure each team has the same numer of players as the first team
-        first_count = team_member_counts[0]
-        for num_team_members in team_member_counts:
-            if num_team_members != first_count:
+            # all teams needs to have same count as the first
+            c = list(teams.values())[0]
+
+        for _, v in teams.items():
+            if v != c:
                 return False
 
         return True
 
-    def team_count(self) -> Dict[int, int]:
-        """
-        Returns a dictionary containing team ids and their respective number of
-        players.
-
-        Example:
-            Team 1 has 2 players
-            Team 2 has 3 players
-            team 3 has 1 player
-
-            Return value is:
-            {
-                1: 2,
-                2: 3,
-                3: 1
-            }
-        """
-        teams: Dict[int, int] = defaultdict(int)
+    def team_count(self):
+        teams = defaultdict(int)
         for player in self.players:
             teams[self.get_player_option(player.id, 'Team')] += 1
 
@@ -376,9 +365,6 @@ class Game(BaseGame):
             elif self.state == GameState.LIVE:
                 self._logger.info("Game finished normally")
 
-                if self.validity is not ValidityState.VALID:
-                    return
-
                 if self.desyncs > 20:
                     await self.mark_invalid(ValidityState.TOO_MANY_DESYNCS)
                     return
@@ -386,6 +372,10 @@ class Game(BaseGame):
                 if time.time() - self.launched_at > 4*60 and self.is_mutually_agreed_draw:
                     self._logger.info("Game is a mutual draw")
                     await self.mark_invalid(ValidityState.MUTUAL_DRAW)
+                    return
+
+                if len(self.players) < 2:
+                    await self.mark_invalid(ValidityState.SINGLE_PLAYER)
                     return
 
                 if len(self._results) == 0:
@@ -622,10 +612,6 @@ class Game(BaseGame):
             await self.mark_invalid(ValidityState.UNEVEN_TEAMS_NOT_RANKED)
             return
 
-        if len(self.players) < 2:
-            await self.mark_invalid(ValidityState.SINGLE_PLAYER)
-            return
-
         valid_options = {
             "Victory": (Victory.DEMORALIZATION, ValidityState.WRONG_VICTORY_CONDITION)
         }
@@ -670,7 +656,7 @@ class Game(BaseGame):
             if result:
                 self.map_id = result['id']
 
-            if (not result or not result['ranked']) and self.validity is ValidityState.VALID:
+            if not result or not result['ranked']:
                 await self.mark_invalid(ValidityState.BAD_MAP)
 
             modId = self.game_service.featured_mods[self.game_mode].id

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -87,6 +87,10 @@ class ValidityState(IntEnum):
     UNLOCKED_TEAMS = 17
     MULTI_TEAM = 18
     HAS_AI_PLAYERS = 19
+    CIVILIANS_REVEALED = 20
+    TOO_EASY = 21
+    EXPANSION_DISABLED = 22
+    SPAWN_NOT_FIXED = 23
 
 
 class GameError(Exception):
@@ -589,14 +593,13 @@ class Game(BaseGame):
         """
         Checks which only apply to the coop mode
         """
-        # Note, the UNEVEN_TEAMS_NOT_RANKED state is used as a placeholder for reasons
-        # which don't exist in the database.
+
         valid_options = {
             "Victory": (Victory.SANDBOX, ValidityState.WRONG_VICTORY_CONDITION),
-            "TeamSpawn": ("fixed", ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-            "RevealedCivilians": ("No", ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-            "Difficulty": (3, ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-            "Expansion": ("true", ValidityState.UNEVEN_TEAMS_NOT_RANKED),
+            "TeamSpawn": ("fixed", ValidityState.SPAWN_NOT_FIXED),
+            "RevealedCivilians": ("No", ValidityState.CIVILIANS_REVEALED),
+            "Difficulty": (3, ValidityState.TOO_EASY),
+            "Expansion": ("true", ValidityState.EXPANSION_DISABLED),
         }
         await self._validate_game_options(valid_options)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -88,7 +88,7 @@ class ValidityState(IntEnum):
     MULTI_TEAM = 18
     HAS_AI_PLAYERS = 19
     CIVILIANS_REVEALED = 20
-    TOO_EASY = 21
+    WRONG_DIFFICULTY = 21
     EXPANSION_DISABLED = 22
     SPAWN_NOT_FIXED = 23
 
@@ -598,7 +598,7 @@ class Game(BaseGame):
             "Victory": (Victory.SANDBOX, ValidityState.WRONG_VICTORY_CONDITION),
             "TeamSpawn": ("fixed", ValidityState.SPAWN_NOT_FIXED),
             "RevealedCivilians": ("No", ValidityState.CIVILIANS_REVEALED),
-            "Difficulty": (3, ValidityState.TOO_EASY),
+            "Difficulty": (3, ValidityState.WRONG_DIFFICULTY),
             "Expansion": ("true", ValidityState.EXPANSION_DISABLED),
         }
         await self._validate_game_options(valid_options)

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -143,15 +143,17 @@ class Game(BaseGame):
         self.state = GameState.INITIALIZING
         self._connections = {}
         self.enforce_rating = False
-        self.gameOptions = {'FogOfWar': 'explored',
-                            'GameSpeed': 'normal',
-                            'Victory': Victory.DEMORALIZATION,
-                            'CheatsEnabled': 'false',
-                            'PrebuiltUnits': 'Off',
-                            'NoRushOption': 'Off',
-                            'TeamLock': 'locked',
-                            'AIReplacement': 'Off',
-                            'RestrictedCategories': 0}
+        self.gameOptions = {
+            'FogOfWar': 'explored',
+            'GameSpeed': 'normal',
+            'Victory': Victory.DEMORALIZATION,
+            'CheatsEnabled': 'false',
+            'PrebuiltUnits': 'Off',
+            'NoRushOption': 'Off',
+            'TeamLock': 'locked',
+            'AIReplacement': 'Off',
+            'RestrictedCategories': 0
+        }
 
         self.mods = {}
         self._logger.debug("%s created", self)
@@ -613,7 +615,7 @@ class Game(BaseGame):
             "TeamSpawn": ("fixed", ValidityState.SPAWN_NOT_FIXED),
             "RevealedCivilians": ("No", ValidityState.CIVILIANS_REVEALED),
             "Difficulty": (3, ValidityState.WRONG_DIFFICULTY),
-            "Expansion": ("true", ValidityState.EXPANSION_DISABLED),
+            "Expansion": (1, ValidityState.EXPANSION_DISABLED),
         }
         await self._validate_game_options(valid_options)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -91,6 +91,7 @@ class ValidityState(IntEnum):
     WRONG_DIFFICULTY = 21
     EXPANSION_DISABLED = 22
     SPAWN_NOT_FIXED = 23
+    OTHER_UNRANK = 24
 
 
 class GameError(Exception):

--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -102,9 +102,8 @@ class GeoIpService(object):
         """
         try:
             self.db = geoip2.database.Reader(self.file_path)
-        except InvalidDatabaseError:
-            self._logger.warning("Failed to load maxmind db! Maybe the download was interrupted")
-            pass
+        except (InvalidDatabaseError, FileNotFoundError, ValueError):
+            self._logger.exception("Failed to load maxmind db! Maybe the download was interrupted")
 
     def country(self, address: str) -> str:
         """

--- a/tests/unit_tests/test_coop_game.py
+++ b/tests/unit_tests/test_coop_game.py
@@ -1,0 +1,14 @@
+import mock
+from server.games import CoopGame
+
+
+def test_create_coop_game():
+    game = CoopGame(
+        id=0,
+        host=mock.Mock(),
+        name="Some game",
+        map="some_map",
+        game_mode='coop',
+        game_service=mock.Mock(),
+        game_stats_service=mock.Mock()
+    )

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -75,7 +75,7 @@ async def test_validate_game_settings_coop(coop_game: Game):
         ('Victory', Victory.DEMORALIZATION, ValidityState.WRONG_VICTORY_CONDITION),
         ('TeamSpawn', 'open', ValidityState.SPAWN_NOT_FIXED),
         ('RevealedCivilians', 'Yes', ValidityState.CIVILIANS_REVEALED),
-        ('Difficulty', 1, ValidityState.TOO_EASY),
+        ('Difficulty', 1, ValidityState.WRONG_DIFFICULTY),
         ('Expansion', 'false', ValidityState.EXPANSION_DISABLED),
     ]
 

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -73,10 +73,10 @@ async def test_validate_game_settings(game: Game):
 async def test_validate_game_settings_coop(coop_game: Game):
     settings = [
         ('Victory', Victory.DEMORALIZATION, ValidityState.WRONG_VICTORY_CONDITION),
-        ('TeamSpawn', 'open', ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-        ('RevealedCivilians', 'Yes', ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-        ('Difficulty', 1, ValidityState.UNEVEN_TEAMS_NOT_RANKED),
-        ('Expansion', 'false', ValidityState.UNEVEN_TEAMS_NOT_RANKED),
+        ('TeamSpawn', 'open', ValidityState.SPAWN_NOT_FIXED),
+        ('RevealedCivilians', 'Yes', ValidityState.CIVILIANS_REVEALED),
+        ('Difficulty', 1, ValidityState.TOO_EASY),
+        ('Expansion', 'false', ValidityState.EXPANSION_DISABLED),
     ]
 
     await check_game_settings(coop_game, settings)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -541,8 +541,8 @@ async def test_persist_results_not_called_with_one_player(game):
 
 async def test_persist_results_not_called_with_no_results(game):
     game.state = GameState.LOBBY
-    add_players(game, 2, team=1)
     add_players(game, 2, team=2)
+    add_players(game, 2, team=3)
     game.persist_results = CoroMock()
     game.launched_at = time.time() - 60*20
 

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -79,7 +79,7 @@ async def test_validate_game_settings_coop(coop_game: Game):
         ('TeamSpawn', 'open', ValidityState.SPAWN_NOT_FIXED),
         ('RevealedCivilians', 'Yes', ValidityState.CIVILIANS_REVEALED),
         ('Difficulty', 1, ValidityState.WRONG_DIFFICULTY),
-        ('Expansion', 'false', ValidityState.EXPANSION_DISABLED),
+        ('Expansion', 0, ValidityState.EXPANSION_DISABLED),
     ]
 
     await check_game_settings(coop_game, settings)
@@ -90,8 +90,7 @@ async def test_validate_game_settings_coop(coop_game: Game):
 
 
 async def check_game_settings(game: Game, settings: List[Tuple[str, Any, ValidityState]]):
-    for data in settings:
-        key, value, expected = data
+    for key, value, expected in settings:
         old = game.gameOptions.get(key)
         game.gameOptions[key] = value
         await game.validate_game_settings()

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -652,3 +652,32 @@ def test_visibility_states():
     for string_value, enum_value in states:
         assert (VisibilityState.from_string(string_value) == enum_value and
                 VisibilityState.to_string(enum_value) == string_value)
+
+
+def test_is_even(game: Game):
+    game.state = GameState.LOBBY
+    add_players(game, 4, team=2)
+    add_players(game, 4, team=3)
+
+    assert game.is_even
+
+
+def test_is_even_no_players(game: Game):
+    game.state = GameState.LOBBY
+
+    assert game.is_even
+
+
+def test_is_even_single_player(game: Game):
+    game.state = GameState.LOBBY
+    add_players(game, 2, team=2)
+
+    assert not game.is_even
+
+
+def test_is_even_ffa(game: Game):
+    game.state = GameState.LOBBY
+    # Team 1 is the special "-" team
+    add_players(game, 5, team=1)
+
+    assert game.is_even


### PR DESCRIPTION
Fixes #387 

* [x] add test

Would be nice if there was a catch all 'Invalid Game Setting' validity state.

Requires:
https://github.com/FAForever/db/pull/187