### PR TITLE
Issue/#407 unranked games not being scored

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -434,9 +434,6 @@ class Game(BaseGame):
             elif self.state == GameState.LIVE:
                 self._logger.info("Game finished normally")
 
-                if self.validity is not ValidityState.VALID:
-                    return
-
                 if self.desyncs > 20:
                     await self.mark_invalid(ValidityState.TOO_MANY_DESYNCS)
                     return

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -450,7 +450,7 @@ class Game(BaseGame):
                 await self.persist_results()
                 await self.rate_game()
                 await self._process_pending_army_stats()
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             self._logger.exception("Error during game end: %s", e)
         finally:
             self.state = GameState.ENDED


### PR DESCRIPTION
Fixes #407.

The check we added to prevent games which were unranked due to bad game settings from being unranked a second time due to desyncs or other reasons, was preventing those unranked games from being scored at all. This results in any unranked games showing up as draws in the replay vault.

I don't think there is a reason to prevent games from being unranked twice. Desyncs seem more serious to me than bad unit restrictions, so I would think that the reason listed in the DB should be Desync and not Bad Unit Restriction anyways.