### PR TITLE
[Refactor] Remove unnecessary dependencies between services

### DIFF
--- a/server.py
+++ b/server.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         server.NatPacketServer.instance = natpacket_server
 
         games = GameService(players_online, game_stats_service)
-        matchmaker_queue = MatchmakerQueue('ladder1v1', players_online, games)
+        matchmaker_queue = MatchmakerQueue('ladder1v1', game_service=games)
         players_online.ladder_queue = matchmaker_queue
 
         ctrl_server = loop.run_until_complete(server.run_control_server(loop, players_online, games))

--- a/server.py
+++ b/server.py
@@ -73,23 +73,23 @@ if __name__ == '__main__':
         event_service = EventService(api_accessor)
         achievement_service = AchievementService(api_accessor)
         game_stats_service = GameStatsService(event_service, achievement_service)
-        geoip_service = GeoIpService()
 
         natpacket_server = NatPacketServer(addresses=config.LOBBY_NAT_ADDRESSES, loop=loop)
         loop.run_until_complete(natpacket_server.listen())
         server.NatPacketServer.instance = natpacket_server
 
         games = GameService(players_online, game_stats_service)
-        matchmaker_queue = MatchmakerQueue('ladder1v1', game_service=games)
-        players_online.ladder_queue = matchmaker_queue
 
         ctrl_server = loop.run_until_complete(server.run_control_server(loop, players_online, games))
 
