### PR TITLE
Remove faftools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,4 @@ aiocron
 marisa-trie
 oauthlib
 requests_oauthlib
-git+https://github.com/FAForever/faftools.git@5fb0fdb28268b612746d693014fe18a46c3f51fd#egg=faftools
 mock

--- a/server/abc/base_player.py
+++ b/server/abc/base_player.py
@@ -2,7 +2,7 @@ from abc import ABCMeta
 
 from trueskill import Rating
 
-from faf.factions import Faction
+from ..factions import Faction
 
 
 class BasePlayer:
@@ -11,12 +11,12 @@ class BasePlayer:
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, id, login):
+    def __init__(self, id_, login):
         self._faction = 0
         self._global_rating = (1500, 500)
         self._ladder_rating = (1500, 500)
 
-        self.id = id
+        self.id = id_
         self.login = login
 
     @property

--- a/server/factions.py
+++ b/server/factions.py
@@ -1,0 +1,14 @@
+from enum import unique, IntEnum
+
+
+@unique
+class Faction(IntEnum):
+    uef = 1
+    aeon = 2
+    cybran = 3
+    seraphim = 4
+    nomads = 5
+
+    @staticmethod
+    def from_string(value):
+        return getattr(Faction, value)

--- a/server/stats/game_stats_service.py
+++ b/server/stats/game_stats_service.py
@@ -1,10 +1,13 @@
-from faf.factions import Faction
-from server.games import Game
+import json
+
 from server import config
+from server.games import Game
 from server.players import Player
 from server.stats.achievement_service import *
 from server.stats.event_service import *
 from server.stats.unit import *
+
+from ..factions import Faction
 
 
 @with_logger

--- a/tests/unit_tests/test_game_stats_service.py
+++ b/tests/unit_tests/test_game_stats_service.py
@@ -1,6 +1,7 @@
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
+
 import pytest
-from faf.factions import Faction
+from server.factions import Faction
 from server.games import Game
 from server.lobbyconnection import LobbyConnection
 from server.players import Player
@@ -62,7 +63,7 @@ def unit_stats():
 
 
 async def test_process_game_stats(game_stats_service, event_service, achievement_service, player, game):
-    
+
     with open("tests/data/game_stats_full_example.json", "r") as stats_file:
         stats = stats_file.read()
 

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -1,10 +1,9 @@
 import gc
 from unittest import mock
 
-from trueskill import Rating
-
-from faf.factions import Faction
+from server.factions import Faction
 from server.players import Player
+from trueskill import Rating
 
 
 def test_ratings():


### PR DESCRIPTION
Faftools was only being used for the faction enum. The python API is no longer used and the python client doesn't use faftools either, so this was the last remaining active use of faftools. Better to just move the Faction enum into this repository. 

This should also remove the `lupa` dependency which will make the server easier to build.

Also cleaned up imports a little bit.