### PR TITLE
Integration tests update

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -759,33 +759,32 @@ class LobbyConnection():
 
         assert isinstance(self.player, Player)
 
-        default_title = "%s' game".format(self.player.login)
-        title = html.escape(message.get('title') or default_title)
-        port = message.get('gameport')
         visibility = VisibilityState.from_string(message.get('visibility'))
         if not isinstance(visibility, VisibilityState):
             # Protocol violation.
-            self.abort("%s sent a nonsense visibility code: %s" % (self.player.login, message.get('visibility')))
+            self.abort("{} sent a nonsense visibility code: {}".format(self.player.login, message.get('visibility')))
             return
 
-        mod = message.get('mod')
+        title = html.escape(message.get('title') or f"{self.player.login}'s game")
+
         try:
             title.encode('ascii')
         except UnicodeEncodeError:
             self.sendJSON(dict(command="notice", style="error", text="Non-ascii characters in game name detected."))
             return
 
+        port = message.get('gameport')
+        mod = message.get('mod')
         mapname = message.get('mapname')
         password = message.get('password')
-
         game_mode = GameMode.from_string(mod.lower())
 
         game = self.game_service.create_game(
             visibility=visibility,
             game_mode=game_mode,
             host=self.player,
-            name=title if title else self.player.login,
-            mapname=mapname,
+            name=title,
+            mapname=mapname or 'scmp_007',
             password=password
         )
         self.launch_game(game, port, is_host=True)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -626,7 +626,7 @@ class LobbyConnection():
 
         self.send_mod_list()
         self.send_game_list()
-        self.send_tutorial_section()
+        await self.send_tutorial_section()
 
     @timed
     def command_ask_session(self, message):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,11 +108,11 @@ def sqlquery():
 
 
 @pytest.fixture
-def mock_db_engine(loop, db_engine, autouse=True):
+def mock_db_engine(loop, db_engine):
     return db_engine
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='session', autouse=True)
 def db_engine(request, loop):
     import server
 
@@ -137,6 +137,16 @@ def db_engine(request, loop):
     request.addfinalizer(fin)
 
     return engine
+
+
+@pytest.fixture(scope='session', autouse=True)
+def test_data(db_engine, loop):
+    async def load_data():
+        with open('tests/data/test-data.sql') as f:
+            async with db_engine.acquire() as conn:
+                await conn.execute(f.read())
+
+    loop.run_until_complete(load_data())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,15 +215,7 @@ def players(create_player):
 
 
 @pytest.fixture
-def player_and_game_service(loop, players, db_engine, game_stats_service):
-    ps = PlayerService()
-    gs = GameService(ps, game_stats_service)
-    ps.ladder_queue = MatchmakerQueue('ladder1v1', ps, gs)
-    return ps, gs
-
-
-@pytest.fixture
-def player_service(loop, players, db_engine):
+def player_service(loop, players):
     return PlayerService()
 
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -1,0 +1,15 @@
+insert into login (id, login, email, password, create_time) values
+    (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), '2000-01-01 00:00:00'),
+    (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), '2000-01-01 00:00:00')
+;
+
+
+insert into global_rating (id, mean, deviation, numGames, is_active) values
+    (100, 1500, 500, 0, 1),
+    (101, 1500, 500, 0, 1)
+;
+
+insert into ladder1v1_rating (id, mean, deviation, numGames, is_active) values
+    (100, 1500, 500, 0, 1),
+    (101, 1500, 500, 0, 1)
+;

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -1,15 +1,21 @@
 insert into login (id, login, email, password, create_time) values
     (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), '2000-01-01 00:00:00'),
-    (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), '2000-01-01 00:00:00')
+    (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), '2000-01-01 00:00:00'),
+    (102, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), '2000-01-01 00:00:00')
 ;
 
 
 insert into global_rating (id, mean, deviation, numGames, is_active) values
     (100, 1500, 500, 0, 1),
-    (101, 1500, 500, 0, 1)
+    (101, 1500, 500, 0, 1),
+    (102, 1500, 500, 0, 1)
 ;
 
 insert into ladder1v1_rating (id, mean, deviation, numGames, is_active) values
     (100, 1500, 500, 0, 1),
-    (101, 1500, 500, 0, 1)
+    (101, 1500, 500, 0, 1),
+    (102, 1500, 500, 0, 1)
 ;