-        lobby_server = server.run_lobby_server(address=('', 8001),
-                                               geoip_service=geoip_service,
-                                               player_service=players_online,
-                                               games=games,
-                                               loop=loop)
+        lobby_server = server.run_lobby_server(
+            address=('', 8001),
+            geoip_service=GeoIpService(),
+            player_service=players_online,
+            games=games,
+            matchmaker_queue=MatchmakerQueue('ladder1v1', game_service=games),
+            loop=loop
+        )
 
         for sock in lobby_server.sockets:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -34,9 +34,11 @@ __copyright__ = 'Copyright (c) 2011-2015 ' + __author__
 
 
 __all__ = [
+    'GameConnection',
     'GameStatsService',
     'GameService',
     'LadderService',
+    'NatPacketServer'
     'run_lobby_server',
     'run_control_server',
     'games',
@@ -144,7 +146,6 @@ def run_lobby_server(
 
     def initialize_connection():
         return LobbyConnection(
-            context=ctx,
             geoip=geoip_service,
             games=games,
             players=player_service,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -24,6 +24,7 @@ from .player_service import PlayerService
 from .game_service import GameService
 from .ladder_service import LadderService
 from .control import init as run_control_server
+from .matchmaker import MatchmakerQueue
 
 __version__ = '0.9.17'
 __author__ = 'Chris Kitching, Dragonfire, Gael Honorez, Jeroen De Dauw, Crotalus, Michael Søndergaard, Michel Jung'
@@ -53,11 +54,14 @@ else:
     stats = aiomeasures.StatsD(config.STATSD_SERVER)
 
 
-def run_lobby_server(address: (str, int),
-                     player_service: PlayerService,
-                     games: GameService,
-                     loop,
-                     geoip_service: GeoIpService):
+def run_lobby_server(
+    address: (str, int),
+    player_service: PlayerService,
+    games: GameService,
+    loop,
+    geoip_service: GeoIpService,
+    matchmaker_queue: MatchmakerQueue
+):
     """
     Run the lobby server
 
@@ -139,11 +143,13 @@ def run_lobby_server(address: (str, int),
         loop.call_later(45, ping_broadcast)
 
     def initialize_connection():
-        return LobbyConnection(context=ctx,
-                               geoip=geoip_service,
-                               games=games,
-                               players=player_service,
-                               loop=loop)
+        return LobbyConnection(
+            context=ctx,
+            geoip=geoip_service,
+            games=games,
+            players=player_service,
+            matchmaker_queue=matchmaker_queue
+        )
     ctx = ServerContext(initialize_connection, name="LobbyServer", loop=loop)
     loop.call_later(5, report_dirties)
     loop.call_soon(ping_broadcast)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -59,9 +59,7 @@ else:
 
 def encode_message(message: str):
     # Crazy evil encoding scheme
-    return QDataStreamProtocol.pack_block(
-        QDataStreamProtocol.pack_qstring(message)
-    )
+    return QDataStreamProtocol.pack_message(message)
 
 
 def encode_dict(d: Dict[Any, Any]):
@@ -131,7 +129,7 @@ def run_lobby_server(
         finally:
             loop.call_later(1, report_dirties)
 
-    ping_msg = QDataStreamProtocol.pack_block(QDataStreamProtocol.pack_qstring('PING'))
+    ping_msg = encode_message('PING')
 
     def ping_broadcast():
         ctx.broadcast_raw(ping_msg)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -144,7 +144,7 @@ def run_lobby_server(
             players=player_service,
             matchmaker_queue=matchmaker_queue
         )
-    ctx = ServerContext(make_connection, name="LobbyServer", loop=loop)
+    ctx = ServerContext(make_connection, name="LobbyServer")
     loop.call_later(5, report_dirties)
     loop.call_soon(ping_broadcast)
     loop.run_until_complete(ctx.listen(*address))

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -150,12 +150,12 @@ class GameService:
         """
         Main entrypoint for creating new games
         """
-        game_id = self.create_uuid()
+        game_id = self.create_uid()
         args = {
-            "id": game_id,
+            "id_": game_id,
             "host": host,
             "name": name,
-            "map": mapname,
+            "map_": mapname,
             "game_mode": str(game_mode),
             "game_service": self,
             "game_stats_service": self.game_stats_service

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Union
+from typing import Dict, List, Optional, Union, ValuesView
 
 import aiocron
 import server.db as db
@@ -39,7 +39,7 @@ class GameService:
         self.ladder_service = None
 
         # The set of active games
-        self.games = dict()
+        self.games: Dict[int, Game] = dict()
 
         # Cached versions for files by game_mode ( featured mod name )
         # For use by the patcher
@@ -142,11 +142,11 @@ class GameService:
 
     def create_game(self,
                     visibility=VisibilityState.PUBLIC,
-                    game_mode: GameMode=None,
-                    host: Player=None,
-                    name: str=None,
-                    mapname: str=None,
-                    password: str=None):
+                    game_mode: GameMode=GameMode.UNKNOWN,
+                    host: Optional[Player]=None,
+                    name: Optional[str]=None,
+                    mapname: Optional[str]=None,
+                    password: Optional[str]=None):
         """
         Main entrypoint for creating new games
         """
@@ -179,12 +179,12 @@ class GameService:
         return game
 
     @property
-    def live_games(self):
+    def live_games(self) -> List[Game]:
         return [game for game in self.games.values()
                 if game.state == GameState.LIVE]
 
     @property
-    def open_games(self):
+    def open_games(self) -> List[Game]:
         """
         Return all games that meet the client's definition of "not closed".
         Server game states are mapped to client game states as follows:
@@ -201,11 +201,11 @@ class GameService:
                 if game.state == GameState.LOBBY or game.state == GameState.LIVE]
 
     @property
-    def all_games(self):
+    def all_games(self) -> ValuesView[Game]:
         return self.games.values()
 
     @property
-    def pending_games(self):
+    def pending_games(self) -> List[Game]:
         return [game for game in self.games.values()
                 if game.state == GameState.LOBBY or game.state == GameState.INITIALIZING]
 
@@ -226,5 +226,5 @@ class GameService:
             })
         return mods
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: int) -> Game:
         return self.games[item]

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -36,11 +36,6 @@ class GameConnection(GpgNetServerProtocol):
     ):
         """
         Construct a new GameConnection
-
-        :param lobby_connection: The lobby connection we're associated with
-        :param player_service: PlayerService
-        :param games: GamesService
-        :return:
         """
         super().__init__()
         self._logger.debug('GameConnection initializing')
@@ -49,7 +44,7 @@ class GameConnection(GpgNetServerProtocol):
         self._state = GameConnectionState.INITIALIZING
         self._waiters = defaultdict(list)
         self.player_service = player_service
