### PR TITLE
Smarter queue pop times

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -1,7 +1,7 @@
 import logging
+import os
 
 import trueskill
-import os
 
 # Logging setup
 TRACE = 5
@@ -63,7 +63,7 @@ LADDER_SEARCH_EXPANSION_END = int(os.getenv('LADDER_SEARCH_EXPANSION_END', 60 * 
 LADDER_SEARCH_EXPANSION_MAX = float(os.getenv('LADDER_SEARCH_EXPANSION_MAX', 0.25))
 
 # The maximum amount of time (in seconds) to wait between pops.
-QUEUE_POP_TIME_MAX = int(os.getenv('QUEUE_POP_TIME_MAX', 60 * 5))
+QUEUE_POP_TIME_MAX = int(os.getenv('QUEUE_POP_TIME_MAX', 60 * 3))
 # The number of players we would like to have in the queue when it pops. The
 # queue pop time will be adjusted based on the current rate of players queuing
 # to try and hit this number.

--- a/server/config.py
+++ b/server/config.py
@@ -64,8 +64,9 @@ LADDER_SEARCH_EXPANSION_MAX = float(os.getenv('LADDER_SEARCH_EXPANSION_MAX', 0.2
 
 # The maximum amount of time (in seconds) to wait if no one is searching.
 QUEUE_POP_TIME_MAX = int(os.getenv('QUEUE_POP_TIME_MAX', 60 * 3))
-# The number of searches in the queue required for the queue time to be cut in
-# half. See https://www.desmos.com/calculator/v3tdrjbqub.
-QUEUE_POP_TIME_SCALE_FACTOR = int(os.getenv('QUEUE_POP_TIME_SCALE_FACTOR', 20))
+# The number of players we would like to have in the queue when it pops. The
+# queue pop time will be adjusted based on the current rate of players queuing
+# to try and hit this number.
+QUEUE_POP_DESIRED_PLAYERS = int(os.getenv('QUEUE_POP_DESIRED_PLAYERS', 8))
 # How many previous queue sizes to consider
 QUEUE_POP_TIME_MOVING_AVG_SIZE = int(os.getenv('QUEUE_POP_TIME_MOVING_AVG_SIZE', 5))

--- a/server/config.py
+++ b/server/config.py
@@ -62,8 +62,8 @@ LADDER_SEARCH_EXPANSION_START = int(os.getenv('LADDER_SEARCH_EXPANSION_START', 6
 LADDER_SEARCH_EXPANSION_END = int(os.getenv('LADDER_SEARCH_EXPANSION_END', 60 * 20))
 LADDER_SEARCH_EXPANSION_MAX = float(os.getenv('LADDER_SEARCH_EXPANSION_MAX', 0.25))
 
-# The maximum amount of time (in seconds) to wait if no one is searching.
-QUEUE_POP_TIME_MAX = int(os.getenv('QUEUE_POP_TIME_MAX', 60 * 3))
+# The maximum amount of time (in seconds) to wait between pops.
+QUEUE_POP_TIME_MAX = int(os.getenv('QUEUE_POP_TIME_MAX', 60 * 5))
 # The number of players we would like to have in the queue when it pops. The
 # queue pop time will be adjusted based on the current rate of players queuing
 # to try and hit this number.

--- a/server/matchmaker/__init__.py
+++ b/server/matchmaker/__init__.py
@@ -5,10 +5,12 @@ Used for keeping track of queues of players wanting to play specific kinds of ga
 just used for 1v1 ``ladder''.
 """
 from .matchmaker_queue import MatchmakerQueue
+from .pop_timer import PopTimer
 from .search import Search
 
 
 __all__ = [
     'MatchmakerQueue',
+    'PopTimer',
     'Search'
 ]

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -1,6 +1,5 @@
 import heapq
-from collections import deque
-from typing import Deque, Dict, Iterable, List, Set
+from typing import Dict, Iterable, List, Set
 
 from ..decorators import with_logger
 from .search import Match, Search
@@ -15,8 +14,6 @@ SM_NUM_TO_RANK = 5
 ################################################################################
 #                                Implementation                                #
 ################################################################################
-
-last_queue_amounts: Deque[int] = deque()
 
 
 def stable_marriage(searches: List[Search]) -> List[Match]:

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -7,7 +7,6 @@ from typing import Deque, Dict
 
 import server
 
-from .. import config
 from ..decorators import with_logger
 from .algorithm import stable_marriage
 from .pop_timer import PopTimer
@@ -50,7 +49,7 @@ class MatchmakerQueue:
         in the queue.
         """
         while self._is_running:
-            await self.timer.next_pop(lambda: len(self))
+            await self.timer.next_pop(lambda: len(self.queue))
 
             self.find_matches()
             server.stats.gauge(f"matchmaker.queue.{self.queue_name}.matches", len(self._matches))
@@ -127,9 +126,6 @@ class MatchmakerQueue:
 
     def shutdown(self):
         self._is_running = False
-
-    def __len__(self):
-        return self.queue.__len__()
 
     def to_dict(self):
         """

--- a/server/matchmaker/pop_timer.py
+++ b/server/matchmaker/pop_timer.py
@@ -1,0 +1,79 @@
+import asyncio
+from collections import deque
+from time import time
+from typing import Callable, Deque, TypeVar
+
+import server
+
+from .. import config
+from ..decorators import with_logger
+
+
+@with_logger
+class PopTimer(object):
+    def __init__(self, queue_name: str):
+        self.queue_name = queue_name
+        self.last_queue_amounts: Deque[int] = deque()
+        self.last_queue_times: Deque[float] = deque()
+
+        self._last_queue_pop = time()
+        # Optimistically schedule first pop for half of the max pop time
+        self.next_queue_pop = self._last_queue_pop + (config.QUEUE_POP_TIME_MAX / 2)
+
+    async def next_pop(self, get_num_players: Callable[[], int]):
+        """ Wait for the timer to pop. get_num_players needs to return the current
+        number of players in the queue. """
+
+        time_remaining = self.next_queue_pop - time()
+        self._logger.info("Next %s wave happening in %is", self.queue_name, time_remaining)
+        server.stats.timing(
+            "matchmaker.queue.pop", int(time_remaining),
+            tags={'queue_name': self.queue_name}
+        )
+        await asyncio.sleep(time_remaining)
+        num_players = get_num_players()
+        server.stats.gauge(f"matchmaker.queue.{self.queue_name}.players", num_players)
+
+        self._last_queue_pop = time()
+        self.next_queue_pop = self._last_queue_pop + self.time_until_next_pop(
+            num_players, time_remaining
+        )
+
+    def time_until_next_pop(self, num_queued: int, time_queued: float) -> float:
+        """ Calculate how long we should wait for the next queue to pop based
+        on the current rate of ladder queues
+        """
+        update_deque(self.last_queue_amounts, num_queued)
+        update_deque(self.last_queue_times, time_queued)
+
+        total_players = sum(self.last_queue_amounts)
+        if total_players < 1:
+            return config.QUEUE_POP_TIME_MAX
+
+        total_times = sum(self.last_queue_times)
+        if total_times:
+            self._logger.debug(
+                "Queue rate for %s: %f/s", self.queue_name,
+                total_players / total_times
+            )
+        # Obtained by solving $ NUM_PLAYERS = rate * time $ for time.
+        next_pop_time = config.QUEUE_POP_DESIRED_PLAYERS * total_times / total_players
+        if next_pop_time > config.QUEUE_POP_TIME_MAX:
+            self._logger.warning(
+                "Required time (%.2fs) for %s is larger than max pop time (%ds). "
+                "Consider increasing the max pop time",
+                next_pop_time, self.queue_name, config.QUEUE_POP_TIME_MAX
+            )
+            return config.QUEUE_POP_TIME_MAX
+        return next_pop_time
+
+
+T = TypeVar("T")
+
+
+def update_deque(d: Deque[T], value: T) -> None:
+    """ Appends the new value, and pops the oldest value off the front if the
+    deque has reached its maximum size. """
+    d.append(value)
+    if len(d) > config.QUEUE_POP_TIME_MOVING_AVG_SIZE:
+        d.popleft()

--- a/server/matchmaker/pop_timer.py
+++ b/server/matchmaker/pop_timer.py
@@ -11,6 +11,17 @@ from ..decorators import with_logger
 
 @with_logger
 class PopTimer(object):
+    """ Calculates when the next pop should happen based on the rate of players
+    queuing.
+
+        timer = PopTimer("some_queue")
+        # Pauses the coroutine until the next queue pop
+        await timer.next_pop(lambda: 5)
+
+    The timer will adjust the pop times in an attempt to maintain a fixed queue
+    size on each pop. So generally, the more people are in the queue, the
+    shorter the time will be.
+    """
     def __init__(self, queue_name: str):
         self.queue_name = queue_name
         self.last_queue_amounts: Deque[int] = deque(maxlen=config.QUEUE_POP_TIME_MOVING_AVG_SIZE)

--- a/server/matchmaker/pop_timer.py
+++ b/server/matchmaker/pop_timer.py
@@ -21,9 +21,13 @@ class PopTimer(object):
     The timer will adjust the pop times in an attempt to maintain a fixed queue
     size on each pop. So generally, the more people are in the queue, the
     shorter the time will be.
+
+    The player queue rate is based on a moving average over the last few pops.
+    The exact size can be set in config.
     """
     def __init__(self, queue_name: str):
         self.queue_name = queue_name
+        # Set up deque's for calculating a moving average
         self.last_queue_amounts: Deque[int] = deque(maxlen=config.QUEUE_POP_TIME_MOVING_AVG_SIZE)
         self.last_queue_times: Deque[float] = deque(maxlen=config.QUEUE_POP_TIME_MOVING_AVG_SIZE)
 
@@ -54,6 +58,7 @@ class PopTimer(object):
         """ Calculate how long we should wait for the next queue to pop based
         on the current rate of ladder queues
         """
+        # Calculate moving average of player queue rate
         self.last_queue_amounts.append(num_queued)
         self.last_queue_times.append(time_queued)
 
@@ -67,6 +72,7 @@ class PopTimer(object):
                 "Queue rate for %s: %f/s", self.queue_name,
                 total_players / total_times
             )
+
         # Obtained by solving $ NUM_PLAYERS = rate * time $ for time.
         next_pop_time = config.QUEUE_POP_DESIRED_PLAYERS * total_times / total_players
         if next_pop_time > config.QUEUE_POP_TIME_MAX:

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -24,7 +24,7 @@ def mock_games(mock_players):
 
 @pytest.fixture
 def ladder_service(mocker, game_service):
-    mocker.patch('server.matchmaker.matchmaker_queue.config.QUEUE_POP_TIME_MAX', 1)
+    mocker.patch('server.matchmaker.pop_timer.config.QUEUE_POP_TIME_MAX', 1)
     return LadderService(game_service)
 
 

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -59,8 +59,8 @@ async def test_game_matchmaking(loop, lobby_server, mocker):
 
 
 async def test_matchmaker_info_message(lobby_server, mocker):
-    mocker.patch('server.matchmaker.matchmaker_queue.time', return_value=1_562_000_000)
-    mocker.patch('server.matchmaker.matchmaker_queue.config.QUEUE_POP_TIME_MAX', 1)
+    mocker.patch('server.matchmaker.pop_timer.time', return_value=1_562_000_000)
+    mocker.patch('server.matchmaker.pop_timer.config.QUEUE_POP_TIME_MAX', 1)
 
     _, _, proto = await connect_and_sign_in(
         ('ladder1', 'ladder1'),

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -61,7 +61,7 @@ def game_stats_service():
 
 @pytest.fixture
 def ladder_service(request, mocker, game_service: GameService):
-    mocker.patch('server.matchmaker.matchmaker_queue.config.QUEUE_POP_TIME_MAX', 1)
+    mocker.patch('server.matchmaker.pop_timer.config.QUEUE_POP_TIME_MAX', 1)
 
     ladder_service = LadderService(game_service)
 

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -123,7 +123,7 @@ async def test_search_await(mocker, loop, matchmaker_players):
     assert await_coro.done()
 
 
-def test_queue_time_until_next_pop(matchmaker_queue):
+def test_queue_time_until_next_pop():
     t1 = PopTimer("test_1")
     t2 = PopTimer("test_2")
 
@@ -145,6 +145,22 @@ def test_queue_time_until_next_pop(matchmaker_queue):
 
     # Make sure that queue moving averages are calculated independently
     assert t2.time_until_next_pop(0, 0) == config.QUEUE_POP_TIME_MAX
+
+
+def test_queue_pop_time_moving_average_size():
+    t1 = PopTimer("test_1")
+
+    for _ in range(100):
+        t1.time_until_next_pop(100, 1)
+
+    # The rate should be extremely high, meaning the pop time should be low
+    assert t1.time_until_next_pop(100, 1) < 1
+
+    for _ in range(config.QUEUE_POP_TIME_MOVING_AVG_SIZE):
+        t1.time_until_next_pop(0, 100)
+
+    # The rate should be extremely low, meaning the pop time should be high
+    assert t1.time_until_next_pop(0, 100) == config.QUEUE_POP_TIME_MAX
 
 
 async def test_queue_matches(matchmaker_queue):

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -224,7 +224,7 @@ async def test_queue_race(mocker, player_service, matchmaker_queue):
     except (TimeoutError, CancelledError):
         pass
 
-    assert len(matchmaker_queue) == 0
+    assert len(matchmaker_queue.queue) == 0
 
 
 async def test_queue_cancel(mocker, player_service, matchmaker_queue, matchmaker_players):
@@ -268,4 +268,4 @@ async def test_queue_mid_cancel(mocker, player_service, matchmaker_queue, matchm
     assert not s1.is_matched
     assert s2.is_matched
     assert s3.is_matched
-    assert len(matchmaker_queue) == 0
+    assert len(matchmaker_queue.queue) == 0

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -6,7 +6,7 @@ from concurrent.futures import CancelledError, TimeoutError
 import mock
 import pytest
 import server.config as config
-from server.matchmaker import MatchmakerQueue, Search
+from server.matchmaker import MatchmakerQueue, PopTimer, Search
 from server.players import Player
 
 
@@ -124,27 +124,27 @@ async def test_search_await(mocker, loop, matchmaker_players):
 
 
 def test_queue_time_until_next_pop(matchmaker_queue):
-    q1 = matchmaker_queue
-    q2 = MatchmakerQueue('test_queue_2', game_service=mock.Mock())
+    t1 = PopTimer("test_1")
+    t2 = PopTimer("test_2")
 
-    assert q1.time_until_next_pop(0, 0) == config.QUEUE_POP_TIME_MAX
+    assert t1.time_until_next_pop(0, 0) == config.QUEUE_POP_TIME_MAX
     # If the desired number of players is not reached within the maximum waiting
     # time, then the next round must wait for the maximum allowed time as well.
-    a1 = q1.time_until_next_pop(
+    a1 = t1.time_until_next_pop(
         num_queued=config.QUEUE_POP_DESIRED_PLAYERS - 1,
         time_queued=config.QUEUE_POP_TIME_MAX
     )
     assert a1 == config.QUEUE_POP_TIME_MAX
 
     # If there are more players than expected, the time should drop
-    a2 = q1.time_until_next_pop(
+    a2 = t1.time_until_next_pop(
         num_queued=config.QUEUE_POP_DESIRED_PLAYERS * 2,
         time_queued=config.QUEUE_POP_TIME_MAX
     )
     assert a2 < a1
 
-    # Make sure that queue moving averages are claculated independently
-    assert q2.time_until_next_pop(0, 0) == config.QUEUE_POP_TIME_MAX
+    # Make sure that queue moving averages are calculated independently
+    assert t2.time_until_next_pop(0, 0) == config.QUEUE_POP_TIME_MAX
 
 
 async def test_queue_matches(matchmaker_queue):


### PR DESCRIPTION
The previous queue pop time calculations were pretty arbitrary. This method is based on trying to achieve a certain number of players in the queue for matching,  based on the observed rate of players queuing for matchmaker. In other words, the queue pop timer tries to adjust the pop times so that there are always a constant number of people in the queue. 