### PR TITLE
Add endpoint for requesting matchmaker info

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -209,8 +209,8 @@ class LobbyConnection():
                 maps.append(json_to_send)
 
         self.protocol.send_messages(maps)
-]
-    async def send_matchmaker_info(self):
+
+    async def command_matchmaker_info(self, message):
         self.send({
             'command': 'matchmaker_info',
             'queues': [queue.to_dict() for queue in self.ladder_service.queues.values()]
@@ -633,7 +633,6 @@ class LobbyConnection():
         json_to_send = {"command": "social", "autojoin": channels, "channels": channels, "friends": friends, "foes": foes, "power": permission_group}
         self.send(json_to_send)
 
-        await self.send_matchmaker_info()
         self.send_game_list()
 
     def command_restore_game_session(self, message):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -209,6 +209,14 @@ class LobbyConnection():
                 maps.append(json_to_send)
 
         self.protocol.send_messages(maps)
+]
+    async def send_matchmaker_info(self):
+        self.send({
+            'command': 'matchmaker_info',
+            'queues': [queue.to_dict() for queue in self.ladder_service.queues.values()]
+        })
+
+        await self.protocol.drain()
 
     @timed()
     def send_game_list(self):
@@ -625,6 +633,7 @@ class LobbyConnection():
         json_to_send = {"command": "social", "autojoin": channels, "channels": channels, "friends": friends, "foes": foes, "power": permission_group}
         self.send(json_to_send)
 
+        await self.send_matchmaker_info()
         self.send_game_list()
 
     def command_restore_game_session(self, message):

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -82,3 +82,31 @@ async def test_matchmaker_info_message(lobby_server, mocker):
             }
         ]
     }
+
+
+@fast_forward(1000)
+async def test_command_matchmaker_info(lobby_server, mocker):
+    mocker.patch('server.matchmaker.pop_timer.time', return_value=1_562_000_000)
+
+    _, _, proto = await connect_and_sign_in(
+        ('ladder1', 'ladder1'),
+        lobby_server
+    )
+
+    await read_until_command(proto, "game_info")
+
+    proto.send_message({"command": "matchmaker_info"})
+    await proto.drain()
+
+    msg = await read_until_command(proto, "matchmaker_info")
+    assert msg == {
+        'command': 'matchmaker_info',
+        'queues': [
+            {
+                'queue_name': 'ladder1v1',
+                'queue_pop_time': '2019-07-01T16:53:21+00:00',
+                'boundary_80s': [],
+                'boundary_75s': []
+            }
+        ]
+    }

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -66,6 +66,9 @@ async def test_matchmaker_info_message(lobby_server, mocker):
         ('ladder1', 'ladder1'),
         lobby_server
     )
+    # Because the mocking hasn't taken effect on the first message we need to
+    # wait for the second message
+    msg = await read_until_command(proto, 'matchmaker_info')
     msg = await read_until_command(proto, 'matchmaker_info')
 
     assert msg == {

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -79,23 +79,7 @@ async def test_server_valid_login(lobby_server):
     await lobby_server.wait_closed()
 
 
-async def test_matchmaker_info_on_login(mocker, lobby_server):
-    proto = await connect_client(lobby_server)
-    await perform_login(proto, ('test', 'test_password'))
-
-    # Make sure we get the matchmaker update before game info
-    got_info = False
-    while True:
-        msg = await proto.read_message()
-        if msg["command"] == "game_info":
-            break
-        elif msg["command"] == "matchmaker_info":
-            got_info = True
-
-    assert got_info
-
-
-async def test_server_double_login(loop, lobby_server):
+async def test_server_double_login(lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ('test', 'test_password'))
     msg = await proto.read_message()

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -79,7 +79,23 @@ async def test_server_valid_login(lobby_server):
     await lobby_server.wait_closed()
 
 
-async def test_server_double_login(lobby_server):
+async def test_matchmaker_info_on_login(mocker, lobby_server):
+    proto = await connect_client(lobby_server)
+    await perform_login(proto, ('test', 'test_password'))
+
+    # Make sure we get the matchmaker update before game info
+    got_info = False
+    while True:
+        msg = await proto.read_message()
+        if msg["command"] == "game_info":
+            break
+        elif msg["command"] == "matchmaker_info":
+            got_info = True
+
+    assert got_info
+
+
+async def test_server_double_login(loop, lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ('test', 'test_password'))
     msg = await proto.read_message()


### PR DESCRIPTION
Need this so the client can display the queue time immediately.

https://github.com/FAForever/downlords-faf-client/pull/1364