-        self.games = games
+        self.game_service = games
 
         self.initTime = time.time()
         self.proxies = {}
@@ -58,7 +53,6 @@ class GameConnection(GpgNetServerProtocol):
 
         self.last_pong = time.time()
 
-        self.ip, self.port = None, None
         self._transport = None
 
         self.connectivity = connectivity
@@ -497,7 +491,7 @@ class GameConnection(GpgNetServerProtocol):
 
     def _mark_dirty(self):
         if self.game:
-            self.games.mark_dirty(self.game)
+            self.game_service.mark_dirty(self.game)
 
     def abort(self, log_message: str=''):
         """

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -49,6 +49,7 @@ class GameConnection(GpgNetServerProtocol):
         self.initTime = time.time()
         self.proxies = {}
         self._player = player
+        player.game_connection = self  # Set up weak reference to self
         self._game = game
 
         self.last_pong = time.time()

--- a/server/games/__init__.py
+++ b/server/games/__init__.py
@@ -2,8 +2,9 @@ from collections import namedtuple
 
 from .coop import CoopGame
 from .custom_game import CustomGame
-from .game import Game
+from .game import Game, VisibilityState, GameState
 from .ladder_game import LadderGame
+from .game_mode import GameMode
 
 FeaturedMod = namedtuple('FeaturedMod', 'id name full_name description publish order')
 
@@ -11,6 +12,9 @@ __all__ = [
     'CoopGame',
     'CustomGame',
     'Game',
+    'GameMode',
+    'GameState',
     'LadderGame',
-    'FeaturedMod'
+    'FeaturedMod',
+    'VisibilityState'
 ]

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -406,6 +406,7 @@ class Game(BaseGame):
 
         self._logger.info("Removed game connection %s", game_connection)
 
+        # TODO: Extract boolean expression to method
         if len(self._connections) == 0 or (self.host == game_connection.player and self.state != GameState.LIVE):
             await self.on_game_end()
         else:

--- a/server/games/game_mode.py
+++ b/server/games/game_mode.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class GameMode(Enum):
+    UNKNOWN = None
+    LADDER = "ladder1v1"
+    COOP = "coop"
+    FAF = "faf"
+    FAF_BETA = "fafbeta"
+    EQUILIBRIUM = "equilibrium"
+
+    @staticmethod
+    def from_string(string: str) -> "GameMode":
+        return {
+            "ladder1v1": GameMode.LADDER,
+            "coop": GameMode.COOP,
+            "faf": GameMode.FAF,
+            "fafbeta": GameMode.FAF_BETA,
+            "equilibrium": GameMode.EQUILIBRIUM,
+        }.get(string, GameMode.UNKNOWN)
+
+    def __str__(self):
+        return str(self.value)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -53,7 +53,6 @@ class LobbyConnection():
     @timed()
     def __init__(
         self,
-        context,
         games: GameService,
         players: PlayerService,
         geoip: GeoIpService,
@@ -63,7 +62,6 @@ class LobbyConnection():
         self.game_service = games
         self.player_service = players
         self.matchmaker_queue = matchmaker_queue
-        self.context = context
         self.ladderPotentialPlayers = []
         self.warned = False
         self._authenticated = False

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -49,13 +49,12 @@ class AuthenticationError(Exception):
 
 
 @with_logger
-class LobbyConnection:
+class LobbyConnection():
     @timed()
     def __init__(self, loop, context,
                  games: GameService,
                  players: PlayerService,
                  geoip: GeoIpService):
-        super(LobbyConnection, self).__init__()
         self.loop = loop
         self.geoip_service = geoip
         self.game_service = games
@@ -92,6 +91,7 @@ class LobbyConnection:
             self._logger.warning("Aborting %s. %s" % (self.peer_address.host, logspam))
         if self.game_connection:
             self.game_connection.abort()
+            self.game_connection = None
         self._authenticated = False
         self.protocol.writer.close()
 
@@ -800,7 +800,8 @@ class LobbyConnection:
         self.game_connection = GameConnection(
             game=game,
             player=self.player,
-            lobby_connection=self,
+            protocol=self.protocol,
+            connectivity=self.connectivity,
             player_service=self.player_service,
             games=self.game_service
         )

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -20,7 +20,7 @@ from .connectivity import Connectivity, ConnectivityState
 from .decorators import timed, with_logger
 from .game_service import GameService
 from .gameconnection import GameConnection
-from .games.game import GameState, VisibilityState
+from .games import GameMode, GameState, VisibilityState
 from .geoip_service import GeoIpService
 from .matchmaker import Search
 from .player_service import PlayerService
@@ -776,14 +776,16 @@ class LobbyConnection:
         mapname = message.get('mapname')
         password = message.get('password')
 
-        game = self.game_service.create_game(**{
-            'visibility': visibility,
-            'game_mode': mod.lower(),
-            'host': self.player,
-            'name': title if title else self.player.login,
-            'mapname': mapname,
-            'password': password
-        })
+        game_mode = GameMode.from_string(mod.lower())
+
+        game = self.game_service.create_game(
+            visibility=visibility,
+            game_mode=game_mode,
+            host=self.player,
+            name=title if title else self.player.login,
+            mapname=mapname,
+            password=password
+        )
         self.launch_game(game, port, True)
         server.stats.incr('game.hosted')
 

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -10,8 +10,11 @@ from .search import Search
 
 @with_logger
 class MatchmakerQueue:
-    def __init__(self, queue_name: str, player_service: "PlayerService", game_service: "GameService"):
-        self.player_service = player_service
+    def __init__(
+        self,
+        queue_name: str,
+        game_service: "GameService"
+    ):
         self.game_service = game_service
         self.queue_name = queue_name
         self.rating_prop = 'ladder_rating'

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -30,7 +30,7 @@ class MatchmakerQueue:
         """
         self.queue[search.player] = search
 
