### PR TITLE
Clean up game outcome handling

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -257,7 +257,7 @@ class GameConnection(GpgNetServerProtocol):
                 self.finished_sim = True
                 await self.game.check_sim_end()
 
-            await self.game.add_result(self.player, army, result[0], int(result[1]))
+            await self.game.add_result(self.player.id, army, result[0], int(result[1]))
         except (KeyError, ValueError):  # pragma: no cover
             self._logger.warning("Invalid result for %s reported: %s", army, result)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -725,7 +725,7 @@ class Game:
                 options['Color'],
                 options['Team'],
                 options['StartSpot'],
-                mean, dev, 0, -1
+                mean, dev, 0, 0
             ))
         if not query_args:
             self._logger.warning("No player options available!")

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -442,13 +442,9 @@ class Game:
         scores = {}
         for player in self.players:
             army = self.get_player_option(player.id, 'Army')
-            try:
-                score = self.get_army_score(army)
-                scores[player] = score
-                self._logger.info('Result for army %s, player: %s: %s', army, player, score)
-            except KeyError:
-                # Default to -1 if there is no result
-                scores[player] = -1
+            score = self.get_army_score(army)
+            scores[player] = score
+            self._logger.info('Result for army %s, player: %s: %s', army, player, score)
 
         async with self._db.acquire() as conn:
             rows = []
@@ -797,11 +793,7 @@ class Game:
             else:
                 if team not in team_scores:
                     team_scores[team] = 0
-                try:
-                    team_scores[team] += self.get_army_score(army)
-                except KeyError:
-                    team_scores[team] += 0
-                    self._logger.warning("Missing game result for %s: %s", army, player)
+                team_scores[team] += self.get_army_score(army)
         ranks = [-score for team, score in sorted(team_scores.items(), key=lambda t: t[0])]
         rating_groups = []
         for team in sorted(self.teams):

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -130,7 +130,7 @@ class Game:
         game_mode: str='faf'
     ):
         self._db = database
-        self._results = GameResults()
+        self._results = GameResults(id_)
         self._army_stats = None
         self._players_with_unsent_army_stats = []
         self._game_stats_service = game_stats_service
@@ -759,7 +759,7 @@ class Game:
                 "WHERE id = %s", (new_validity_state.value, self.id))
 
     def get_army_score(self, army):
-        return self._results.score(army, self.id)
+        return self._results.score(army)
 
     def get_army_result(self, player):
         army = self.get_player_option(player.id, 'Army')

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -292,19 +292,6 @@ class Game:
         if not self._is_hosted.done():
             self._is_hosted.set_result(value)
 
-    def outcome(self, player: Player) -> GameOutcome:
-        """
-        Determines what the game outcome was for a given player. Did the
-        player win, lose, draw?
-
-        :param player: The player who's perspective we want
-        :return: GameOutcome or None if the outcome could not be determined
-        """
-        army = self.get_player_option(player.id, 'Army')
-        if army is None:
-            return GameOutcome.UNKNOWN
-        return self._results.outcome(army)
-
     async def add_result(self, reporter: int, army: int, result_type: str, score: int):
         """
         As computed by the game.
@@ -509,7 +496,7 @@ class Game:
         table = f'{rating.value}_rating'
 
         if rating is RatingType.LADDER_1V1:
-            is_victory = self.outcome(player) is GameOutcome.VICTORY
+            is_victory = self.get_army_result(player) is GameOutcome.VICTORY
             await conn.execute(
                 "UPDATE ladder1v1_rating "
                 "SET mean = %s, is_active=1, deviation = %s, numGames = numGames + 1, winGames = winGames + %s "
@@ -781,9 +768,9 @@ class Game:
     def get_army_result(self, player):
         army = self.get_player_option(player.id, 'Army')
         if army is None:
-            return None
+            return GameOutcome.UNKNOWN
 
-        return self._results.result(army)
+        return self._results.outcome(army)
 
     def compute_rating(self, rating=RatingType.GLOBAL):
         """

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -305,19 +305,15 @@ class Game:
             return GameOutcome.UNKNOWN
         return self._results.outcome(army)
 
