### PR TITLE
Fix players with high deviations not getting 1v1 ladder matches

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -62,7 +62,7 @@ def encode_message(message: str):
 
 
 def encode_dict(d: Dict[Any, Any]):
-    return encode_message(json.dumps(d))
+    return encode_message(json.dumps(d, separators=(',', ':')))
 
 
 def encode_players(players):

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -121,5 +121,11 @@ def _rank_all(searches: List[Search]) -> Dict[Search, List[Search]]:
 
 
 def _rank_partners(search: Search, others: Iterable[Search]) -> List[Search]:
-    matchable_others = [other for other in others if search.matches_with(other)]
-    return heapq.nlargest(SM_NUM_TO_RANK, matchable_others, key=lambda other: search.quality_with(other))
+    return heapq.nlargest(
+        SM_NUM_TO_RANK, 
+        filter(
+            lambda other: search.matches_with(other),
+            others
+        ), 
+        key=lambda other: search.quality_with(other)
+    )

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -29,7 +29,9 @@ class StableMarriage(object):
         self.searches = searches
 
     def find(self) -> List[Match]:
-        "Perform stable matching"
+        """Perform SM_NUM_TO_RANK runs of the stable matching algorithm. 
+        Assumes that _rank_all only returns edges whose matches are acceptable
+        to both parties."""
         ranks = _rank_all(self.searches)
         self.matches: Dict[Search, Search] = {}
 
@@ -55,8 +57,6 @@ class StableMarriage(object):
                     search, preferred, search.quality_with(preferred),
                     search.match_threshold, preferred.match_threshold
                 )
-                if not search.matches_with(preferred):
-                    continue
 
                 self._propose(search, preferred)
 

--- a/server/protocol/qdatastreamprotocol.py
+++ b/server/protocol/qdatastreamprotocol.py
@@ -153,12 +153,17 @@ class QDataStreamProtocol(Protocol):
         self.writer.close()
 
     def send_message(self, message: dict):
-        self.writer.write(self.pack_message(json.dumps(message)))
+        self.writer.write(
+            self.pack_message(json.dumps(message, separators=(',', ':')))
+        )
         server.stats.incr('server.sent_messages')
 
     def send_messages(self, messages):
         server.stats.incr('server.sent_messages')
-        payload = [self.pack_message(json.dumps(msg)) for msg in messages]
+        payload = [
+            self.pack_message(json.dumps(msg, separators=(',', ':')))
+            for msg in messages
+        ]
         self.writer.writelines(payload)
 
     def send_raw(self, data):

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -46,15 +46,29 @@ def test_search_threshold(mocker, loop, matchmaker_players):
     assert s.match_threshold >= 0
 
 
