### PR TITLE
Remove check for matchmaker_ban table

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -695,14 +695,6 @@ class LobbyConnection():
             self.ladder_service.cancel_search(self.player)
             return
 
-        async with db.engine.acquire() as conn:
-            result = await conn.execute("SELECT id FROM matchmaker_ban WHERE `userid` = %s", (self.player.id))
-            row = await result.fetchone()
-            if row:
-                self.sendJSON(dict(command="notice", style="error",
-                                   text="You are banned from the matchmaker. Contact an admin to have the reason."))
-                return
-
         if state == "start":
             assert self.player is not None
             # Faction can be either the name (e.g. 'uef') or the enum value (e.g. 1)

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -37,9 +37,6 @@ insert into avatars (idUser, idAvatar, selected) values
     (52, 1, 1),
     (52, 2, 0);
 
-delete from matchmaker_ban where id = 102 and userid = 102;
-insert into matchmaker_ban (id, userid) values (102, 102);
-
 delete from ban where player_id = 200;
 
 insert into game_stats (id, startTime, gameType, gameMod, host, mapId, gameName, validity) values

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -50,28 +50,3 @@ async def test_game_matchmaking(loop, lobby_server):
     assert msg1['uid'] == msg2['uid']
     assert msg1['mod'] == 'ladder1v1'
     assert msg2['mod'] == 'ladder1v1'
-
-
-async def test_game_matchmaking_ban(loop, lobby_server, db_engine):
-    _, _, proto = await connect_and_sign_in(
-        ('ladder_ban', 'ladder_ban'),
-        lobby_server
-    )
-
-    await read_until_command(proto, 'game_info')
-
-    proto.send_message({
-        'command': 'game_matchmaking',
-        'state': 'start',
-        'faction': 'uef'
-    })
-    await proto.drain()
-
-    # This may fail due to a timeout error
-    msg = await read_until_command(proto, 'notice')
-
-    assert msg == {
-        'command': 'notice',
-        'style': 'error',
-        'text': 'You are banned from the matchmaker. Contact an admin to have the reason.'
-    }


### PR DESCRIPTION
Apparently this table has never been used. If we really need a ban for only matchmaking in the future, we can use the same `ban` table as for other bans, and add another scope for matchmaking.

Removing database table dependencies will make it easier to transition to a new schema.

Closes https://github.com/FAForever/db/issues/109