### PR TITLE
Fix wrong player avatar being selected

### DIFF
--- a/server/player_service.py
+++ b/server/player_service.py
@@ -68,7 +68,7 @@ class PlayerService:
                 .outerjoin(clan)
                 .outerjoin(avatars)
                 .outerjoin(avatars_list)
-            ).where(login.c.id == player.id)
+            ).where(login.c.id == player.id).where(avatars.selected)
 
             result = await conn.execute(sql)
             row = await result.fetchone()


### PR DESCRIPTION
Currently all selected avatars are the first avatar of the player due to the query not filtering the avatars if it is selected.