-    def match(self, s1: Search, s2: Search):
+    def match(self, s1: Search, s2: Search) -> bool:
         """
         Mark the given two searches as matched
         :param s1:

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -1,22 +1,26 @@
 import asyncio
-import time
-
 import math
+import time
+from typing import Optional
+
 import server.config as config
-
 from server.decorators import with_logger
-from trueskill import quality_1vs1, Rating
-
 from server.players import Player
+from trueskill import Rating, quality_1vs1
 
 
 @with_logger
-class Search:
+class Search():
     """
     Represents the state of a users search for a match.
     """
 
-    def __init__(self, player, start_time=None, rating_prop='ladder_rating'):
+    def __init__(
+        self,
+        player: Player,
+        start_time: Optional[float]=None,
+        rating_prop: str='ladder_rating'
+    ):
         """
         Default ctor for a search
 

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -83,10 +83,10 @@ class PlayerService:
         if player.id in self.players:
             del self.players[player.id]
 
-    def get_permission_group(self, user_id: int):
+    def get_permission_group(self, user_id: int) -> int:
         return self.privileged_users.get(user_id, 0)
 
-    def is_uniqueid_exempt(self, user_id):
+    def is_uniqueid_exempt(self, user_id: int) -> bool:
         return user_id in self.uniqueid_exempt
 
     def has_blacklisted_domain(self, email: str) -> bool:

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -21,7 +21,6 @@ class PlayerService:
         self.blacklisted_email_domains = {}
         self._dirty_players = set()
 
-        self.ladder_queue = None
         asyncio.get_event_loop().run_until_complete(asyncio.async(self.update_data()))
         self._update_cron = aiocron.crontab('*/10 * * * *', func=self.update_data)
 

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional, Set
 
 import aiocron
 import marisa_trie
@@ -30,17 +31,17 @@ class PlayerService:
     def __iter__(self):
         return self.players.values().__iter__()
 
-    def __getitem__(self, item) -> Player:
-        return self.players.get(item)
+    def __getitem__(self, player_id: int) -> Optional[Player]:
+        return self.players.get(player_id)
 
-    def __setitem__(self, key, value):
-        self.players[key] = value
+    def __setitem__(self, player_id: int, player: Player):
+        self.players[player_id] = player
 
     @property
-    def dirty_players(self):
+    def dirty_players(self) -> Set[Player]:
         return self._dirty_players
 
