### PR TITLE
[RFC] Implement utf8 protocol and dynamic protocol switching

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -18,7 +18,7 @@ from .stats.game_stats_service import GameStatsService
 from .gameconnection import GameConnection
 from .ice_servers.nts import TwilioNTS
 from .lobbyconnection import LobbyConnection
-from .protocol import QDataStreamProtocol
+from .protocol import QDataStreamProtocol, Protocol
 from .servercontext import ServerContext
 from .geoip_service import GeoIpService
 from .player_service import PlayerService
@@ -26,6 +26,7 @@ from .game_service import GameService
 from .ladder_service import LadderService
 from .control import init as run_control_server
 from .matchmaker import MatchmakerQueue
+from .types import Address
 
 __version__ = '0.9.17'
 __author__ = 'Chris Kitching, Dragonfire, Gael Honorez, Jeroen De Dauw, Crotalus, Michael Søndergaard, Michel Jung'
@@ -136,13 +137,15 @@ def run_lobby_server(
         ctx.broadcast_raw(ping_msg)
         loop.call_later(45, ping_broadcast)
 
-    def make_connection() -> LobbyConnection:
+    def make_connection(protocol: Protocol, peername: Address) -> LobbyConnection:
         return LobbyConnection(
             geoip=geoip_service,
             games=games,
             nts_client=nts_client,
             players=player_service,
-            matchmaker_queue=matchmaker_queue
+            matchmaker_queue=matchmaker_queue,
+            protocol=protocol,
+            peername=peername
         )
     ctx = ServerContext(make_connection, name="LobbyServer")
     loop.call_later(DIRTY_REPORT_INTERVAL, report_dirties)

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -10,7 +10,7 @@ from .game_service import GameService
 from .games.game import Game, GameState, ValidityState, Victory
 from .player_service import PlayerService
 from .players import Player, PlayerState
-from .protocol import GpgNetServerProtocol, QDataStreamProtocol
+from .protocol import GpgNetServerProtocol, Protocol
 
 
 class AuthenticationError(Exception):
@@ -27,7 +27,7 @@ class GameConnection(GpgNetServerProtocol):
         self,
         game: Game,
         player: Player,
-        protocol: QDataStreamProtocol,
+        protocol: Protocol,
         player_service: PlayerService,
         games: GameService,
         state: GameConnectionState = GameConnectionState.INITIALIZING

--- a/server/protocol/__init__.py
+++ b/server/protocol/__init__.py
@@ -1,11 +1,13 @@
-from .qdatastreamprotocol import QDataStreamProtocol
-from .protocol import Protocol
 from .gpgnet import GpgNetClientProtocol, GpgNetServerProtocol
+from .protocol import Protocol
+from .qdatastreamprotocol import QDataStreamProtocol
+from .utf8_protocol import UTF8Protocol
 
 
 __all__ = [
-    'QDataStreamProtocol',
-    'Protocol',
     'GpgNetClientProtocol',
-    'GpgNetServerProtocol'
+    'GpgNetServerProtocol',
+    'Protocol',
+    'QDataStreamProtocol',
+    'UTF8Protocol',
 ]

--- a/server/protocol/protocol.py
+++ b/server/protocol/protocol.py
@@ -41,3 +41,17 @@ class Protocol(metaclass=ABCMeta):
         :param data: bytes to send
         """
         pass  # pragma: no cover
+
+    @abstractmethod
+    async def drain(self) -> None:
+        """
+        Await the write buffer to empty
+        """
+        pass  # pragma: no cover
+
+    @abstractmethod
+    def close(self) -> None:
+        """
+        Close the stream
+        """
+        pass  # pragma: no cover

--- a/server/protocol/utf8_protocol.py
+++ b/server/protocol/utf8_protocol.py
@@ -1,0 +1,72 @@
+import json
+from asyncio import IncompleteReadError, StreamReader, StreamWriter
+from json.decoder import JSONDecodeError
+from typing import List
+
+import server
+
+from .protocol import Protocol
+
+
+class UTF8Protocol(Protocol):
+    """ Implements a UTF-8 based encoding scheme """
+
+    def __init__(self, reader: StreamReader, writer: StreamWriter):
+        """
+        Initialize the protocol
+
+        :param StreamReader reader: asyncio stream to read from
+        """
+        self.reader = reader
+        self.writer = writer
+
+    async def read_message(self) -> dict:
+        """
+        Asynchronously read a message from the stream
+
+        :raises: IncompleteReadError, UnicodeDecodeError, JSONDecodeError
+        :return dict: Parsed message
+        """
+        message = await self.reader.readline()
+        return json.loads(message.decode('utf8'))
+
+    def send_message(self, message: dict) -> None:
+        """
+        Send a single message in the form of a dictionary
+
+        :param message: Message to send
+        """
+        data = (json.dumps(message) + "\n").encode('utf8')
+        self.send_raw(data)
+
+    def send_messages(self, messages: List[dict]) -> None:
+        """
+        Send multiple messages in the form of a list of dictionaries.
+
+        May be more optimal than sending a single message.
+
+        :param messages:
+        """
+        for message in messages:
+            self.send_message(message)
+
+    def send_raw(self, data: bytes) -> None:
+        """
+        Send raw bytes. Should generally not be used.
+
+        :param data: bytes to send
+        """
+        server.stats.incr('server.sent_messages')
+        self.writer.write(data)
+
+    async def drain(self) -> None:
+        """
+        Await the write buffer to empty
+        """
+        await self.writer.drain()
+
+    def close(self) -> None:
+        """
+        Close the stream
+        """
+        self.writer.close()

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -58,9 +58,11 @@ class ServerContext:
     async def client_connected(self, stream_reader, stream_writer):
         self._logger.debug("%s: Client connected", self)
         protocol = QDataStreamProtocol(stream_reader, stream_writer)
-        connection = self._connection_factory()
+        connection = self._connection_factory(
+            protocol=protocol,
+            peername=Address(*stream_writer.get_extra_info('peername'))
+        )
         try:
-            await connection.on_connection_made(protocol, Address(*stream_writer.get_extra_info('peername')))
             self.connections[connection] = protocol
             server.stats.gauge('user.agents.None', 1, delta=True)
             while True:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import pytest
 from server.api.api_accessor import ApiAccessor
-from server.config import DB_LOGIN, DB_PASSWORD, DB_PORT, DB_SERVER
+from server.config import DB_LOGIN, DB_PASSWORD, DB_PORT, DB_SERVER, TRACE
 from server.game_service import GameService
 from server.geoip_service import GeoIpService
 from server.matchmaker import MatchmakerQueue
@@ -20,7 +20,7 @@ from server.player_service import PlayerService
 from tests import CoroMock
 from trueskill import Rating
 
-logging.getLogger().setLevel(logging.DEBUG)
+logging.getLogger('server').setLevel(TRACE)
 
 
 def async_test(f):

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -71,7 +71,6 @@ async def read_until(proto, pred):
                 return msg
         except (KeyError, ValueError):
             logging.getLogger().info("read_until predicate raised during message: {}".format(msg))
-            pass
 
 
 async def get_session(proto):

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -30,7 +30,7 @@ def mock_server(loop):
 
 @pytest.fixture
 def mock_context(loop, request, mock_server):
-    ctx = ServerContext(lambda: mock_server, name='TestServer')
+    ctx = ServerContext(lambda protocol, peername: mock_server, name='TestServer')
 
     def fin():
         ctx.close()

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -11,7 +11,7 @@ from server.geoip_service import GeoIpService
 from server.lobbyconnection import LobbyConnection
 from server.player_service import PlayerService
 from server.players import Player, PlayerState
-from server.protocol import QDataStreamProtocol
+from server.protocol import Protocol, QDataStreamProtocol
 from server.types import Address
 from sqlalchemy import and_, select
 from tests import CoroMock
@@ -80,7 +80,9 @@ def lobbyconnection(loop, mock_protocol, mock_games, mock_players, mock_player, 
         games=mock_games,
         players=mock_players,
         nts_client=mock_nts_client,
-        matchmaker_queue=mock.Mock()
+        matchmaker_queue=mock.Mock(),
+        protocol=mock.create_autospec(Protocol),
+        peername=mock.create_autospec(Address)
     )
 
     lc.player = mock_player
@@ -255,7 +257,7 @@ def test_abort(loop, mocker, lobbyconnection):
 
     lobbyconnection.abort()
 
-    proto.writer.close.assert_any_call()
+    proto.close.assert_any_call()
 
 
 def test_send_game_list(mocker, lobbyconnection, game_stats_service):

--- a/tests/unit_tests/test_protocol.py
+++ b/tests/unit_tests/test_protocol.py
@@ -4,25 +4,33 @@ import asyncio
 from unittest import mock
 import pytest
 import struct
+from json.decoder import JSONDecodeError
 
-from server.protocol import QDataStreamProtocol
+from server.protocol import QDataStreamProtocol, UTF8Protocol
 
 
 @pytest.fixture
 def reader(loop):
     return StreamReader(loop=loop)
 
+
 @pytest.fixture
 def writer():
     return mock.Mock()
+
 
 @pytest.fixture
 def protocol(reader, writer):
     return QDataStreamProtocol(reader, writer)
 
 
+@pytest.fixture
+def utf8protocol(reader, writer):
+    return UTF8Protocol(reader, writer)
+
+
 @asyncio.coroutine
-def test_QDataStreamProtocol_recv_small_message(protocol,reader):
+def test_QDataStreamProtocol_recv_small_message(protocol, reader):
     data = QDataStreamProtocol.pack_block(b''.join([QDataStreamProtocol.pack_qstring('{"some_header": true}'),
                                                     QDataStreamProtocol.pack_qstring('Goodbye')]))
     reader.feed_data(data)
@@ -40,6 +48,7 @@ def test_QDataStreamProtocol_recv_malformed_message(protocol, reader):
     with pytest.raises(asyncio.IncompleteReadError):
         yield from protocol.read_message()
 
+
 @asyncio.coroutine
 def test_QDataStreamProtocol_recv_large_array(protocol, reader):
     reader.feed_data(QDataStreamProtocol.pack_block(b''.join(
@@ -51,6 +60,7 @@ def test_QDataStreamProtocol_recv_large_array(protocol, reader):
 
     assert message == {'some_header': True, 'legacy': [str(i) for i in range(1520)]}
 
+
 async def test_unpacks_evil_qstring(protocol, reader):
     reader.feed_data(struct.pack('!I', 64))
     reader.feed_data(b'\x00\x00\x004\x00{\x00"\x00c\x00o\x00m\x00m\x00a\x00n\x00d\x00"\x00:\x00 \x00"\x00a\x00s\x00k\x00_\x00s\x00e\x00s\x00s\x00i\x00o\x00n\x00"\x00}\xff\xff\xff\xff\xff\xff\xff\xff')
@@ -59,3 +69,25 @@ async def test_unpacks_evil_qstring(protocol, reader):
     message = await protocol.read_message()
 
     assert message == {'command': 'ask_session'}
+
+
+async def test_utf8protocol_simple_message(utf8protocol, reader):
+    reader.feed_data(b'{"command": "ask_session"}\n')
+
+    message = await utf8protocol.read_message()
+
+    assert message == {'command': 'ask_session'}
+
+
+async def test_utf8protocol_recv_malformed_utf8(utf8protocol, reader):
+    reader.feed_data(b'\xf0\x0d\xba\xbe\n')
+
+    with pytest.raises(UnicodeDecodeError):
+        await utf8protocol.read_message()
+
+
+async def test_utf8protocol_recv_malformed_json(utf8protocol, reader):
+    reader.feed_data(b'{"command": "ask_session"\n')
+
+    with pytest.raises(JSONDecodeError):
+        await utf8protocol.read_message()


### PR DESCRIPTION
Fixes #132.

Makes some minor adjustments to allow different protocol encoding schemes to be implemented and add a basic JSON/UTF-8 implementation. Currently ping messages are still encoded as QStrings, but these messages are also completely ignored by the server. Can they be removed entirely?

Please give feedback:
* How does the client tell the server to switch to a different protocol?
* Can we safely make UTF-8 be the default protocol, now that py client is deprecated?
* What should happen with ping messages?