+
+delete from matchmaker_ban;
+insert into matchmaker_ban (id, userid) values (102, 102);

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -19,3 +19,22 @@ insert into ladder1v1_rating (id, mean, deviation, numGames, is_active) values
 
 delete from matchmaker_ban;
 insert into matchmaker_ban (id, userid) values (102, 102);
+
+insert into game_stats (id, startTime, gameType, gameMod, host, mapId, gameName, validity) values
+    (41935, NOW(), '0', 6, 1, 0, 'MapRepetition', 0),
+    (41936, NOW() + interval 1 minute, '0', 6, 1, 1, 'MapRepetition', 0),
+    (41937, NOW() + interval 2 minute, '0', 6, 1, 2, 'MapRepetition', 0),
+    (41938, NOW() + interval 3 minute, '0', 6, 1, 3, 'MapRepetition', 0),
+    (41939, NOW() + interval 4 minute, '0', 6, 1, 4, 'MapRepetition', 0),
+    (41940, NOW() + interval 5 minute, '0', 6, 1, 5, 'MapRepetition', 0),
+    (41941, NOW() + interval 6 minute, '0', 6, 1, 6, 'MapRepetition', 0);
+
+insert into game_player_stats (gameId, playerId, AI, faction, color, team, place, mean, deviation, scoreTime) values
+    (1, 1, 0, 0, 0, 2, 0, 1500, 500, NOW()),
+    (41935, 1, 0, 0, 0, 2, 0, 1500, 500, NOW()),
+    (41936, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 1 minute),
+    (41937, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 2 minute),
+    (41938, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 3 minute),
+    (41939, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 4 minute),
+    (41940, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 5 minute),
+    (41941, 1, 0, 0, 0, 2, 0, 1500, 500, NOW() + interval 6 minute);

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from server import GameService, PlayerService
+from server import GameService, PlayerService, run_lobby_server
 
 
 @pytest.fixture
@@ -14,3 +14,23 @@ def mock_players(db_engine):
 @pytest.fixture
 def mock_games(mock_players):
     return mock.create_autospec(GameService(mock_players))
+
+
+@pytest.fixture
+def lobby_server(request, loop, db_engine, player_service, game_service, geoip_service):
+    ctx = run_lobby_server(
+        address=('127.0.0.1', None),
+        geoip_service=geoip_service,
+        player_service=player_service,
+        games=game_service,
+        loop=loop
+    )
+    player_service.is_uniqueid_exempt = lambda id: True
+
+    def fin():
+        ctx.close()
+        loop.run_until_complete(ctx.wait_closed())
+
+    request.addfinalizer(fin)
+
+    return ctx

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,7 +1,13 @@
+import asyncio
+import hashlib
+import logging
 from unittest import mock
 
 import pytest
+import server
 from server import GameService, PlayerService, run_lobby_server
+from server.natpacketserver import NatPacketServer
+from server.protocol import QDataStreamProtocol
 
 
 @pytest.fixture
@@ -17,7 +23,10 @@ def mock_games(mock_players):
 
 
 @pytest.fixture