-    def mark_dirty(self, player):
+    def mark_dirty(self, player: Player):
         self._dirty_players.add(player)
 
     def clear_dirty(self):
@@ -78,24 +79,23 @@ class PlayerService:
             except (pymysql.ProgrammingError, pymysql.OperationalError):
                 pass
 
-    def remove_player(self, player):
+    def remove_player(self, player: Player):
         if player.id in self.players:
             del self.players[player.id]
 
-    def get_permission_group(self, user_id):
+    def get_permission_group(self, user_id: int):
         return self.privileged_users.get(user_id, 0)
 
     def is_uniqueid_exempt(self, user_id):
         return user_id in self.uniqueid_exempt
 
-    def has_blacklisted_domain(self, email):
+    def has_blacklisted_domain(self, email: str) -> bool:
         # A valid email only has one @ anyway.
         domain = email.split("@")[1]
         return domain in self.blacklisted_email_domains
 
-    def get_player(self, player_id):
-        if player_id in self.players:
-            return self.players[player_id]
+    def get_player(self, player_id: int) -> Optional[Player]:
+        return self.players.get(player_id)
 
     async def update_data(self):
         """

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -12,15 +12,14 @@ class ServerContext:
     Base class for managing connections and holding state about them.
     """
 
-    def __init__(self, connection_factory, loop, name='Unknown server'):
+    def __init__(self, connection_factory, name='Unknown server'):
         super().__init__()
-        self.loop = loop
         self.name = name
         self._server = None
         self._connection_factory = connection_factory
         self.connections = {}
         self._transport = None
-        self._logger.debug("%s initialized with loop: %s", self, loop)
+        self._logger.debug("%s initialized", self)
         self.addr = None
 
     def __repr__(self):
@@ -29,10 +28,11 @@ class ServerContext:
     async def listen(self, host, port):
         self.addr = (host, port)
         self._logger.debug("ServerContext.listen(%s,%d)", host, port)
-        self._server = await asyncio.start_server(self.client_connected,
-                                            host=host,
-                                            port=port,
-                                            loop=self.loop)
+        self._server = await asyncio.start_server(
+            self.client_connected,
+            host=host,
+            port=port
+        )
         return self._server
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def players(create_player):
 
 
 @pytest.fixture
-def player_service(loop, players, db_engine):
+def player_service(loop, db_engine):
     from server.player_service import PlayerService
     return PlayerService()
 

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -1,30 +1,27 @@
-import pytest
+import asyncio
 import hashlib
+import logging
 
-from server import VisibilityState
-
+import pytest
+from server import VisibilityState, run_lobby_server
+from server.protocol import QDataStreamProtocol
 from tests.integration_tests.testclient import ClientTest
 
 slow = pytest.mark.slow
 
 TEST_ADDRESS = ('127.0.0.1', None)
 
-import asyncio
-import logging
-import pytest
-from server import run_lobby_server
-from server.protocol import QDataStreamProtocol
-
-slow = pytest.mark.slow
-
 
 @pytest.fixture
-def lobby_server(request, loop, db_engine, player_service, game_service, geoip_service):
-    ctx = run_lobby_server(address=('127.0.0.1', None),
-                           geoip_service=geoip_service,
-                           player_service=player_service,
-                           games=game_service,
-                           loop=loop)
+def lobby_server(request, loop, db_engine, player_service, game_service, geoip_service, matchmaker_queue):
+    ctx = run_lobby_server(
+        address=('127.0.0.1', None),
+        geoip_service=geoip_service,
+        player_service=player_service,
+        games=game_service,
+        matchmaker_queue=matchmaker_queue,
+        loop=loop
+    )
     player_service.is_uniqueid_exempt = lambda id: True
 
     def fin():

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -19,24 +19,16 @@ def lobbythread():
 
 @pytest.fixture
 def game_connection(request, game, player_service, players, game_service, transport):
