### PR TITLE
Fix command_modvault exception

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -797,7 +797,7 @@ class LobbyConnection():
                     try:
                         link = urllib.parse.urljoin(config.CONTENT_URL, "faf/vault/" + filename)
                         thumbstr = ""
-                        if icon != "":
+                        if icon:
                             thumbstr = urllib.parse.urljoin(config.CONTENT_URL, "faf/vault/mods_thumbs/" + urllib.parse.quote(icon))
 
                         out = dict(command="modvault_info", thumbnail=thumbstr, link=link, bugreports=[],

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -64,3 +64,10 @@ insert into game_player_stats (gameId, playerId, AI, faction, color, team, place
 delete from friends_and_foes where user_id = 1 and subject_id = 2;
 insert into friends_and_foes (user_id, subject_id, status) values
     (2, 1, 'FRIEND');
+
+
+insert into `mod` (id, display_name, author) values
+    (100, 'Mod without icon', 'askaholic');
+
+insert into mod_version (mod_id, uid, version, description, type, filename, icon) VALUES
+        (100, 'FFF', 1, 'The best version so far', 'UI', 'noicon.zip', null);

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import logging
+from typing import Any, Callable, Dict, Tuple
 from unittest import mock
 
 import pytest
@@ -49,13 +50,15 @@ def lobby_server(request, loop, player_service, game_service, geoip_service, lad
     return ctx
 
 
-async def connect_client(server):
+async def connect_client(server) -> QDataStreamProtocol:
     return QDataStreamProtocol(
         *(await asyncio.open_connection(*server.sockets[0].getsockname()))
     )
 
 
-async def perform_login(proto, credentials):
+async def perform_login(
+    proto: QDataStreamProtocol, credentials: Tuple[str, str]
+) -> None:
     login, pw = credentials
     pw_hash = hashlib.sha256(pw.encode('utf-8'))
     proto.send_message({
@@ -69,7 +72,9 @@ async def perform_login(proto, credentials):
     await proto.drain()
 
 
-async def read_until(proto, pred):
+async def read_until(
+    proto: QDataStreamProtocol, pred: Callable[[Dict[str, Any]], bool]
+) -> Dict[str, Any]:
     while True:
         msg = await proto.read_message()
         try:
@@ -80,7 +85,7 @@ async def read_until(proto, pred):
             pass
 
 
-async def read_until_command(proto, command):
+async def read_until_command(proto: QDataStreamProtocol, command: str) -> Dict[str, Any]:
     return await read_until(proto, lambda msg: msg.get('command') == command)
 
 

--- a/tests/integration_tests/test_modvault.py
+++ b/tests/integration_tests/test_modvault.py
@@ -11,11 +11,47 @@ async def test_modvault_start(lobby_server):
 
     proto.send_message({
         'command': 'modvault',
-        'type': 'start',
-        'faction': 'uef'
+        'type': 'start'
     })
     await proto.drain()
 
     # Make sure all 5 mod version messages are sent
     for _ in range(5):
         await read_until_command(proto, 'modvault_info')
+
+
+async def test_modvault_like(lobby_server):
+    _, _, proto = await connect_and_sign_in(
+        ('test', 'test_password'),
+        lobby_server
+    )
+
+    await read_until_command(proto, 'game_info')
+
+    proto.send_message({
+        'command': 'modvault',
+        'type': 'like',
+        'uid': 'FFF'
+    })
+    await proto.drain()
+
+    msg = await read_until_command(proto, 'modvault_info')
+    # Not going to verify the date
+    del msg['date']
+
+    assert msg == {
+        'command': 'modvault_info',
+        'thumbnail': '',
+        'link': 'http://content.faforever.com/faf/vault/noicon.zip',
+        'bugreports': [],
+        'comments': [],
+        'description': 'The best version so far',
+        'played': 0,
+        'likes': 1.0,
+        'downloads': 0,
+        'uid': 'FFF',
+        'name': 'Mod without icon',
+        'version': 1,
+        'author': 'askaholic',
+        'ui': 1
+    }

--- a/tests/integration_tests/test_modvault.py
+++ b/tests/integration_tests/test_modvault.py
@@ -1,0 +1,21 @@
+from .conftest import connect_and_sign_in, read_until_command
+
+
+async def test_modvault_start(lobby_server):
+    _, _, proto = await connect_and_sign_in(
+        ('test', 'test_password'),
+        lobby_server
+    )
+
+    await read_until_command(proto, 'game_info')
+
+    proto.send_message({
+        'command': 'modvault',
+        'type': 'start',
+        'faction': 'uef'
+    })
+    await proto.drain()
+
+    # Make sure all 5 mod version messages are sent
+    for _ in range(5):
+        await read_until_command(proto, 'modvault_info')


### PR DESCRIPTION
Mods that have a `null` value for their `icon` would cause the `modvault` command to crash with the following exception:

```
ERROR    Jun 21  15:04:30 LobbyConnection                Error handling table_mod row (uid: 022E3DB4-9C00-5ED7-9876-4866D316E014)
Traceback (most recent call last):
  File "/code/server/lobbyconnection.py", line 801, in command_modvault
    thumbstr = urllib.parse.urljoin(config.CONTENT_URL, "faf/vault/mods_thumbs/" + urllib.parse.quote(icon))
  File "/usr/local/lib/python3.6/urllib/parse.py", line 805, in quote
    return quote_from_bytes(string, safe)
  File "/usr/local/lib/python3.6/urllib/parse.py", line 830, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```