-def test_search_threshold_of_old_players_is_high(mocker, loop):
+def test_search_threshold_of_single_old_players_is_high(mocker, loop):
     old_player = Player('experienced_player', player_id=1, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
     s = Search([old_player])
     assert s.match_threshold >= 0.6
 
 
-def test_search_threshold_of_new_players_is_low(mocker, loop):
+def test_search_threshold_of_team_old_players_is_high(mocker, loop):
+    old_player = Player('experienced_player', player_id=1, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
+    another_old_player = Player('another experienced_player', player_id=2, ladder_rating=(1600, 60), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
+    s = Search([old_player, another_old_player])
+    assert s.match_threshold >= 0.6
+
+
+def test_search_threshold_of_single_new_players_is_low(mocker, loop):
     new_player = Player('new_player', player_id=1, ladder_rating=(1500, 500), ladder_games=1)
     s = Search([new_player])
+    assert s.match_threshold <= 0.4
+
+
+def test_search_threshold_of_team_new_players_is_low(mocker, loop):
+    new_player = Player('new_player', player_id=1, ladder_rating=(1500, 500), ladder_games=1)
+    another_new_player = Player('another_new_player', player_id=2, ladder_rating=(1450, 450), ladder_games=1)
+    s = Search([new_player, another_new_player])
     assert s.match_threshold <= 0.4
 
 

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -34,13 +34,13 @@ def matchmaker_players_all_match():
            Player('Rhiza', player_id=5, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
 
 
-def test_newbie_min_games(mocker, loop, matchmaker_players):
+def test_newbie_min_games(matchmaker_players):
     p1, _, _, _, _, p6 = matchmaker_players
     s1, s6 = Search([p1]), Search([p6])
     assert s1.ratings[0] == p1.ladder_rating and s6.ratings[0] != p6.ladder_rating
 
 
-def test_search_threshold(mocker, loop, matchmaker_players):
+def test_search_threshold(matchmaker_players):
     s = Search([matchmaker_players[0]])
     assert s.match_threshold <= 1
     assert s.match_threshold >= 0
@@ -72,25 +72,25 @@ def test_search_threshold_of_team_new_players_is_low(mocker, loop):
     assert s.match_threshold <= 0.4
 
 
-def test_search_quality_equivalence(mocker, loop, matchmaker_players):
+def test_search_quality_equivalence(matchmaker_players):
     p1, _, _, p4, _, _ = matchmaker_players
     s1, s4 = Search([p1]), Search([p4])
     assert s1.quality_with(s4) == s4.quality_with(s1)
 
 
-def test_search_quality(mocker, loop, matchmaker_players):
+def test_search_quality(matchmaker_players):
     p1, _, p3, _, p5, p6 = matchmaker_players
     s1, s3, s5, s6 = Search([p1]), Search([p3]), Search([p5]), Search([p6])
     assert s3.quality_with(s5) > 0.7 and s1.quality_with(s6) < 0.2
 
 
-async def test_search_match(mocker, loop, matchmaker_players):
+async def test_search_match(matchmaker_players):
     p1, _, _, p4, _, _ = matchmaker_players
     s1, s4 = Search([p1]), Search([p4])
     assert s1.matches_with(s4)
 
 
-def test_search_threshold_low_enough_to_play_yourself(mocker, loop, matchmaker_players):
+def test_search_threshold_low_enough_to_play_yourself(matchmaker_players):
     for player in matchmaker_players:
         s = Search([player])
         assert s.matches_with(s)
@@ -108,7 +108,7 @@ async def test_search_team_not_match(matchmaker_players):
     assert not s1.matches_with(s4)
 
 
-async def test_search_no_match(mocker, loop, matchmaker_players):
+async def test_search_no_match(matchmaker_players):
     p1, p2, _, _, _, _ = matchmaker_players
     s1, s2 = Search([p1]), Search([p2])
     assert not s1.matches_with(s2)
@@ -145,7 +145,7 @@ def test_search_expansion(matchmaker_players, mocker):
     assert e1 == s1.search_expansion
 
 
-async def test_search_await(mocker, loop, matchmaker_players):
+async def test_search_await(matchmaker_players):
     p1, p2, _, _, _, _ = matchmaker_players
     s1, s2 = Search([p1]), Search([p2])
     assert not s1.matches_with(s2)

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -46,26 +46,26 @@ def test_search_threshold(matchmaker_players):
     assert s.match_threshold >= 0
 
 
-def test_search_threshold_of_single_old_players_is_high(mocker, loop):
+def test_search_threshold_of_single_old_players_is_high():
     old_player = Player('experienced_player', player_id=1, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
     s = Search([old_player])
     assert s.match_threshold >= 0.6
 
 
-def test_search_threshold_of_team_old_players_is_high(mocker, loop):
+def test_search_threshold_of_team_old_players_is_high():
     old_player = Player('experienced_player', player_id=1, ladder_rating=(1500, 50), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
     another_old_player = Player('another experienced_player', player_id=2, ladder_rating=(1600, 60), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
     s = Search([old_player, another_old_player])
     assert s.match_threshold >= 0.6
 
 
-def test_search_threshold_of_single_new_players_is_low(mocker, loop):
+def test_search_threshold_of_single_new_players_is_low():
     new_player = Player('new_player', player_id=1, ladder_rating=(1500, 500), ladder_games=1)
     s = Search([new_player])
     assert s.match_threshold <= 0.4
 
 
-def test_search_threshold_of_team_new_players_is_low(mocker, loop):
+def test_search_threshold_of_team_new_players_is_low():
     new_player = Player('new_player', player_id=1, ladder_rating=(1500, 500), ladder_games=1)
     another_new_player = Player('another_new_player', player_id=2, ladder_rating=(1450, 450), ladder_games=1)
     s = Search([new_player, another_new_player])
@@ -216,7 +216,7 @@ async def test_shutdown_matchmaker(matchmaker_queue):
         assert False
 
 
-async def test_queue_many(mocker, player_service, matchmaker_queue):
+async def test_queue_many(player_service, matchmaker_queue):
     p1, p2, p3 = Player('Dostya', player_id=1, ladder_rating=(2200, 150), ladder_games=(config.NEWBIE_MIN_GAMES + 1)), \
                  Player('Brackman', player_id=2, ladder_rating=(1500, 150), ladder_games=(config.NEWBIE_MIN_GAMES + 1)), \
                  Player('Zoidberg', player_id=3, ladder_rating=(1500, 125), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
@@ -236,7 +236,7 @@ async def test_queue_many(mocker, player_service, matchmaker_queue):
     assert s3.is_matched
 
 
-async def test_queue_race(mocker, player_service, matchmaker_queue):
+async def test_queue_race(player_service, matchmaker_queue):
     p1, p2, p3 = Player('Dostya', player_id=1, ladder_rating=(2300, 150), ladder_games=(config.NEWBIE_MIN_GAMES + 1)), \
                  Player('Brackman', player_id=2, ladder_rating=(2200, 150), ladder_games=(config.NEWBIE_MIN_GAMES + 1)), \
                  Player('Zoidberg', player_id=3, ladder_rating=(2300, 125), ladder_games=(config.NEWBIE_MIN_GAMES + 1))
@@ -259,7 +259,7 @@ async def test_queue_race(mocker, player_service, matchmaker_queue):
     assert len(matchmaker_queue.queue) == 0
 
 
-async def test_queue_cancel(mocker, player_service, matchmaker_queue, matchmaker_players):
+async def test_queue_cancel(player_service, matchmaker_queue, matchmaker_players):
     # Turn list of players into map from ids to players.
     player_service.players = dict(map(lambda x: (x.id, x), list(matchmaker_players)))
 
@@ -275,7 +275,7 @@ async def test_queue_cancel(mocker, player_service, matchmaker_queue, matchmaker
     assert not s2.is_matched
 
 
-async def test_queue_mid_cancel(mocker, player_service, matchmaker_queue, matchmaker_players_all_match):
+async def test_queue_mid_cancel(player_service, matchmaker_queue, matchmaker_players_all_match):
     # Turn list of players into map from ids to players.
     player_service.players = dict(map(lambda x: (x.id, x), list(matchmaker_players_all_match)))
     p0, p1, p2, p3, _ = matchmaker_players_all_match

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -56,7 +56,7 @@ def test_stable_marriage():
     assert (s2, s5) in matches
     assert (s3, s6) in matches
 
-def test_stable_marriage_matches_new_players_with_new_and_old_with_old():
+def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_different_mean():
     new1 = Search([p(1500, 500, name='new1', ladder_games=1)])
     new2 = Search([p(1400, 500, name='new2', ladder_games=2)])
     old1 = Search([p(2300, 75, name='old1', ladder_games=100)])
@@ -68,6 +68,22 @@ def test_stable_marriage_matches_new_players_with_new_and_old_with_old():
 
     assert (new1, new2) in matches
     assert (old1, old2) in matches
+
+
+def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_same_mean():
+    # Assumes that both new players initialized with mean 1500 will be matched
+    # as if they had mean 500
+    new1 = Search([p(1500, 500, name='new1', ladder_games=0)])
+    new2 = Search([p(1500, 500, name='new2', ladder_games=0)])
+    old1 = Search([p(500, 75, name='old1', ladder_games=100)])
+    old2 = Search([p(500, 75, name='old2', ladder_games=100)])
+
+    searches = [new1, new2, old1, old2]
+
+    matches = algorithm.stable_marriage(searches)
+
+    assert (new1, new2) in matches or (new2, new1) in matches
+    assert (old1, old2) in matches or (old2, old1) in matches
 
 
 def test_stable_marriage_better_than_greedy():


### PR DESCRIPTION
See issue #487.

Two main changes:
1. Matchmaking graph for stable marriage will include top five matches for every player *of those who would accept the match* 
2. Minimum acceptable match quality is calculated as 80% of quality in a game against yourself, not hard-coded in `_deviation_quality`