-    from server import GameConnection, LobbyConnection
+    from server import GameConnection
     conn = GameConnection(
         game=game,
         player=players.hosting,
-        lobby_connection=mock.create_autospec(
-            LobbyConnection(
-                loop=mock.Mock(),
-                context=mock.Mock(),
-                geoip=mock.Mock(),
-                games=mock.Mock(),
-                players=mock.Mock()
-            )
-        ),
+        protocol=mock.Mock(),
+        connectivity=mock.Mock(),
         player_service=player_service,
         games=game_service
     )
     conn._transport = transport
-    conn.lobby = mock.Mock(spec=LobbyConnection)
     conn.finished_sim = False
 
     def fin():
@@ -74,17 +66,16 @@ def connections(loop, player_service, game_service, transport, game):
     from server import GameConnection
 
     def make_connection(player, connectivity):
-        lc = LobbyConnection(loop)
-        lc.protocol = mock.Mock()
         conn = GameConnection(
             game=game,
             player=player,
-            lobby_connection=lc,
+            protocol=mock.Mock(),
+            connectivity=connectivity,
             player_service=player_service,
             games=game_service
         )
         conn._transport = transport
-        conn._connectivity_state.set_result(connectivity)
+        # conn._connectivity_state.set_result(connectivity)
         return conn
 
     return mock.Mock(

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -18,23 +18,24 @@ def lobbythread():
 
 
 @pytest.fixture
-def game_connection(request, game, loop, player_service, players, game_service, transport):
+def game_connection(request, game, player_service, players, game_service, transport):
     from server import GameConnection, LobbyConnection
-    conn = GameConnection(loop=loop,
-                          lobby_connection=mock.create_autospec(
-                              LobbyConnection(
-                                  loop=mock.Mock(),
-                                  context=mock.Mock(),
-                                  geoip=mock.Mock(),
-                                  games=mock.Mock(),
-                                  players=mock.Mock()
-                              )
-                          ),
-                          player_service=player_service,
-                          games=game_service)
+    conn = GameConnection(
+        game=game,
+        player=players.hosting,
+        lobby_connection=mock.create_autospec(
+            LobbyConnection(
+                loop=mock.Mock(),
+                context=mock.Mock(),
+                geoip=mock.Mock(),
+                games=mock.Mock(),
+                players=mock.Mock()
+            )
+        ),
+        player_service=player_service,
+        games=game_service
+    )
     conn._transport = transport
-    conn.player = players.hosting
-    conn.game = game
     conn.lobby = mock.Mock(spec=LobbyConnection)
     conn.finished_sim = False
 
@@ -75,12 +76,13 @@ def connections(loop, player_service, game_service, transport, game):
     def make_connection(player, connectivity):
         lc = LobbyConnection(loop)
         lc.protocol = mock.Mock()
-        conn = GameConnection(loop=loop,
-                              lobby_connection=lc,
-                              player_service=player_service,
-                              games=game_service)
-        conn.player = player
-        conn.game = game
+        conn = GameConnection(
+            game=game,
+            player=player,
+            lobby_connection=lc,
+            player_service=player_service,
+            games=game_service
+        )
         conn._transport = transport
         conn._connectivity_state.set_result(connectivity)
         return conn

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -14,7 +14,7 @@ LOCAL_PROXY = ConnectivityResult(addr=None, state=ConnectivityState.BLOCKED)
 
 
 def assert_message_sent(game_connection: GameConnection, command, args):
-    game_connection.lobby_connection.send.assert_called_with({
+    game_connection.protocol.send_message.assert_called_with({
         'command': command,
         'target': 'game',
         'args': args
@@ -36,7 +36,6 @@ async def test_handle_action_GameState_idle_adds_connection(
     players
 ):
     players.joining.game = game
-    game_connection.lobby_connection = mock.Mock()
     game_connection.player = players.hosting
     game_connection.game = game
 

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -1,37 +1,41 @@
 import pytest
-
-import server
 from server.game_service import GameService
-from server.games.game import VisibilityState
+from server.games import CustomGame, GameMode, VisibilityState
 from server.players import PlayerState
 
 
 @pytest.fixture
-def service(players, game_stats_service):
+def game_service(players, game_stats_service):
     return GameService(players, game_stats_service)
 
 
-def test_initialization(service):
-    assert len(service.dirty_games) == 0
+def test_initialization(game_service):
+    assert len(game_service.dirty_games) == 0
 
 
-def test_create_game(players, service):
+def test_create_game(players, game_service):
     players.hosting.state = PlayerState.IDLE
-    game = service.create_game(visibility=VisibilityState.PUBLIC,
-                               game_mode='faf',
-                               host=players.hosting,
-                               name='Test',
-                               mapname='SCMP_007',
-                               password=None)
+    game = game_service.create_game(
+        visibility=VisibilityState.PUBLIC,
+        game_mode=GameMode.FAF,
+        host=players.hosting,
+        name='Test',
+        mapname='SCMP_007',
+        password=None
+    )
     assert game is not None
-    assert game in service.dirty_games
+    assert game in game_service.dirty_games
+    assert isinstance(game, CustomGame)
 
 
-def test_all_games(players, service):
-    game = service.create_game(visibility=VisibilityState.PUBLIC,
-                               game_mode='faf',
-                               host=players.hosting,
-                               name='Test',
-                               mapname='SCMP_007',
-                               password=None)
-    assert game in service.pending_games
+def test_all_games(players, game_service):
+    game = game_service.create_game(
+        visibility=VisibilityState.PUBLIC,
+        game_mode=GameMode.FAF,
+        host=players.hosting,
+        name='Test',
+        mapname='SCMP_007',
+        password=None
+    )
+    assert game in game_service.pending_games
+    assert isinstance(game, CustomGame)

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from server import GameService, GameStatsService, LadderService
+from server import GameService, LadderService
 from server.db.models import game_player_stats, game_stats
 from server.players import Player
 from sqlalchemy import func, text
@@ -9,9 +9,8 @@ from tests import CoroMock
 
 
 @pytest.fixture
-def ladder_service(game_service: GameService, game_stats_service: GameStatsService, db_engine):
-    # db_engine needed to ensure the engine is created globally
-    return LadderService(game_service, game_stats_service)
+def ladder_service(game_service: GameService, db_engine):
+    return LadderService(game_service)
 
 
 async def test_start_game(ladder_service: LadderService, game_service: GameService):

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -49,11 +49,6 @@ def mock_player():
 
 
 @pytest.fixture
-def mock_context(loop):
-    return mock.create_autospec(ServerContext(lambda: None, loop))
-
-
-@pytest.fixture
 def mock_players(db_engine):
     return mock.create_autospec(PlayerService())
 
@@ -74,9 +69,8 @@ def mock_geoip():
 
 
 @pytest.fixture
-def lobbyconnection(loop, mock_context, mock_protocol, mock_games, mock_players, mock_player, mock_geoip):
+def lobbyconnection(loop, mock_protocol, mock_games, mock_players, mock_player, mock_geoip):
     lc = LobbyConnection(
-        context=mock_context,
         geoip=mock_geoip,
         games=mock_games,
         players=mock_players,

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -75,11 +75,13 @@ def mock_geoip():
 
 @pytest.fixture
 def lobbyconnection(loop, mock_context, mock_protocol, mock_games, mock_players, mock_player, mock_geoip):
-    lc = LobbyConnection(loop,
-                         context=mock_context,
-                         geoip=mock_geoip,
-                         games=mock_games,
-                         players=mock_players)
+    lc = LobbyConnection(
+        context=mock_context,
+        geoip=mock_geoip,
+        games=mock_games,
+        players=mock_players,
+        matchmaker_queue=mock.Mock()
+    )
     lc.player = mock_player
     lc.connectivity = mock.create_autospec(Connectivity)
     lc.protocol = mock_protocol

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -9,8 +9,8 @@ from tests import CoroMock
 
 
 @pytest.fixture
-def matchmaker_queue(player_service, game_service):
-    return MatchmakerQueue('test_queue', player_service, Mock())
+def matchmaker_queue(game_service):
+    return MatchmakerQueue('test_queue', game_service=Mock())
 
 
 @pytest.fixture


### PR DESCRIPTION
Trying to decouple the services as much as possible. There are a lot of cyclic dependencies that should be removed. Some are handled as weak references, but most are owning such as `LobbyConnection` <-> `GameConnection`