### PR TITLE
Don't send mod list to the client

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -2,8 +2,8 @@ import asyncio
 from typing import Dict, List, Optional, Union, ValuesView
 
 import aiocron
-from server.db import FAFDatabase
 from server import GameState, VisibilityState
+from server.db import FAFDatabase
 from server.decorators import with_logger
 from server.games import CoopGame, CustomGame, FeaturedMod, LadderGame
 from server.games.game import Game
@@ -188,19 +188,6 @@ class GameService:
     def remove_game(self, game: Game):
         if game.id in self.games:
             del self.games[game.id]
-
-    def all_game_modes(self):
-        mods = []
-        for name, mod in self.featured_mods.items():
-            mods.append({
-                'command': 'mod_info',
-                'publish': mod.publish,
-                'name': name,
-                'order': mod.order,
-                'fullname': mod.full_name,
-                'desc': mod.description
-            })
-        return mods
 
     def __getitem__(self, item: int) -> Game:
         return self.games[item]

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -210,10 +210,6 @@ class LobbyConnection():
 
         self.protocol.send_messages(maps)
 
-    @timed
-    def send_mod_list(self):
-        self.protocol.send_messages(self.game_service.all_game_modes())
-
     @timed()
     def send_game_list(self):
         self.send({
@@ -629,7 +625,6 @@ class LobbyConnection():
         json_to_send = {"command": "social", "autojoin": channels, "channels": channels, "friends": friends, "foes": foes, "power": permission_group}
         self.send(json_to_send)
 
-        self.send_mod_list()
         self.send_game_list()
 
     def command_restore_game_session(self, message):

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -189,3 +189,20 @@ async def test_host_missing_fields(event_loop, lobby_server, player_service):
         assert msg['mapname'] == 'scmp_007'
         assert msg['map_file_path'] == 'maps/scmp_007.zip'
         assert msg['featured_mod'] == 'faf'
+
+
+async def test_coop_list(lobby_server):
+    _, _, proto = await connect_and_sign_in(
+        ('test', 'test_password'),
+        lobby_server
+    )
+
+    await read_until(proto, lambda msg: msg['command'] == 'game_info')
+
+    proto.send_message({"command": "coop_list"})
+    await proto.drain()
+
+    msg = await read_until_command(proto, "coop_info")
+    assert "name" in msg
+    assert "description" in msg
+    assert "filename" in msg

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 from aiohttp import web
+from asynctest import CoroutineMock
 from server import GameState, VisibilityState
 from server.db.models import ban, friends_and_foes
 from server.game_service import GameService
@@ -18,7 +19,6 @@ from server.protocol import QDataStreamProtocol
 from server.rating import RatingType
 from server.types import Address
 from sqlalchemy import and_, select, text
-from asynctest import CoroutineMock
 
 pytestmark = pytest.mark.asyncio
 
@@ -301,14 +301,6 @@ async def test_send_game_list(mocker, database, lobbyconnection, game_stats_serv
 
     protocol.send_message.assert_any_call({'command': 'game_info',
                                            'games': [game1.to_dict(), game2.to_dict()]})
-
-
-async def test_send_mod_list(mocker, lobbyconnection, mock_games):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
-
-    lobbyconnection.send_mod_list()
-
-    protocol.send_messages.assert_called_with(mock_games.all_game_modes())
 
 
 async def test_send_coop_maps(mocker, lobbyconnection):


### PR DESCRIPTION
Doesn't completely remove the dependency on `game_featuredMods` table as the server still needs to convert mod names into mod id's for inserting into `game_stats` (lobbyconnection#L748).