### PR TITLE
Un-skip tests that were waiting on test data from v63

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.5"
+  - "3.6"
 
 sudo: required
 dist: trusty
@@ -13,7 +13,7 @@ before_install:
   - sudo /etc/init.d/mysql stop
   - git clone https://github.com/FAForever/faf-stack.git faf-stack
       && pushd faf-stack
-      && git checkout 2873b47
+      && git checkout 0979304
       && cp -r config.template config
       && ./scripts/init-db.sh
       && wget https://raw.githubusercontent.com/FAForever/db/$(grep -oP 'faforever/faf-db-migrations:\K(.*)$' ./docker-compose.yml)/test-data.sql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,10 +139,25 @@ def transport():
 
 @pytest.fixture
 def game(players):
+    return make_game(1, players)
+
+
+GAME_UID = 1
+
+
+@pytest.fixture
+def ugame(players):
+    global GAME_UID
+    game = make_game(GAME_UID, players)
+    GAME_UID += 1
+    return game
+
+
+def make_game(uid, players):
     from server.games import Game
     from server.abc.base_game import InitMode
     mock_parent = mock.Mock()
-    game = mock.create_autospec(spec=Game(1, mock_parent, mock.Mock()))
+    game = mock.create_autospec(spec=Game(uid, mock_parent, mock.Mock()))
     game.remove_game_connection = CoroMock()
     players.hosting.getGame = mock.Mock(return_value=game)
     players.joining.getGame = mock.Mock(return_value=game)
@@ -150,8 +165,9 @@ def game(players):
     game.hostPlayer = players.hosting
     game.init_mode = InitMode.NORMAL_LOBBY
     game.name = "Some game name"
-    game.id = 1
+    game.id = uid
     return game
+
 
 @pytest.fixture
 def create_player():

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -267,7 +267,6 @@ async def test_handle_action_OperationComplete(game: Game, game_connection: Game
 
     Requires that the map from `game.map_file_path` exists in the database.
     """
-    pytest.skip("requires test data from faf-db:v63 which doesn't exist yet")
 
     game.map_file_path = "maps/prothyon16.v0005.zip"
     secondary = 1

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -244,8 +244,6 @@ def test_send_mod_list(mocker, lobbyconnection, mock_games):
 
 
 async def test_send_coop_maps(mocker, lobbyconnection):
-    pytest.skip("requires test data from faf-db:v63 which doesn't exist yet")
-
     protocol = mocker.patch.object(lobbyconnection, 'protocol')
 
     await lobbyconnection.send_coop_maps()


### PR DESCRIPTION
With the v64 image being done, we can now un-skip the two tests that were waiting for the updated `test-data.sql` file. Hooray!