-    async def add_result(self, reporter: Union[Player, int], army: int, result_type: str, score: int):
+    async def add_result(self, reporter: int, army: int, result_type: str, score: int):
         """
         As computed by the game.
-        :param reporter: a player instance or the player ID
+        :param reporter: player ID
         :param army: the army number being reported for
         :param result_type: a string representing the result
         :param score: an arbitrary number assigned with the result
         :return:
         """
-
-        if isinstance(reporter, Player):
-            reporter = reporter.id
-
         if army not in self.armies:
             self._logger.debug(
                 "Ignoring results for unknown army %s: %s %s reported by: %s",

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -1,0 +1,146 @@
+from enum import Enum
+from collections import Counter
+from collections.abc import Mapping
+from server.decorators import with_logger
+from typing import NamedTuple
+
+
+class GameOutcome(Enum):
+    VICTORY = 'victory'
+    DEFEAT = 'defeat'
+    DRAW = 'draw'
+    MUTUAL_DRAW = 'mutual_draw'
+    UNKNOWN = 'unknown'
+
+    @classmethod
+    def from_message(cls, msg: str):
+        try:
+            return cls(msg.lower())
+        except ValueError:
+            return cls.UNKNOWN
+
+
+class GameResult(NamedTuple):
+    """
+    These are sent from each player's FA when they quit the game. 'Score'
+    depends on the number of ACUs killed, whether the player died, maybe other
+    factors.
+    """
+    reporter: int
+    army: int
+    outcome: GameOutcome
+    score: int
+
+
+@with_logger
+class GameResults(Mapping):
+    """
+    Collects all results from a single game. Allows to determine results for an
+    army and game as a whole. Supports a dict-like access to lists of results
+    for each army, but don't modify these.
+    """
+    def __init__(self):
+        Mapping.__init__(self)
+        self._back = {}
+
+    def __getitem__(self, key: int):
+        return self._back[key]
+
+    def __iter__(self):
+        return iter(self._back)
+
+    def __len__(self):
+        return len(self._back)
+
+    def add(self, result: GameResult):
+        army_results = self._back.setdefault(result.army, [])
+        army_results.append(result)
+
+    def is_mutually_agreed_draw(self, player_armies):
+        # Can't tell if we have no results
+        if not self:
+            return False
+        # Everyone has to agree to a mutual draw
+        for army in player_armies:
+            if army not in self:
+                continue
+            if any(r.outcome is not GameOutcome.MUTUAL_DRAW
+                   for r in self[army]):
+                return False
+        return True
+
+    def outcome(self, army: int) -> GameOutcome:
+        """
+        Determines what the game outcome was for a given army. Did the
+        army win, lose, draw?
+        """
+        if army not in self:
+            return GameOutcome.UNKNOWN
+
+        outcomes = set(r.outcome for r in self[army])
+        if len(outcomes) == 1:
+            return outcomes.pop()
+        else:
+            return GameOutcome.UNKNOWN
+
+    def score(self, army: int, game_id=None):
+        """
+        Pick and return most frequently reported score for an army. If multiple
+        scores are most frequent, pick the largest one.
+        """
+        if army not in self:
+            return 0
+
+        scores = Counter(r.score for r in self[army])
+        if len(scores) == 1:
+            return scores.popitem()[0]
+
+        # FIXME - we pass game id just for logging
+        self._logger.info("Conflicting scores (%s) reported for game %s",
+                          scores, game_id)
+        score, _ = max(scores.items(), key=lambda kv: kv[::-1])
+        return score
+
+    def victory_only_score(self, army: int):
+        """
+        Calculate our own score depending *only* on victory.
+        """
+        if army not in self:
+            return 0
+
+        if any(r.outcome is GameOutcome.VICTORY for r in self[army]):
+            return 1
+        else:
+            return 0
+
+    def result(self, army: int):
+        """
+        Return most frequently reported outcome.
+        FIXME: this is almost the same as 'outcome' method. Determine why and
+        fix it.
+        """
+        if army not in self:
+            return GameOutcome.UNKNOWN
+
+        most_common = Counter(i.outcome for i in self[army]).most_common(1)[0]
+        outcome = most_common[0]
+        return outcome
+
+    # FIXME: Should we gather such methods in one class, or place them near
+    # corresponding types?
+    @classmethod
+    async def from_db(cls, database, game_id):
+        results = cls()
+        async with database.acquire() as conn:
+            rows = await conn.execute(
+                "SELECT `place`, `score` "
+                "FROM `game_player_stats` "
+                "WHERE `gameId`=%s", (game_id,))
+
+            async for row in rows:
+                startspot, score = row[0], row[1]
+                # FIXME: Assertion about startspot == army
+                # FIXME: Reporter not retained in database
+                result = GameResult(0, startspot, GameOutcome.UNKNOWN, score)
+                results.add(result)
+        return results

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -89,7 +89,8 @@ class GameResults(Mapping):
     def score(self, army: int, game_id=None):
         """
         Pick and return most frequently reported score for an army. If multiple
-        scores are most frequent, pick the largest one.
+        scores are most frequent, pick the largest one. Returns 0 if there are
+        no results for a given army.
         """
         if army not in self:
             return 0

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -71,13 +71,16 @@ class GameResults(Mapping):
 
     def outcome(self, army: int) -> GameOutcome:
         """
-        Determines what the game outcome was for a given army. Did the
-        army win, lose, draw?
+        Determines what the game outcome was for a given army. Returns the
+        outcome all players agree on, excluding players that reported an
+        unknown outcome. Reports unknown outcome if players disagree.
         """
         if army not in self:
             return GameOutcome.UNKNOWN
 
-        outcomes = set(r.outcome for r in self[army])
+        outcomes = set(r.outcome for r in self[army]
+                       if r.outcome is not GameOutcome.UNKNOWN)
+
         if len(outcomes) == 1:
             return outcomes.pop()
         else:
@@ -112,19 +115,6 @@ class GameResults(Mapping):
             return 1
         else:
             return 0
-
-    def result(self, army: int):
-        """
-        Return most frequently reported outcome.
-        FIXME: this is almost the same as 'outcome' method. Determine why and
-        fix it.
-        """
-        if army not in self:
-            return GameOutcome.UNKNOWN
-
-        most_common = Counter(i.outcome for i in self[army]).most_common(1)[0]
-        outcome = most_common[0]
-        return outcome
 
     # FIXME: Should we gather such methods in one class, or place them near
     # corresponding types?

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -103,7 +103,6 @@ class GameResults(Mapping):
         if len(scores) == 1:
             return scores.popitem()[0]
 
-        # FIXME - we pass game id just for logging
         self._logger.info("Conflicting scores (%s) reported for game %s",
                           scores, self._game_id)
         score, _ = max(scores.items(), key=lambda kv: kv[::-1])
@@ -121,8 +120,6 @@ class GameResults(Mapping):
         else:
             return 0
 
-    # FIXME: Should we gather such methods in one class, or place them near
-    # corresponding types?
     @classmethod
     async def from_db(cls, database, game_id):
         results = cls(game_id)

--- a/server/games/ladder_game.py
+++ b/server/games/ladder_game.py
@@ -24,14 +24,11 @@ class LadderGame(Game):
             await self.persist_rating_change_stats(new_ratings, RatingType.LADDER_1V1)
 
     def is_winner(self, player: Player):
-        return self.outcome(player) == GameOutcome.VICTORY
+        return self.outcome(player) is GameOutcome.VICTORY
 
     def get_army_score(self, army: int) -> int:
         """
         We override this function so that ladder game scores are only reported
         as 1 for win and 0 for anything else.
         """
-        for result in self._results.get(army, []):
-            if result[1] == 'victory':
-                return 1
-        return 0
+        return self._results.victory_only_score(army)

--- a/server/games/ladder_game.py
+++ b/server/games/ladder_game.py
@@ -24,7 +24,7 @@ class LadderGame(Game):
             await self.persist_rating_change_stats(new_ratings, RatingType.LADDER_1V1)
 
     def is_winner(self, player: Player):
-        return self.outcome(player) is GameOutcome.VICTORY
+        return self.get_army_result(player) is GameOutcome.VICTORY
 
     def get_army_score(self, army: int) -> int:
         """

--- a/server/stats/game_stats_service.py
+++ b/server/stats/game_stats_service.py
@@ -2,6 +2,7 @@ import json
 
 from server import config
 from server.games import Game
+from server.games.game_results import GameOutcome
 from server.players import Player
 from server.stats.achievement_service import *
 from server.stats.event_service import *
@@ -46,7 +47,7 @@ class GameStatsService:
             return
 
         army_result = game.get_army_result(player)
-        if not army_result:
+        if army_result is GameOutcome.UNKNOWN:
             self._logger.warning("No army result available for player %s", player.login)
             return
 
@@ -59,7 +60,7 @@ class GameStatsService:
         e_queue = []
         self._logger.debug('Army result for %s => %s ', player, army_result)
 
-        survived = army_result == 'victory'
+        survived = army_result is GameOutcome.VICTORY
         blueprint_stats = stats['blueprints']
         unit_stats = stats['units']
         scored_highest = highest_scorer == player.login

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from server.db import FAFDatabase
 from tests.utils import MockDatabase
 
 from asynctest import CoroutineMock
+import asynctest
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -127,12 +128,12 @@ def ugame(database, players):
 def make_game(database, uid, players):
     from server.games import Game
     from server.abc.base_game import InitMode
-    mock_parent = mock.Mock()
-    game = mock.create_autospec(spec=Game(uid, database, mock_parent, mock.Mock()))
-    game.remove_game_connection = CoroutineMock()
-    players.hosting.getGame = mock.Mock(return_value=game)
-    players.joining.getGame = mock.Mock(return_value=game)
-    players.peer.getGame = mock.Mock(return_value=game)
+    mock_parent = CoroutineMock()
+    game = asynctest.create_autospec(spec=Game(uid, database, mock_parent,
+                                               CoroutineMock()))
+    players.hosting.getGame = CoroutineMock(return_value=game)
+    players.joining.getGame = CoroutineMock(return_value=game)
+    players.peer.getGame = CoroutineMock(return_value=game)
     game.hostPlayer = players.hosting
     game.init_mode = InitMode.NORMAL_LOBBY
     game.name = "Some game name"

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -7,6 +7,7 @@ from server.gameconnection import GameConnection, GameConnectionState
 from server.games import Game
 from server.geoip_service import GeoIpService
 from server.ladder_service import LadderService
+import asynctest
 from asynctest import CoroutineMock
 
 
@@ -44,7 +45,7 @@ def mock_game_connection():
 
 
 def make_mock_game_connection(state=GameConnectionState.INITIALIZING, player=None):
-    gc = mock.create_autospec(spec=GameConnection)
+    gc = asynctest.create_autospec(spec=GameConnection)
     gc.state = state
     gc.player = player
     gc.finished_sim = False

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -406,25 +406,6 @@ async def test_compute_rating_balanced_teamgame(game: Game, player_factory):
             assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
 
 
-# FIXME - discuss correct get_army_result behaviour
-@pytest.mark.skip
-async def test_game_get_army_result_takes_most_reported_result(game,
-                                                               game_add_players):
-
-    game.state = GameState.LOBBY
-    players = game_add_players(game, 1)
-    await game.add_result(0, 0, 'defeat', 0)
-    await game.add_result(0, 0, 'defeat', 0)
-    await game.add_result(0, 0, 'victory', 0)
-
-    assert game.get_army_result(players[0]) == GameOutcome.DEFEAT
-
-    await game.add_result(0, 0, 'victory', 0)
-    await game.add_result(0, 0, 'victory', 0)
-
-    assert game.get_army_result(players[0]) == GameOutcome.VICTORY
-
-
 async def test_game_get_army_result_ignores_unknown_results(game,
                                                             game_add_players):
     game.state = GameState.LOBBY

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -6,8 +6,9 @@ from unittest import mock
 import pytest
 from server.gameconnection import GameConnection, GameConnectionState
 from server.games import CoopGame, CustomGame
-from server.games.game import (Game, GameError, GameOutcome, GameState,
-                               ValidityState, Victory, VisibilityState)
+from server.games.game import (Game, GameError, GameState, ValidityState,
+                               Victory, VisibilityState)
+from server.games.game_results import GameOutcome
 from server.rating import RatingType
 from asynctest import CoroutineMock
 from tests.unit_tests.conftest import (add_connected_player,
@@ -414,12 +415,12 @@ async def test_game_get_army_result_takes_most_reported_result(game,
     await game.add_result(0, 0, 'defeat', 0)
     await game.add_result(0, 0, 'victory', 0)
 
-    assert game.get_army_result(players[0]) == 'defeat'
+    assert game.get_army_result(players[0]) == GameOutcome.DEFEAT
 
     await game.add_result(0, 0, 'victory', 0)
     await game.add_result(0, 0, 'victory', 0)
 
-    assert game.get_army_result(players[0]) == 'victory'
+    assert game.get_army_result(players[0]) == GameOutcome.VICTORY
 
 
 async def test_on_game_end_does_not_call_rate_game_for_single_player(game):
@@ -696,8 +697,8 @@ async def test_game_outcomes_no_results(game: Game, players):
 
     host_outcome = game.outcome(players.hosting)
     guest_outcome = game.outcome(players.joining)
-    assert host_outcome is None
-    assert guest_outcome is None
+    assert host_outcome is GameOutcome.UNKNOWN
+    assert guest_outcome is GameOutcome.UNKNOWN
 
 
 async def test_game_outcomes_conflicting(game: Game, players):
@@ -715,8 +716,8 @@ async def test_game_outcomes_conflicting(game: Game, players):
 
     host_outcome = game.outcome(players.hosting)
     guest_outcome = game.outcome(players.joining)
-    assert host_outcome is None
-    assert guest_outcome is None
+    assert host_outcome is GameOutcome.UNKNOWN
+    assert guest_outcome is GameOutcome.UNKNOWN
 
 
 async def test_victory_conditions():

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -306,7 +306,7 @@ async def test_game_teams_represents_active_teams(game: Game, players):
 
 
 async def test_invalid_army_not_add_result(game: Game, players):
-    await game.add_result(players.hosting, 99, "win", 10)
+    await game.add_result(players.hosting.id, 99, "win", 10)
 
     assert 99 not in game._results
 
@@ -318,8 +318,8 @@ async def test_game_ends_in_mutually_agreed_draw(game: Game, game_add_players):
     await game.launch()
     game.launched_at = time.time()-60*60
 
-    await game.add_result(players[0], 0, 'mutual_draw', 0)
-    await game.add_result(players[1], 1, 'mutual_draw', 0)
+    await game.add_result(players[0].id, 0, 'mutual_draw', 0)
+    await game.add_result(players[1].id, 1, 'mutual_draw', 0)
     await game.on_game_end()
 
     assert game.validity is ValidityState.MUTUAL_DRAW
@@ -333,8 +333,8 @@ async def test_game_not_ends_in_unilatery_agreed_draw(game: Game, players,
     await game.launch()
     game.launched_at = time.time()-60*60
 
-    await game.add_result(players.hosting, 0, 'mutual_draw', 0)
-    await game.add_result(players.joining, 1, 'victory', 10)
+    await game.add_result(players.hosting.id, 0, 'mutual_draw', 0)
+    await game.add_result(players.joining.id, 1, 'victory', 10)
     await game.on_game_end()
 
     assert game.validity is not ValidityState.MUTUAL_DRAW
@@ -358,8 +358,8 @@ async def test_compute_rating_computes_global_ratings(game: Game, players):
     players.joining.ratings[RatingType.GLOBAL] = Rating(1500, 250)
     add_connected_players(game, [players.hosting, players.joining])
     await game.launch()
-    await game.add_result(players.hosting, 0, 'victory', 1)
-    await game.add_result(players.joining, 1, 'defeat', 0)
+    await game.add_result(players.hosting.id, 0, 'victory', 1)
+    await game.add_result(players.joining.id, 1, 'defeat', 0)
     game.set_player_option(players.hosting.id, 'Team', 2)
     game.set_player_option(players.joining.id, 'Team', 3)
     groups = game.compute_rating()
@@ -373,8 +373,8 @@ async def test_compute_rating_computes_ladder_ratings(game: Game, players):
     players.joining.ratings[RatingType.LADDER_1V1] = Rating(1500, 250)
     add_connected_players(game, [players.hosting, players.joining])
     await game.launch()
-    await game.add_result(players.hosting, 0, 'victory', 1)
-    await game.add_result(players.joining, 1, 'defeat', 0)
+    await game.add_result(players.hosting.id, 0, 'victory', 1)
+    await game.add_result(players.joining.id, 1, 'defeat', 0)
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
     groups = game.compute_rating(rating=RatingType.LADDER_1V1)
@@ -675,8 +675,8 @@ async def test_game_outcomes(game: Game, players):
     players.joining.ratings[RatingType.LADDER_1V1] = Rating(1500, 250)
     add_connected_players(game, [players.hosting, players.joining])
     await game.launch()
-    await game.add_result(players.hosting, 0, 'victory', 1)
-    await game.add_result(players.joining, 1, 'defeat', 0)
+    await game.add_result(players.hosting.id, 0, 'victory', 1)
+    await game.add_result(players.joining.id, 1, 'defeat', 0)
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
 
@@ -707,10 +707,10 @@ async def test_game_outcomes_conflicting(game: Game, players):
     players.joining.ratings[RatingType.LADDER_1V1] = Rating(1500, 250)
     add_connected_players(game, [players.hosting, players.joining])
     await game.launch()
-    await game.add_result(players.hosting, 0, 'victory', 1)
-    await game.add_result(players.joining, 1, 'victory', 0)
-    await game.add_result(players.hosting, 0, 'defeat', 1)
-    await game.add_result(players.joining, 1, 'defeat', 0)
+    await game.add_result(players.hosting.id, 0, 'victory', 1)
+    await game.add_result(players.joining.id, 1, 'victory', 0)
+    await game.add_result(players.hosting.id, 0, 'defeat', 1)
+    await game.add_result(players.joining.id, 1, 'defeat', 0)
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
 

--- a/tests/unit_tests/test_game_stats_service.py
+++ b/tests/unit_tests/test_game_stats_service.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 from server.factions import Faction
 from server.games import Game
+from server.games.game_results import GameOutcome, GameResult, GameResults
 from server.stats import achievement_service as ach
 from server.stats import event_service as ev
 from server.stats.game_stats_service import GameStatsService
@@ -39,7 +40,8 @@ def player(player_factory):
 def game(database, game_stats_service, player):
     game = Game(1, database, Mock(), game_stats_service)
     game._player_options[player.id] = {'Army': 1}
-    game._results = {1: [('', 'victory', '')]}
+    game._results = GameResults()
+    game._results.add(GameResult(1, 1, GameOutcome.VICTORY, 0))
     return game
 
 
@@ -444,7 +446,7 @@ async def test_process_game_stats_abort_processing_if_no_army_result(game_stats_
     with open("tests/data/game_stats_full_example.json", "r") as stats_file:
         stats = stats_file.read()
 
-    game._results = {}
+    game._results = GameResults()
 
     await game_stats_service.process_game_stats(player, game, stats)
     assert len(achievement_service.mock_calls) == 0

--- a/tests/unit_tests/test_game_stats_service.py
+++ b/tests/unit_tests/test_game_stats_service.py
@@ -40,7 +40,7 @@ def player(player_factory):
 def game(database, game_stats_service, player):
     game = Game(1, database, Mock(), game_stats_service)
     game._player_options[player.id] = {'Army': 1}
-    game._results = GameResults()
+    game._results = GameResults(1)
     game._results.add(GameResult(1, 1, GameOutcome.VICTORY, 0))
     return game
 
@@ -446,7 +446,7 @@ async def test_process_game_stats_abort_processing_if_no_army_result(game_stats_
     with open("tests/data/game_stats_full_example.json", "r") as stats_file:
         stats = stats_file.read()
 
-    game._results = GameResults()
+    game._results = GameResults(1)
 
     await game_stats_service.process_game_stats(player, game, stats)
     assert len(achievement_service.mock_calls) == 0

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -196,7 +196,7 @@ async def test_handle_action_GameResult_calls_add_result(game: Game, game_connec
     game_connection.connect_to_host = CoroutineMock()
 
     await game_connection.handle_action('GameResult', [0, 'score -5'])
-    game.add_result.assert_called_once_with(game_connection.player, 0, 'score', -5)
+    game.add_result.assert_called_once_with(game_connection.player.id, 0, 'score', -5)
 
 
 async def test_handle_action_GameOption(game: Game, game_connection: GameConnection):

--- a/tests/unit_tests/test_laddergame.py
+++ b/tests/unit_tests/test_laddergame.py
@@ -19,8 +19,8 @@ async def test_results_ranked_by_victory(laddergame, players):
     laddergame.state = GameState.LOBBY
     add_connected_players(laddergame, [players.hosting, players.joining])
 
-    await laddergame.add_result(players.hosting, 0, 'victory', 1)
-    await laddergame.add_result(players.joining, 1, 'defeat', 0)
+    await laddergame.add_result(players.hosting.id, 0, 'victory', 1)
+    await laddergame.add_result(players.joining.id, 1, 'defeat', 0)
 
     assert laddergame.get_army_score(0) == 1
     assert laddergame.get_army_score(1) == 0
@@ -37,8 +37,8 @@ async def test_get_army_score_returns_0_or_1_only(laddergame, players):
     laddergame.state = GameState.LOBBY
     add_connected_players(laddergame, [players.hosting, players.joining])
 
-    await laddergame.add_result(players.hosting, 0, 'victory', 100)
-    await laddergame.add_result(players.joining, 1, 'defeat', 50)
+    await laddergame.add_result(players.hosting.id, 0, 'victory', 100)
+    await laddergame.add_result(players.joining.id, 1, 'defeat', 50)
 
     assert laddergame.get_army_score(0) == 1
 
@@ -47,22 +47,22 @@ async def test_is_winner(laddergame, players):
     laddergame.state = GameState.LOBBY
     add_connected_players(laddergame, [players.hosting, players.joining])
 
-    await laddergame.add_result(players.hosting, 0, 'victory', 1)
-    await laddergame.add_result(players.joining, 1, 'defeat', 0)
+    await laddergame.add_result(players.hosting.id, 0, 'victory', 1)
+    await laddergame.add_result(players.joining.id, 1, 'defeat', 0)
 
     assert laddergame.is_winner(players.hosting)
-    assert laddergame.is_winner(players.joining) is False
+    assert not laddergame.is_winner(players.joining)
 
 
 async def test_is_winner_on_draw(laddergame, players):
     laddergame.state = GameState.LOBBY
     add_connected_players(laddergame, [players.hosting, players.joining])
 
-    await laddergame.add_result(players.hosting, 0, 'draw', 1)
-    await laddergame.add_result(players.joining, 1, 'draw', 1)
+    await laddergame.add_result(players.hosting.id, 0, 'draw', 1)
+    await laddergame.add_result(players.joining.id, 1, 'draw', 1)
 
-    assert laddergame.is_winner(players.hosting) is False
-    assert laddergame.is_winner(players.joining) is False
+    assert not laddergame.is_winner(players.hosting)
+    assert not laddergame.is_winner(players.joining)
 
 
 async def test_rate_game(laddergame: LadderGame, database, game_add_players):


### PR DESCRIPTION
This moves the logic determining game's outcome for players into a separate class. Methods for choosing an outcome from multiple reports are merged into one. TODO: discuss if the method chosen is appropriate.

The PR is based on top of #494, so it has some extra commits.