-def lobby_server(request, loop, db_engine, player_service, game_service, geoip_service):
+def lobby_server(request, loop, db_engine, player_and_game_service, geoip_service):
+    (player_service, game_service) = player_and_game_service
+    server.NatPacketServer.instance = NatPacketServer(addresses=server.config.LOBBY_NAT_ADDRESSES, loop=loop)
+    loop.run_until_complete(server.NatPacketServer.instance.listen())
     ctx = run_lobby_server(
         address=('127.0.0.1', None),
         geoip_service=geoip_service,
@@ -34,3 +43,51 @@ def lobby_server(request, loop, db_engine, player_service, game_service, geoip_s
     request.addfinalizer(fin)
 
     return ctx
+
+
+async def connect_client(server):
+    return QDataStreamProtocol(
+        *(await asyncio.open_connection(*server.sockets[0].getsockname()))
+    )
+
+
+async def perform_login(proto, credentials):
+    login, pw = credentials
+    pw_hash = hashlib.sha256(pw.encode('utf-8'))
+    proto.send_message({
+        'command': 'hello',
+        'version': '1.0.0-dev',
+        'user_agent': 'faf-client',
+        'login': login,
+        'password': pw_hash.hexdigest(),
+        'unique_id': 'some_id'
+    })
+    await proto.drain()
+
+
+async def read_until(proto, pred):
+    while True:
+        msg = await proto.read_message()
+        try:
+            if pred(msg):
+                return msg
+        except (KeyError, ValueError):
+            logging.getLogger().info("read_until predicate raised during message: {}".format(msg))
+            pass
+
+
+async def get_session(proto):
+    proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.11.16'})
+    await proto.drain()
+    msg = await proto.read_message()
+
+    return msg['session']
+
+
+async def connect_and_sign_in(credentials, lobby_server):
+    proto = await connect_client(lobby_server)
+    session = await get_session(proto)
+    await perform_login(proto, credentials)
+    hello = await proto.read_message()
+    player_id = hello['id']
+    return player_id, session, proto

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -23,7 +23,7 @@ def mock_games(mock_players):
 
 
 @pytest.fixture
-def lobby_server(request, loop, db_engine, player_and_game_service, geoip_service):
+def lobby_server(request, loop, player_and_game_service, geoip_service):
     (player_service, game_service) = player_and_game_service
     server.NatPacketServer.instance = NatPacketServer(addresses=server.config.LOBBY_NAT_ADDRESSES, loop=loop)
     loop.run_until_complete(server.NatPacketServer.instance.listen())

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,16 +1,16 @@
 from unittest import mock
 
 import pytest
+from server import GameService, PlayerService
 
 
 @pytest.fixture
 def mock_players(db_engine):
-    from server import PlayerService
     m = mock.create_autospec(PlayerService())
     m.client_version_info = (0, None)
     return m
 
+
 @pytest.fixture
 def mock_games(mock_players):
-    from server import GameService
     return mock.create_autospec(GameService(mock_players))

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -1,0 +1,59 @@
+import pytest
+
+from .conftest import connect_and_sign_in, read_until
+from .testclient import ClientTest
+
+
+async def test_game_matchmaking(loop, lobby_server, db_engine):
+    async with db_engine.acquire() as conn:
+        result = await conn.execute("SELECT mean, deviation, id from ladder1v1_rating WHERE id in (1,3)")
+        ratings = [(row['mean'], row['deviation'], row['id']) async for row in result]
+        await conn.execute("UPDATE ladder1v1_rating SET mean=2000,deviation=500 WHERE id in (1,3)")
+    _, _, proto1 = await connect_and_sign_in(
+        ('test', 'test_password'),
+        lobby_server
+    )
+    _, _, proto2 = await connect_and_sign_in(
+        ('Rhiza', 'puff_the_magic_dragon'),
+        lobby_server
+    )
+
+    await read_until(proto1, lambda msg: msg['command'] == 'game_info')
+    await read_until(proto2, lambda msg: msg['command'] == 'game_info')
+
+    with ClientTest(loop=loop, process_nat_packets=True, proto=proto1) as client1:
+        with ClientTest(loop=loop, process_nat_packets=True, proto=proto2) as client2:
+            port1, port2 = 6112, 6113
+            await client1.listen_udp(port=port1)
+            await client1.perform_connectivity_test(port=port1)
+
+            await client2.listen_udp(port=port2)
+            await client2.perform_connectivity_test(port=port2)
+
+            proto1.send_message({
+                'command': 'game_matchmaking',
+                'state': 'start',
+                'faction': 'uef'
+            })
+            await proto1.drain()
+
+            proto2.send_message({
+                'command': 'game_matchmaking',
+                'state': 'start',
+                'faction': 'uef'
+            })
+            await proto2.drain()
+
+            # If the players did not match, this test will fail due to a timeout error
+            msg1 = await read_until(proto1, lambda msg: msg['command'] == 'game_launch')
+            msg2 = await read_until(proto2, lambda msg: msg['command'] == 'game_launch')
+
+            assert msg1['uid'] == msg2['uid']
+            assert msg1['mod'] == 'ladder1v1'
+            assert msg2['mod'] == 'ladder1v1'
+
+    async with db_engine.acquire() as conn:
+        await conn.execute(
+            "UPDATE ladder1v1_rating SET mean=%s,deviation=%s WHERE id =%s",
+            ratings
+        )

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -3,34 +3,13 @@ import hashlib
 import logging
 
 import pytest
-from server import VisibilityState, run_lobby_server
+from server import VisibilityState
 from server.protocol import QDataStreamProtocol
-from tests.integration_tests.testclient import ClientTest
+from .testclient import ClientTest
 
 slow = pytest.mark.slow
 
 TEST_ADDRESS = ('127.0.0.1', None)
-
-
-@pytest.fixture
-def lobby_server(request, loop, db_engine, player_service, game_service, geoip_service, matchmaker_queue):
-    ctx = run_lobby_server(
-        address=('127.0.0.1', None),
-        geoip_service=geoip_service,
-        player_service=player_service,
-        games=game_service,
-        matchmaker_queue=matchmaker_queue,
-        loop=loop
-    )
-    player_service.is_uniqueid_exempt = lambda id: True
-
-    def fin():
-        ctx.close()
-        loop.run_until_complete(ctx.wait_closed())
-
-    request.addfinalizer(fin)
-
-    return ctx
 
 
 async def connect_client(server):

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -33,37 +33,37 @@ def lobby_server(request, loop, db_engine, player_service, game_service, geoip_s
     return ctx
 
 
-@asyncio.coroutine
-def connect_client(server):
-    return QDataStreamProtocol(*(yield from asyncio.open_connection(*server.sockets[0].getsockname())))
+async def connect_client(server):
+    return QDataStreamProtocol(
+        *(await asyncio.open_connection(*server.sockets[0].getsockname()))
+    )
 
 
-@asyncio.coroutine
-def get_session(proto):
+async def get_session(proto):
     proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.11.16'})
-    yield from proto.drain()
-    msg = yield from proto.read_message()
+    await proto.drain()
+    msg = await proto.read_message()
+
     return msg['session']
 
 
-@asyncio.coroutine
-def perform_login(proto, credentials):
+async def perform_login(proto, credentials):
     login, pw = credentials
     pw_hash = hashlib.sha256(pw.encode('utf-8'))
-    proto.send_message({'command': 'hello',
-                        'version': '1.0.0-dev',
-                        'user_agent': 'faf-client',
-                        'login': login,
-                        'password': pw_hash.hexdigest(),
-                        'unique_id': 'some_id'
-                        })
-    yield from proto.drain()
+    proto.send_message({
+        'command': 'hello',
+        'version': '1.0.0-dev',
+        'user_agent': 'faf-client',
+        'login': login,
+        'password': pw_hash.hexdigest(),
+        'unique_id': 'some_id'
+    })
+    await proto.drain()
 
 
-@asyncio.coroutine
-def read_until(proto, pred):
+async def read_until(proto, pred):
     while True:
-        msg = yield from proto.read_message()
+        msg = await proto.read_message()
         try:
             if pred(msg):
                 return msg
@@ -82,12 +82,11 @@ async def test_server_invalid_login(loop, lobby_server):
     proto.close()
 
 
-@asyncio.coroutine
 @slow
-def test_server_valid_login(loop, lobby_server):
-    proto = yield from connect_client(lobby_server)
-    yield from perform_login(proto, ('test', 'test_password'))
-    msg = yield from proto.read_message()
+async def test_server_valid_login(loop, lobby_server):
+    proto = await connect_client(lobby_server)
+    await perform_login(proto, ('test', 'test_password'))
+    msg = await proto.read_message()
     assert msg == {'command': 'welcome',
                    'me': {'clan': '678',
                           'country': '',
@@ -100,20 +99,20 @@ def test_server_valid_login(loop, lobby_server):
                    'login': 'test'}
     lobby_server.close()
     proto.close()
-    yield from lobby_server.wait_closed()
+    await lobby_server.wait_closed()
 
 
-@asyncio.coroutine
-def test_player_info_broadcast(loop, lobby_server):
-    p1 = yield from connect_client(lobby_server)
-    p2 = yield from connect_client(lobby_server)
+async def test_player_info_broadcast(loop, lobby_server):
+    p1 = await connect_client(lobby_server)
+    p2 = await connect_client(lobby_server)
 
-    yield from perform_login(p1, ('test', 'test_password'))
-    yield from perform_login(p2, ('Rhiza', 'puff_the_magic_dragon'))
+    await perform_login(p1, ('test', 'test_password'))
+    await perform_login(p2, ('Rhiza', 'puff_the_magic_dragon'))
 
-    yield from read_until(p2,
-                          lambda m: 'player_info' in m.values()
-                                    and any(map(lambda d: ('login', 'test') in d.items(), m['players'])))
+    await read_until(
+        p2, lambda m: 'player_info' in m.values()
+        and any(map(lambda d: ('login', 'test') in d.items(), m['players']))
+    )
     p1.close()
     p2.close()
 

--- a/tests/integration_tests/testclient.py
+++ b/tests/integration_tests/testclient.py
@@ -33,7 +33,7 @@ class UDPClientProtocol(asyncio.DatagramProtocol):
 
 
 @with_logger
-class ClientTest():
+class ClientTest(GpgNetClientProtocol):
     """
     Client used for acting as a GPGNet client (The game itself).
 
@@ -52,9 +52,14 @@ class ClientTest():
         self._udp_transport, self._udp_protocol = (None, None)
         self._gpg_socket_pair = None
 
-    def send_connectivity_message(self, command_id, arguments: List[Union[int, str, bool]]) -> None:
+    def send_connectivity_message(self, command_id, arguments: List[Union[int, str, bool]]):
         self._proto.send_message({'command': command_id,
                                   'target': 'connectivity',
+                                  'args': arguments})
+
+    def send_gpgnet_message(self, command_id, arguments: List[Union[int, str, bool]]):
+        self._proto.send_message({'command': command_id,
+                                  'target': 'game',
                                   'args': arguments})
 
     async def listen_udp(self, port=6112):

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -9,7 +9,7 @@ from tests import CoroMock
 
 
 @pytest.fixture
-def ladder_service(game_service: GameService, db_engine):
+def ladder_service(game_service: GameService):
     return LadderService(game_service)
 
 

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -80,48 +80,10 @@ async def test_choose_map_raises_on_empty_map_pool(ladder_service: LadderService
 
 
 async def test_get_ladder_history(ladder_service: LadderService, players, db_engine):
-    async with db_engine.acquire() as conn:
-        await conn.execute(
-            game_player_stats.insert().values(gameId=1, playerId=players.hosting.id, AI=False, faction=0, color=0, team=2, place=0, mean=1500, deviation=500, scoreTime=func.now())
-        )
-    history = await ladder_service.get_ladder_history(players.hosting)
-
-    print(history)
-    assert history == [1]
+    history = await ladder_service.get_ladder_history(players.hosting, limit=1)
+    assert history == [6]
 
 
 async def test_get_ladder_history_many_maps(ladder_service: LadderService, players, db_engine):
-    game_id_start = 41935  # Some arbitrary number
-    num_maps = 7
-    async with db_engine.acquire() as conn:
-        for i in range(num_maps):
-            await conn.execute(
-                game_stats.insert().values(
-                    id=game_id_start+i,
-                    startTime=func.now() + text(f"interval {i+1} minute"),
-                    gameType='0',
-                    gameMod=6,
-                    host=players.hosting.id,
-                    mapId=i,
-                    gameName="MapRepitition",
-                    validity=0
-                )
-            )
-            await conn.execute(
-                game_player_stats.insert().values(
-                    gameId=game_id_start+i,
-                    playerId=players.hosting.id,
-                    AI=False,
-                    faction=0,
-                    color=0,
-                    team=2,
-                    place=0,
-                    mean=1500,
-                    deviation=500,
-                    scoreTime=func.now() + text(f"interval {i+1} minute")
-                )
-            )
-
-    history = await ladder_service.get_ladder_history(players.hosting)
-
-    assert history == [num_maps-1, num_maps-2, num_maps-3]
+    history = await ladder_service.get_ladder_history(players.hosting, limit=4)
+    assert history == [6, 5, 4, 3]


### PR DESCRIPTION
Make the integration tests actually check something. This will be an OK way of testing things which are otherwise hard to do with unit tests because of the mocks. For example checking that a game's default title is set correctly if the host doesn't specify a title.

Added integration tests for:
  * Queueing a ladder match
  * Players banned form ladder receive the 'you are banned' message
  * Hosting a game with missing or empty fields

I also added a test-data.sql file to this repo so that we don't need to insert data in the test themselves, and don't need to submit PR's to Faforever/db just to add some test data.