### PR TITLE
Hotfix 9.30: Fix avatars and py client matchmaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ develop_venv/
 .mypy_cache
 .pytest_cache
 .venv
-test-data.sql
+/test-data.sql

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -304,6 +304,12 @@ class GameConnection(GpgNetServerProtocol):
             :param teamkiller_id: teamkiller id
             :param teamkiller_name: teamkiller nickname (for debug purpose only)
         """
+        victim_id = int(victim_id)
+        teamkiller_id = int(teamkiller_id)
+
+        if 0 in (victim_id, teamkiller_id):
+            self._logger.debug("Ignoring teamkill report for AI player")
+            return
 
         async with db.engine.acquire() as conn:
             await conn.execute(
@@ -486,6 +492,7 @@ COMMAND_HANDLERS = {
     "JsonStats":            GameConnection.handle_json_stats,
     "EnforceRating":        GameConnection.handle_enforce_rating,
     "TeamkillReport":       GameConnection.handle_teamkill_report,
+    "TeamkillHappened":     GameConnection.handle_teamkill_report,
     "GameEnded":            GameConnection.handle_game_ended,
     "Rehost":               GameConnection.handle_rehost,
     "Bottleneck":           GameConnection.handle_bottleneck,

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -4,6 +4,7 @@ import server.db as db
 from sqlalchemy import text
 
 from .abc.base_game import GameConnectionState
+from .config import TRACE
 from .decorators import with_logger
 from .game_service import GameService
 from .games.game import Game, GameState, ValidityState, Victory
@@ -71,7 +72,7 @@ class GameConnection(GpgNetServerProtocol):
     def send_message(self, message):
         message['target'] = "game"
 
-        self._logger.debug(">>: %s", message)
+        self._logger.log(TRACE, ">>: %s", message)
         self.protocol.send_message(message)
 
     async def _handle_idle_state(self):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -854,7 +854,7 @@ class LobbyConnection():
                 uid, name, version, author, ui, date, downloads, likes, played, description, filename, icon, likerList = (row[i] for i in range(13))
                 link = urllib.parse.urljoin(config.CONTENT_URL, "faf/vault/" + filename)
                 thumbstr = ""
-                if icon != "":
+                if icon:
                     thumbstr = urllib.parse.urljoin(config.CONTENT_URL, "faf/vault/mods_thumbs/" + urllib.parse.quote(icon))
 
                 out = dict(command="modvault_info", thumbnail=thumbstr, link=link, bugreports=[],

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -741,7 +741,8 @@ class LobbyConnection():
 
         if state == "start":
             assert self.player is not None
-            self.player.faction = str(message['faction'])
+            # Faction can be either the name (e.g. 'uef') or the enum value (e.g. 1)
+            self.player.faction = message['faction']
 
             if mod == "ladder1v1":
                 search = Search([self.player])

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -6,7 +6,7 @@ import marisa_trie
 import server.db as db
 from server.decorators import with_logger
 from server.players import Player
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from .db.models import (avatars, avatars_list, clan, clan_membership,
                         global_rating, ladder1v1_rating, login)
@@ -66,7 +66,10 @@ class PlayerService:
                 .join(ladder1v1_rating)
                 .outerjoin(clan_membership)
                 .outerjoin(clan)
-                .outerjoin(avatars)
+                .outerjoin(avatars, onclause=and_(
+                    avatars.c.idUser == login.c.id,
+                    avatars.c.selected == 1
+                ))
                 .outerjoin(avatars_list)
             ).where(login.c.id == player.id)
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -1,5 +1,7 @@
 insert into login (id, login, email, password, create_time) values
-    (50,  'player_service', 'ps@example.com', SHA2('player_service', 256), '2000-01-01 00:00:00'),
+    (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), '2000-01-01 00:00:00'),
+    (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), '2000-01-01 00:00:00'),
+    (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), '2000-01-01 00:00:00'),
     (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), '2000-01-01 00:00:00'),
     (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), '2000-01-01 00:00:00'),
     (102, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), '2000-01-01 00:00:00'),
@@ -12,6 +14,8 @@ insert into clan_membership (clan_id, player_id) values
 
 insert into global_rating (id, mean, deviation, numGames, is_active) values
     (50,  1200, 250, 42, 1),
+    (51,  1200, 250, 42, 1),
+    (52,  1200, 250, 42, 1),
     (100, 1500, 500, 0, 1),
     (101, 1500, 500, 0, 1),
     (102, 1500, 500, 0, 1)
@@ -19,13 +23,19 @@ insert into global_rating (id, mean, deviation, numGames, is_active) values
 
 insert into ladder1v1_rating (id, mean, deviation, numGames, is_active) values
     (50,  1300, 400, 12, 1),
+    (51,  1300, 400, 12, 1),
+    (52,  1300, 400, 12, 1),
     (100, 1500, 500, 0, 1),
     (101, 1500, 500, 0, 1),
     (102, 1500, 500, 0, 1)
 ;
 
 insert into avatars (idUser, idAvatar, selected) values
-    (50, 2, 1);
+    (50, 2, 1),
+    (51, 1, 0),
+    (51, 2, 1),
+    (52, 1, 1),
+    (52, 2, 0);
 
 delete from matchmaker_ban where id = 102 and userid = 102;
 insert into matchmaker_ban (id, userid) values (102, 102);

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -80,6 +80,10 @@ async def read_until(proto, pred):
             pass
 
 
+async def read_until_command(proto, command):
+    return await read_until(proto, lambda msg: msg.get('command') == command)
+
+
 async def get_session(proto):
     proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.11.16'})
     await proto.drain()

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -26,29 +26,27 @@ async def test_game_matchmaking(loop, lobby_server, mocker):
     await read_until(proto1, lambda msg: msg['command'] == 'game_info')
     await read_until(proto2, lambda msg: msg['command'] == 'game_info')
 
-    with ClientTest(loop=loop, process_nat_packets=True, proto=proto1) as client1:
-        with ClientTest(loop=loop, process_nat_packets=True, proto=proto2) as client2:
-            proto1.send_message({
-                'command': 'game_matchmaking',
-                'state': 'start',
-                'faction': 'uef'
-            })
-            await proto1.drain()
+    proto1.send_message({
+        'command': 'game_matchmaking',
+        'state': 'start',
+        'faction': 'uef'
+    })
+    await proto1.drain()
 
-            proto2.send_message({
-                'command': 'game_matchmaking',
-                'state': 'start',
-                'faction': 'uef'
-            })
-            await proto2.drain()
+    proto2.send_message({
+        'command': 'game_matchmaking',
+        'state': 'start',
+        'faction': 1
+    })
+    await proto2.drain()
 
-            # If the players did not match, this test will fail due to a timeout error
-            msg1 = await read_until(proto1, lambda msg: msg['command'] == 'game_launch')
-            msg2 = await read_until(proto2, lambda msg: msg['command'] == 'game_launch')
+    # If the players did not match, this test will fail due to a timeout error
+    msg1 = await read_until(proto1, lambda msg: msg['command'] == 'game_launch')
+    msg2 = await read_until(proto2, lambda msg: msg['command'] == 'game_launch')
 
-            assert msg1['uid'] == msg2['uid']
-            assert msg1['mod'] == 'ladder1v1'
-            assert msg2['mod'] == 'ladder1v1'
+    assert msg1['uid'] == msg2['uid']
+    assert msg1['mod'] == 'ladder1v1'
+    assert msg2['mod'] == 'ladder1v1'
 
 
 async def test_game_matchmaking_ban(loop, lobby_server, db_engine):

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -230,7 +230,17 @@ async def test_handle_action_TeamkillReport(game: Game, game_connection: GameCon
         assert game.id == row[0]
 
 
-async def test_handle_action_TeamkillReport_AI(game: Game, game_connection: GameConnection, db_engine):
+async def test_handle_action_TeamkillHappened(game: Game, game_connection: GameConnection, db_engine):
+    game.launch = CoroMock()
+    await game_connection.handle_action('TeamkillHappened', ['200', '2', 'Dostya', '3', 'Rhiza'])
+
+    async with db_engine.acquire() as conn:
+        result = await conn.execute("select game_id from teamkills where victim=2 and teamkiller=3 and game_id=%s and gametime=200", (game.id))
+        row = await result.fetchone()
+        assert game.id == row[0]
+
+
+async def test_handle_action_TeamkillHappened_AI(game: Game, game_connection: GameConnection, db_engine):
     # Should fail with a sql constraint error if this isn't handled correctly
     game_connection.abort = mock.Mock()
     await game_connection.handle_action('TeamkillHappened', ['200', 0, 'Dostya', '0', 'Rhiza'])

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -230,6 +230,13 @@ async def test_handle_action_TeamkillReport(game: Game, game_connection: GameCon
         assert game.id == row[0]
 
 
+async def test_handle_action_TeamkillReport_AI(game: Game, game_connection: GameConnection, db_engine):
+    # Should fail with a sql constraint error if this isn't handled correctly
+    game_connection.abort = mock.Mock()
+    await game_connection.handle_action('TeamkillHappened', ['200', 0, 'Dostya', '0', 'Rhiza'])
+    game_connection.abort.assert_not_called()
+
+
 async def test_handle_action_GameResult_victory_ends_sim(
     game: Game,
     game_connection: GameConnection

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -47,7 +47,17 @@ def test_inform_player(ladder_service: LadderService):
 
     ladder_service.inform_player(p1)
 
-    assert p1.lobby_connection.sendJSON.called
+    # Message is sent after the first call
+    p1.lobby_connection.sendJSON.assert_called_once()
+    ladder_service.inform_player(p1)
+    p1.lobby_connection.sendJSON.reset_mock()
+    # But not after the second
+    p1.lobby_connection.sendJSON.assert_not_called()
+    ladder_service.on_connection_lost(p1)
+    ladder_service.inform_player(p1)
+
+    # But it is called if the player relogs
+    p1.lobby_connection.sendJSON.assert_called_once()
 
 
 async def test_start_and_cancel_search(ladder_service: LadderService):

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -13,6 +13,19 @@ async def test_fetch_player_data(player_service):
     assert player.avatar == {'url': 'http://content.faforever.com/faf/avatars/UEF.png', 'tooltip': 'UEF'}
 
 
+async def test_fetch_player_data_multiple_avatar(player_service):
+    player1 = Mock()
+    player1.id = 51
+    player2 = Mock()
+    player2.id = 52
+
+    await player_service.fetch_player_data(player1)
+    assert player1.avatar == {'url': 'http://content.faforever.com/faf/avatars/UEF.png', 'tooltip': 'UEF'}
+
+    await player_service.fetch_player_data(player2)
+    assert player2.avatar == {'url': 'http://content.faforever.com/faf/avatars/qai2.png', 'tooltip': 'QAI'}
+
+
 async def test_fetch_player_data_no_avatar_or_clan(player_service):
     player = Mock()
     player.id = 100


### PR DESCRIPTION
Closes #435 

Avatar query was not taking into account which avatar was selected. Note that if somehow a player manages to select multiple avatars, only one of them will be taken.

The lobbyconnection was also doing some extra input validation which was not compatible with the py client, (py client sends factions as numbers while java client sends the string of the faction name).

The modvault command was trying to create icon URL's even when the `icon` field was null.

Automatic teamkill reports (GPGNet `TeamkillHappened`) were being ignored. These will now be inserted to the DB. Note that every player in a game will send one of these.

Included tests for both of these issues.