### PR TITLE
Refactor message sending interface to be a coroutine

### DIFF
--- a/server/api/oauth_session.py
+++ b/server/api/oauth_session.py
@@ -3,8 +3,9 @@ import os
 from typing import Dict
 
 import aiohttp
-from oauthlib.oauth2.rfc6749.errors import (InsecureTransportError,
-                                            MissingTokenError)
+from oauthlib.oauth2.rfc6749.errors import (
+    InsecureTransportError, MissingTokenError
+)
 
 
 class OAuth2Session(object):

--- a/server/control.py
+++ b/server/control.py
@@ -2,12 +2,15 @@
 Tiny local-only http server for getting stats and performing various tasks
 """
 
+import logging
 import socket
+from json import dumps
 
 from aiohttp import web
-import logging
-from server import PlayerService, GameService, config
-from json import dumps
+
+from . import config
+from .game_service import GameService
+from .player_service import PlayerService
 
 logger = logging.getLogger(__name__)
 

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -2,11 +2,10 @@ import asyncio
 from typing import Dict, List, Optional, Union, ValuesView
 
 import aiocron
-from server import GameState, VisibilityState
 from server.db import FAFDatabase
 from server.decorators import with_logger
 from server.games import CoopGame, CustomGame, FeaturedMod, LadderGame
-from server.games.game import Game
+from server.games.game import Game, GameState, VisibilityState
 from server.matchmaker import MatchmakerQueue
 from server.players import Player
 

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -538,12 +538,11 @@ class GameConnection(GpgNetServerProtocol):
 
             tasks.append(peer.send_DisconnectFromPeer(self.player.id))
 
-        try:
-            await asyncio.gather(*tasks)
-        except Exception:  # pragma no cover
-            self._logger.exception(
-                "peer_sendDisconnectFromPeer failed for player %i",
-                self.player.id)
+        for result in await asyncio.gather(*tasks, return_exceptions=True):
+            if isinstance(result, Exception):
+                self._logger.exception(
+                    "peer_sendDisconnectFromPeer failed for player %i",
+                    self.player.id)
 
     async def on_connection_lost(self):
         try:

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -120,7 +120,7 @@ class GameConnection(GpgNetServerProtocol):
                     if peer != self and peer.player != self.game.host:
                         self._logger.debug("%s connecting to %s", self.player, peer)
                         tasks.append(self.connect_to_peer(peer))
-                await asyncio.gather(tasks)
+                await asyncio.gather(*tasks)
         except Exception as e:  # pragma: no cover
             self._logger.exception(e)
 
@@ -539,7 +539,7 @@ class GameConnection(GpgNetServerProtocol):
             tasks.append(peer.send_DisconnectFromPeer(self.player.id))
 
         try:
-            await asyncio.gather(tasks)
+            await asyncio.gather(*tasks)
         except Exception:  # pragma no cover
             self._logger.exception(
                 "peer_sendDisconnectFromPeer failed for player %i",

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -3,17 +3,17 @@ import functools
 import logging
 import re
 import time
-from collections import Counter, defaultdict
+from collections import defaultdict
 from enum import Enum, unique
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 import trueskill
+from server.games.game_results import GameOutcome, GameResult, GameResults
+from server.rating import RatingType
 from trueskill import Rating
 
 from ..abc.base_game import GameConnectionState, InitMode
 from ..players import Player, PlayerState
-from server.rating import RatingType
-from server.games.game_results import GameOutcome, GameResult, GameResults
 
 FFA_TEAM = 1
 

--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -28,10 +28,12 @@ class GeoIpService(object):
         self.db = None
 
         # crontab: min hour day month day_of_week
-        # Run every Wednesday because GeoLite2 is updated every Tuesday
+        # Run every Wednesday because GeoLite2 is updated every first Tuesday
+        # of the month.
         self._update_cron = aiocron.crontab(
-            '0 0 0 * * 3', func=self.check_update_geoip_db, start=True
+            '0 0 0 * * 3', func=self.check_update_geoip_db
         )
+        asyncio.ensure_future(self.check_update_geoip_db())
 
     async def check_update_geoip_db(self) -> None:
         """

--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -30,9 +30,8 @@ class GeoIpService(object):
         # crontab: min hour day month day_of_week
         # Run every Wednesday because GeoLite2 is updated every Tuesday
         self._update_cron = aiocron.crontab(
-            '0 0 0 * * 3', func=self.check_update_geoip_db
+            '0 0 0 * * 3', func=self.check_update_geoip_db, start=True
         )
-        asyncio.ensure_future(self.check_update_geoip_db())
 
     async def check_update_geoip_db(self) -> None:
         """

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -3,16 +3,16 @@ import random
 from collections import defaultdict
 from typing import Dict, List, NamedTuple, Set
 
+from server.db import FAFDatabase
+from server.rating import RatingType
 from sqlalchemy import and_, func, select, text
 
-from server.db import FAFDatabase
 from .config import LADDER_ANTI_REPETITION_LIMIT
 from .db.models import game_featuredMods, game_player_stats, game_stats
 from .decorators import with_logger
 from .game_service import GameService
 from .matchmaker import MatchmakerQueue, Search
 from .players import Player, PlayerState
-from server.rating import RatingType
 
 MapDescription = NamedTuple('Map', [("id", int), ("name", str), ("path", str)])
 
@@ -37,7 +37,7 @@ class LadderService:
 
         asyncio.ensure_future(self.handle_queue_matches())
 
-    def start_search(self, initiator: Player, search: Search, queue_name: str):
+    async def start_search(self, initiator: Player, search: Search, queue_name: str):
         self._cancel_existing_searches(initiator)
 
         for player in search.players:
@@ -45,7 +45,7 @@ class LadderService:
 
             # For now, inform_player is only designed for ladder1v1
             if queue_name == "ladder1v1":
-                self.inform_player(player)
+                await self.inform_player(player)
 
         self.searches[queue_name][initiator] = search
 
@@ -76,13 +76,13 @@ class LadderService:
                 del self.searches[queue_name][initiator]
         return searches
 
-    def inform_player(self, player: Player):
+    async def inform_player(self, player: Player):
         if player not in self._informed_players:
             self._informed_players.add(player)
             mean, deviation = player.ratings[RatingType.LADDER_1V1]
 
             if deviation > 490:
-                player.lobby_connection.send({
+                await player.lobby_connection.send({
                     "command": "notice",
                     "style": "info",
                     "text": (
@@ -97,7 +97,7 @@ class LadderService:
                 })
             elif deviation > 250:
                 progress = (500.0 - deviation) / 2.5
-                player.lobby_connection.send({
+                await player.lobby_connection.send({
                     "command": "notice",
                     "style": "info",
                     "text": (
@@ -113,8 +113,8 @@ class LadderService:
                 assert len(s2.players) == 1
                 p1, p2 = s1.players[0], s2.players[0]
                 msg = {"command": "match_found", "queue": "ladder1v1"}
-                p1.lobby_connection.send(msg)
-                p2.lobby_connection.send(msg)
+                await p1.lobby_connection.send(msg)
+                await p2.lobby_connection.send(msg)
                 asyncio.ensure_future(self.start_game(p1, p2))
             except Exception as e:
                 self._logger.exception(
@@ -159,15 +159,15 @@ class LadderService:
         # FIXME: Database filenames contain the maps/ prefix and .zip suffix.
         # Really in the future, just send a better description
         self._logger.debug("Starting ladder game: %s", game)
-        host.lobby_connection.launch_game(game, is_host=True, use_map=mapname)
+        await host.lobby_connection.launch_game(game, is_host=True, use_map=mapname)
         try:
             hosted = await game.await_hosted()
             if not hosted:
                 raise TimeoutError("Host left lobby")
         except TimeoutError:
             msg = {"command": "game_launch_timeout"}
-            host.lobby_connection.send(msg)
-            guest.lobby_connection.send(msg)
+            await host.lobby_connection.send(msg)
+            await guest.lobby_connection.send(msg)
             # TODO: Uncomment this line once the client supports `game_launch_timeout`.
             # Until then, returning here will cause the client to think it is
             # searching for ladder, even though the server has already removed it
@@ -175,7 +175,7 @@ class LadderService:
             # return
             self._logger.debug("Ladder game failed to launch due to a timeout")
 
-        guest.lobby_connection.launch_game(
+        await guest.lobby_connection.launch_game(
             game, is_host=False, use_map=mapname
         )
         self._logger.debug("Ladder game launched successfully")

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -113,8 +113,10 @@ class LadderService:
                 assert len(s2.players) == 1
                 p1, p2 = s1.players[0], s2.players[0]
                 msg = {"command": "match_found", "queue": "ladder1v1"}
-                await p1.lobby_connection.send(msg)
-                await p2.lobby_connection.send(msg)
+                await asyncio.gather(
+                    p1.lobby_connection.send(msg),
+                    p2.lobby_connection.send(msg)
+                )
                 asyncio.ensure_future(self.start_game(p1, p2))
             except Exception as e:
                 self._logger.exception(
@@ -166,8 +168,10 @@ class LadderService:
                 raise TimeoutError("Host left lobby")
         except TimeoutError:
             msg = {"command": "game_launch_timeout"}
-            await host.lobby_connection.send(msg)
-            await guest.lobby_connection.send(msg)
+            await asyncio.gather(
+                host.lobby_connection.send(msg),
+                guest.lobby_connection.send(msg)
+            )
             # TODO: Uncomment this line once the client supports `game_launch_timeout`.
             # Until then, returning here will cause the client to think it is
             # searching for ladder, even though the server has already removed it

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -149,29 +149,29 @@ class LobbyConnection():
             else:
                 handler(message)
         except AuthenticationError as ex:
-            self.protocol.send_message(
-                {'command': 'authentication_failed',
-                 'text': ex.message}
-            )
+            await self.send({
+                'command': 'authentication_failed',
+                'text': ex.message
+            })
         except ClientError as ex:
             self._logger.warning("Client error: %s", ex.message)
-            self.protocol.send_message(
-                {'command': 'notice',
-                 'style': 'error',
-                 'text': ex.message}
-            )
+            await self.send({
+                'command': 'notice',
+                'style': 'error',
+                'text': ex.message
+            })
             if not ex.recoverable:
                 self.abort(ex.message)
         except (KeyError, ValueError) as ex:
             self._logger.exception(ex)
             self.abort("Garbage command: {}".format(message))
         except Exception as ex:  # pragma: no cover
-            self.protocol.send_message({'command': 'invalid'})
+            await self.send({'command': 'invalid'})
             self._logger.exception(ex)
             self.abort("Error processing command")
 
-    def command_ping(self, msg):
-        self.protocol.send_raw(self.protocol.pack_message('PONG'))
+    async def command_ping(self, msg):
+        await self.protocol.send_raw(self.protocol.pack_message('PONG'))
 
     def command_pong(self, msg):
         pass
@@ -209,19 +209,16 @@ class LobbyConnection():
                 json_to_send["uid"] = row["id"]
                 maps.append(json_to_send)
 
-        self.protocol.send_messages(maps)
+        await self.protocol.send_messages(maps)
 
     async def command_matchmaker_info(self, message):
-        self.send({
+        await self.send({
             'command': 'matchmaker_info',
             'queues': [queue.to_dict() for queue in self.ladder_service.queues.values()]
         })
 
-        await self.protocol.drain()
-
-    @timed()
-    def send_game_list(self):
-        self.send({
+    async def send_game_list(self):
+        await self.send({
             'command': 'game_info',
             'games': [game.to_dict() for game in self.game_service.open_games]
         })
@@ -258,15 +255,15 @@ class LobbyConnection():
                 subject_id=subject_id,
             ))
 
-    def kick(self):
-        self.send({
+    async def kick(self):
+        await self.send({
             "command": "notice",
             "style": "kick",
         })
         self.abort()
 
-    def send_updated_achievements(self, updated_achievements):
-        self.send({
+    async def send_updated_achievements(self, updated_achievements):
+        await self.send({
             "command": "updated_achievements",
             "updated_achievements": updated_achievements
         })
@@ -333,7 +330,7 @@ class LobbyConnection():
                 for player in self.player_service:
                     try:
                         if player.lobby_connection:
-                            player.lobby_connection.send_warning(message.get('message'))
+                            await player.lobby_connection.send_warning(message.get('message'))
                     except Exception as ex:
                         self._logger.debug("Could not send broadcast message to %s: %s".format(player, ex))
 
@@ -403,7 +400,7 @@ class LobbyConnection():
 
         return player_id, real_username, steamid
 
-    def check_version(self, message):
+    async def check_version(self, message):
         versionDB, updateFile = self.player_service.client_version_info
         update_msg = {
             'command': 'update',
@@ -417,7 +414,7 @@ class LobbyConnection():
         server.stats.gauge('user.agents.{}'.format(self.user_agent), 1, delta=True)
 
         if not self.user_agent or 'downlords-faf-client' not in self.user_agent:
-            self.send_warning(
+            await self.send_warning(
                 "You are using an unofficial client version! "
                 "Some features might not work as expected. "
                 "If you experience any problems please download the latest "
@@ -428,7 +425,7 @@ class LobbyConnection():
         if not version or not self.user_agent:
             update_msg['command'] = 'welcome'
             # For compatibility with 0.10.x updating mechanism
-            self.send(update_msg)
+            await self.send(update_msg)
             return False
 
         # Check their client is reporting the right version number.
@@ -439,10 +436,10 @@ class LobbyConnection():
                 if "+" in version:
                     version = version.split('+')[0]
                 if semver.compare(versionDB, version) > 0:
-                    self.send(update_msg)
+                    await self.send(update_msg)
                     return False
             except ValueError:
-                self.send(update_msg)
+                await self.send(update_msg)
                 return False
         return True
 
@@ -467,7 +464,7 @@ class LobbyConnection():
 
         if response.get('result', '') == 'vm':
             self._logger.debug("Using VM: %d: %s", player_id, uid_hash)
-            self.send({
+            await self.send({
                 "command": "notice",
                 "style": "error",
                 "text": (
@@ -477,7 +474,7 @@ class LobbyConnection():
                     "positive."
                 )
             })
-            self.send_warning("Your computer seems to be a virtual machine.<br><br>In order to "
+            await self.send_warning("Your computer seems to be a virtual machine.<br><br>In order to "
                               "log in from a VM, you have to link your account to Steam: <a href='" +
                               config.WWW_URL + "/account/link'>" +
                               config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
@@ -485,7 +482,7 @@ class LobbyConnection():
 
         if response.get('result', '') == 'already_associated':
             self._logger.warning("UID hit: %d: %s", player_id, uid_hash)
-            self.send_warning("Your computer is already associated with another FAF account.<br><br>In order to "
+            await self.send_warning("Your computer is already associated with another FAF account.<br><br>In order to "
                               "log in with an additional account, you have to link it to Steam: <a href='" +
                               config.WWW_URL + "/account/link'>" +
                               config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
@@ -494,7 +491,7 @@ class LobbyConnection():
 
         if response.get('result', '') == 'fraudulent':
             self._logger.info("Banning player %s for fraudulent looking login.", player_id)
-            self.send_warning("Fraudulent login attempt detected. As a precautionary measure, your account has been "
+            await self.send_warning("Fraudulent login attempt detected. As a precautionary measure, your account has been "
                               "banned permanently. Please contact an admin or moderator on the forums if you feel this is "
                               "a false positive.",
                               fatal=True)
@@ -566,7 +563,7 @@ class LobbyConnection():
         if old_player:
             self._logger.debug("player {} already signed in: {}".format(self.player.id, old_player))
             if old_player.lobby_connection:
-                old_player.lobby_connection.send_warning("You have been signed out because you signed in elsewhere.", fatal=True)
+                await old_player.lobby_connection.send_warning("You have been signed out because you signed in elsewhere.", fatal=True)
                 old_player.lobby_connection.game_connection = None
                 old_player.lobby_connection.player = None
                 self._logger.debug("Removing previous game_connection and player reference of player {} in hope on_connection_lost() wouldn't drop her out of the game".format(self.player.id))
@@ -581,7 +578,7 @@ class LobbyConnection():
         self.player.country = self.geoip_service.country(self.peer_address.host)
 
         # Send the player their own player info.
-        self.send({
+        await self.send({
             "command": "welcome",
             "me": self.player.to_dict(),
 
@@ -591,12 +588,10 @@ class LobbyConnection():
         })
 
         # Tell player about everybody online. This must happen after "welcome".
-        self.send(
-            {
-                "command": "player_info",
-                "players": [player.to_dict() for player in self.player_service]
-            }
-        )
+        await self.send({
+            "command": "player_info",
+            "players": [player.to_dict() for player in self.player_service]
+        })
 
         # Tell everyone else online about us. This must happen after all the player_info messages.
         # This ensures that no other client will perform an operation that interacts with the
@@ -630,21 +625,21 @@ class LobbyConnection():
             channels.append("#%s_clan" % self.player.clan)
 
         json_to_send = {"command": "social", "autojoin": channels, "channels": channels, "friends": friends, "foes": foes, "power": permission_group}
-        self.send(json_to_send)
+        await self.send(json_to_send)
 
-        self.send_game_list()
+        await self.send_game_list()
 
-    def command_restore_game_session(self, message):
+    async def command_restore_game_session(self, message):
         game_id = int(message.get('game_id'))
 
         # Restore the player's game connection, if the game still exists and is live
         if not game_id or game_id not in self.game_service:
-            self.send_warning("The game you were connected to does no longer exist")
+            await self.send_warning("The game you were connected to does no longer exist")
             return
 
         game = self.game_service[game_id]  # type: Game
         if game.state != GameState.LOBBY and game.state != GameState.LIVE:
-            self.send_warning("The game you were connected to is no longer available")
+            await self.send_warning("The game you were connected to is no longer available")
             return
 
         self._logger.debug("Restoring game session of player %s to game %s", self.player, game)
@@ -663,10 +658,9 @@ class LobbyConnection():
         if not hasattr(self.player, "game"):
             self.player.game = game
 
-    @timed
-    def command_ask_session(self, message):
-        if self.check_version(message):
-            self.send({"command": "session", "session": self.session})
+    async def command_ask_session(self, message):
+        if await self.check_version(message):
+            await self.send({"command": "session", "session": self.session})
 
     async def command_avatar(self, message):
         action = message['action']
@@ -684,7 +678,7 @@ class LobbyConnection():
                     avatarList.append(avatar)
 
                 if avatarList:
-                    self.send({"command": "avatar", "avatarlist": avatarList})
+                    await self.send({"command": "avatar", "avatarlist": avatarList})
 
         elif action == "select":
             avatar = message['avatar']
@@ -719,7 +713,7 @@ class LobbyConnection():
             game = self.game_service[uuid]
             if not game or game.state != GameState.LOBBY:
                 self._logger.debug("Game not in lobby state: %s", game)
-                self.send({
+                await self.send({
                     "command": "notice",
                     "style": "info",
                     "text": "The game you are trying to join is not ready."
@@ -727,17 +721,17 @@ class LobbyConnection():
                 return
 
             if game.password != password:
-                self.send({
+                await self.send({
                     "command": "notice",
                     "style": "info",
                     "text": "Bad password (it's case sensitive)"
                 })
                 return
 
-            self.launch_game(game, is_host=False)
+            await self.launch_game(game, is_host=False)
 
         except KeyError:
-            self.send({
+            await self.send({
                 "command": "notice",
                 "style": "info",
                 "text": "The host has left the game"
@@ -765,7 +759,7 @@ class LobbyConnection():
                 # TODO: Put player parties here
                 search = Search([self.player])
 
-            self.ladder_service.start_search(self.player, search, queue_name=mod)
+            await self.ladder_service.start_search(self.player, search, queue_name=mod)
 
     def command_coop_list(self, message):
         """ Request for coop map list"""
@@ -790,7 +784,7 @@ class LobbyConnection():
         try:
             title.encode('ascii')
         except UnicodeEncodeError:
-            self.send({
+            await self.send({
                 "command": "notice",
                 "style": "error",
                 "text": "Non-ascii characters in game name detected."
@@ -810,10 +804,10 @@ class LobbyConnection():
             mapname=mapname,
             password=password
         )
-        self.launch_game(game, is_host=True)
+        await self.launch_game(game, is_host=True)
         server.stats.incr('game.hosted', tags={'game_mode': game_mode})
 
-    def launch_game(self, game, is_host=False, use_map=None):
+    async def launch_game(self, game, is_host=False, use_map=None):
         # TODO: Fix setting up a ridiculous amount of cyclic pointers here
         if self.game_connection:
             self.game_connection.abort("Player launched a new game")
@@ -840,7 +834,7 @@ class LobbyConnection():
         }
         if use_map:
             cmd['mapname'] = use_map
-        self.send(cmd)
+        await self.send(cmd)
 
     async def command_modvault(self, message):
         type = message["type"]
@@ -861,7 +855,7 @@ class LobbyConnection():
                                    comments=[], description=description, played=played, likes=likes,
                                    downloads=downloads, date=int(date.timestamp()), uid=uid, name=name, version=version, author=author,
                                    ui=ui)
-                        self.send(out)
+                        await self.send(out)
                     except:
                         self._logger.error("Error handling table_mod row (uid: {})".format(uid), exc_info=True)
                         pass
@@ -899,7 +893,7 @@ class LobbyConnection():
                         "JOIN mod_version v ON v.mod_id = s.mod_id "
                         "SET s.likes = s.likes + 1, likers=%s WHERE v.uid = %s",
                         json.dumps(likers), uid)
-                    self.send(out)
+                    await self.send(out)
 
             elif type == "download":
                 uid = message["uid"]
@@ -910,7 +904,6 @@ class LobbyConnection():
             else:
                 raise ValueError('invalid type argument')
 
-    @asyncio.coroutine
     async def command_ice_servers(self, message):
         if not self.player:
             return
@@ -924,13 +917,13 @@ class LobbyConnection():
         if self.nts_client:
             ice_servers = ice_servers + await self.nts_client.server_tokens(ttl=ttl)
 
-        self.send({
+        await self.send({
             'command': 'ice_servers',
             'ice_servers': ice_servers,
             'ttl': ttl
         })
 
-    def send_warning(self, message: str, fatal: bool=False):
+    async def send_warning(self, message: str, fatal: bool=False):
         """
         Display a warning message to the client
         :param message: Warning message to display
@@ -939,20 +932,22 @@ class LobbyConnection():
                       and not attempt to reconnect.
         :return: None
         """
-        self.send({'command': 'notice',
-                   'style': 'info' if not fatal else 'error',
-                   'text': message})
+        await self.send({
+            'command': 'notice',
+            'style': 'info' if not fatal else 'error',
+            'text': message
+        })
         if fatal:
             self.abort(message)
 
-    def send(self, message):
+    async def send(self, message):
         """
 
         :param message:
         :return:
         """
         self._logger.log(TRACE, ">>: %s", message)
-        self.protocol.send_message(message)
+        await self.protocol.send_message(message)
 
     async def drain(self):
         await self.protocol.drain()

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -176,11 +176,11 @@ class LobbyConnection():
     def command_pong(self, msg):
         pass
 
-    @asyncio.coroutine
-    def command_create_account(self, message):
+    async def command_create_account(self, message):
         raise ClientError("FAF no longer supports direct registration. Please use the website to register.", recoverable=True)
 
-    async def send_coop_maps(self):
+    async def command_coop_list(self, message):
+        """ Request for coop map list"""
         async with self._db.acquire() as conn:
             result = await conn.execute("SELECT name, description, filename, type, id FROM `coop_map`")
 
@@ -760,10 +760,6 @@ class LobbyConnection():
                 search = Search([self.player])
 
             await self.ladder_service.start_search(self.player, search, queue_name=mod)
-
-    def command_coop_list(self, message):
-        """ Request for coop map list"""
-        asyncio.ensure_future(self.send_coop_maps())
 
     async def command_game_host(self, message):
         assert isinstance(self.player, Player)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -171,7 +171,7 @@ class LobbyConnection():
     async def command_ping(self, msg):
         await self.protocol.send_raw(self.protocol.pack_message('PONG'))
 
-    def command_pong(self, msg):
+    async def command_pong(self, msg):
         pass
 
     async def command_create_account(self, message):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -144,10 +144,8 @@ class LobbyConnection():
                 raise ClientError("Your client version is no longer supported. Please update to the newest version: https://faforever.com")
 
             handler = getattr(self, 'command_{}'.format(cmd))
-            if asyncio.iscoroutinefunction(handler):
-                await handler(message)
-            else:
-                handler(message)
+            await handler(message)
+
         except AuthenticationError as ex:
             await self.send({
                 'command': 'authentication_failed',

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -3,12 +3,12 @@ import math
 import time
 from typing import List, Optional, Tuple
 
+from server.rating import RatingType
 from trueskill import Rating, quality
 
 from .. import config
 from ..decorators import with_logger
 from ..players import Player
-from server.rating import RatingType
 
 
 @with_logger
@@ -70,7 +70,6 @@ class Search:
     def has_no_top_player(self) -> bool:
         max_rating = max(map(lambda rating_tuple: rating_tuple[0], self.ratings))
         return max_rating < config.TOP_PLAYER_MIN_RATING
-
 
     @property
     def ratings(self):

--- a/server/protocol/gpgnet.py
+++ b/server/protocol/gpgnet.py
@@ -6,44 +6,44 @@ class GpgNetServerProtocol(metaclass=ABCMeta):
     """
     Defines an interface for the server side GPGNet protocol
     """
-    def send_ConnectToPeer(self, player_name: str, player_uid: int, offer: bool):
+    async def send_ConnectToPeer(self, player_name: str, player_uid: int, offer: bool):
         """
         Tells a client that has a listening LobbyComm instance to connect to the given peer
         :param player_name: Remote player name
         :param player_uid: Remote player identifier
         """
-        self.send_gpgnet_message('ConnectToPeer', [player_name, player_uid, offer])
+        await self.send_gpgnet_message('ConnectToPeer', [player_name, player_uid, offer])
 
-    def send_JoinGame(self, remote_player_name: str, remote_player_uid: int):
+    async def send_JoinGame(self, remote_player_name: str, remote_player_uid: int):
         """
         Tells the game to join the given peer by ID
         :param remote_player_name:
         :param remote_player_uid:
         """
-        self.send_gpgnet_message('JoinGame', [remote_player_name, remote_player_uid])
+        await self.send_gpgnet_message('JoinGame', [remote_player_name, remote_player_uid])
 
-    def send_HostGame(self, map):
+    async def send_HostGame(self, map):
         """
         Tells the game to start listening for incoming connections as a host
         :param map: Which scenario to use
         """
-        self.send_gpgnet_message('HostGame', [str(map)])
+        await self.send_gpgnet_message('HostGame', [str(map)])
 
-    def send_DisconnectFromPeer(self, id: int):
+    async def send_DisconnectFromPeer(self, id: int):
         """
         Instructs the game to disconnect from the peer given by id
 
         :param id:
         :return:
         """
-        self.send_gpgnet_message('DisconnectFromPeer', [id])
+        await self.send_gpgnet_message('DisconnectFromPeer', [id])
 
-    def send_gpgnet_message(self, command_id, arguments):
+    async def send_gpgnet_message(self, command_id, arguments):
         message = {"command": command_id, "args": arguments}
-        self.send_message(message)
+        await self.send_message(message)
 
     @abstractmethod
-    def send_message(self, message):
+    async def send_message(self, message):
         pass  # pragma: no cover
 
 

--- a/server/protocol/protocol.py
+++ b/server/protocol/protocol.py
@@ -14,7 +14,7 @@ class Protocol(metaclass=ABCMeta):
         pass  # pragma: no cover
 
     @abstractmethod
-    def send_message(self, message: dict) -> None:
+    async def send_message(self, message: dict) -> None:
         """
         Send a single message in the form of a dictionary
 
@@ -23,7 +23,7 @@ class Protocol(metaclass=ABCMeta):
         pass  # pragma: no cover
 
     @abstractmethod
-    def send_messages(self, messages: List[dict]) -> None:
+    async def send_messages(self, messages: List[dict]) -> None:
         """
         Send multiple messages in the form of a list of dictionaries.
 
@@ -34,7 +34,7 @@ class Protocol(metaclass=ABCMeta):
         pass  # pragma: no cover
 
     @abstractmethod
-    def send_raw(self, data: bytes) -> None:
+    async def send_raw(self, data: bytes) -> None:
         """
         Send raw bytes. Should generally not be used.
 

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -48,9 +48,12 @@ class ServerContext:
 
     async def broadcast_raw(self, message, validate_fn=lambda a: True):
         server.stats.incr('server.broadcasts')
+        tasks = []
         for conn, proto in self.connections.items():
             if validate_fn(conn):
-                await proto.send_raw(message)
+                tasks.append(proto.send_raw(message))
+
+        await asyncio.gather(tasks)
 
     async def client_connected(self, stream_reader, stream_writer):
         self._logger.debug("%s: Client connected", self)

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -53,7 +53,7 @@ class ServerContext:
             if validate_fn(conn):
                 tasks.append(proto.send_raw(message))
 
-        await asyncio.gather(tasks)
+        await asyncio.gather(*tasks)
 
     async def client_connected(self, stream_reader, stream_writer):
         self._logger.debug("%s: Client connected", self)

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -46,11 +46,11 @@ class ServerContext:
     def __contains__(self, connection):
         return connection in self.connections.keys()
 
-    def broadcast_raw(self, message, validate_fn=lambda a: True):
+    async def broadcast_raw(self, message, validate_fn=lambda a: True):
         server.stats.incr('server.broadcasts')
         for conn, proto in self.connections.items():
             if validate_fn(conn):
-                proto.send_raw(message)
+                await proto.send_raw(message)
 
     async def client_connected(self, stream_reader, stream_writer):
         self._logger.debug("%s: Client connected", self)
@@ -64,9 +64,6 @@ class ServerContext:
                 message = await protocol.read_message()
                 with server.stats.timer('connection.on_message_received'):
                     await connection.on_message_received(message)
-                with server.stats.timer('servercontext.drain'):
-                    await asyncio.sleep(0)
-                    await connection.drain()
         except ConnectionResetError:
             pass
         except ConnectionAbortedError:

--- a/server/timing/__init__.py
+++ b/server/timing/__init__.py
@@ -1,0 +1,3 @@
+from .timer import Timer, at_interval
+
+__all__ = ("Timer", "at_interval")

--- a/server/timing/timer.py
+++ b/server/timing/timer.py
@@ -7,11 +7,9 @@ https://github.com/gawel/aiocron/blob/e82a53c3f9a7950209cee7b3e493204c1dfc8b12/a
 
 import asyncio
 import functools
-import time
 
 
-@asyncio.coroutine
-def null_callback(*args):
+async def null_callback(*args):
     return args
 
 
@@ -23,7 +21,7 @@ def wrap_func(func):
 
 
 class Timer(object):
-    """Schedules a function to be called asynchronusly on a fixed interval"""
+    """Schedules a function to be called asynchronously on a fixed interval"""
 
     def __init__(self, interval, func=None, args=(), start=False, loop=None):
         self.interval = interval
@@ -33,7 +31,7 @@ class Timer(object):
             self.func = null_callback
         self.cron = wrap_func(self.func)
         self.auto_start = start
-        self.handle = self.future = self.croniter = None
+        self.handle = self.future = None
         self.loop = loop if loop is not None else asyncio.get_event_loop()
         if start and self.func is not null_callback:
             self.handle = self.loop.call_soon_threadsafe(self.start)

--- a/server/timing/timer.py
+++ b/server/timing/timer.py
@@ -1,0 +1,100 @@
+"""
+This code is a modified version of Gael Pasgrimaud's library `aiocron`.
+
+See the original code here:
+https://github.com/gawel/aiocron/blob/e82a53c3f9a7950209cee7b3e493204c1dfc8b12/aiocron/__init__.py
+"""
+
+import asyncio
+import functools
+import time
+
+
+@asyncio.coroutine
+def null_callback(*args):
+    return args
+
+
+def wrap_func(func):
+    """wrap in a coroutine"""
+    if not asyncio.iscoroutinefunction(func):
+        return asyncio.coroutine(func)
+    return func
+
+
+class Timer(object):
+    """Schedules a function to be called asynchronusly on a fixed interval"""
+
+    def __init__(self, interval, func=None, args=(), start=False, loop=None):
+        self.interval = interval
+        if func is not None:
+            self.func = func if not args else functools.partial(func, *args)
+        else:
+            self.func = null_callback
+        self.cron = wrap_func(self.func)
+        self.auto_start = start
+        self.handle = self.future = self.croniter = None
+        self.loop = loop if loop is not None else asyncio.get_event_loop()
+        if start and self.func is not null_callback:
+            self.handle = self.loop.call_soon_threadsafe(self.start)
+
+    def start(self):
+        """Start scheduling"""
+        self.stop()
+        self.handle = self.loop.call_later(self.get_delay(), self.call_next)
+
+    def stop(self):
+        """Stop scheduling"""
+        if self.handle is not None:
+            self.handle.cancel()
+        self.handle = self.future = None
+
+    def get_delay(self):
+        """Return next interval to wait between calls"""
+        return self.interval
+
+    def call_next(self):
+        """Set next hop in the loop. Call task"""
+        if self.handle is not None:
+            self.handle.cancel()
+        delay = self.get_delay()
+        self.handle = self.loop.call_later(delay, self.call_next)
+        self.call_func()
+
+    def call_func(self, *args, **kwargs):
+        """Called. Take care of exceptions using gather"""
+        asyncio.gather(
+            self.cron(*args, **kwargs),
+            loop=self.loop, return_exceptions=True
+        ).add_done_callback(self.set_result)
+
+    def set_result(self, result):
+        """Set future's result if needed (can be an exception).
+        Else raise if needed."""
+        result = result.result()[0]
+        if self.future is not None:
+            if isinstance(result, Exception):
+                self.future.set_exception(result)
+            else:
+                self.future.set_result(result)
+            self.future = None
+        elif isinstance(result, Exception):
+            raise result
+
+    def __call__(self, func):
+        """Used as a decorator"""
+        self.func = func
+        self.cron = wrap_func(func)
+        if self.auto_start:
+            self.loop.call_soon_threadsafe(self.start)
+        return self
+
+    def __str__(self):
+        return f"{self.interval} {self.func}"
+
+    def __repr__(self):
+        return f"<Timer {str(self)}>"
+
+
+def at_interval(interval, func=None, args=(), start=True, loop=None):
+    return Timer(interval, func=func, args=args, start=start, loop=loop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,19 +11,19 @@ import logging
 from typing import Iterable
 from unittest import mock
 
+import asynctest
 import pytest
+from asynctest import CoroutineMock
 from server.api.api_accessor import ApiAccessor
 from server.config import DB_LOGIN, DB_PASSWORD, DB_PORT, DB_SERVER
+from server.db import FAFDatabase
 from server.game_service import GameService
 from server.geoip_service import GeoIpService
+from server.lobbyconnection import LobbyConnection
 from server.matchmaker import MatchmakerQueue
 from server.player_service import PlayerService
 from server.rating import RatingType
-from server.db import FAFDatabase
 from tests.utils import MockDatabase
-
-from asynctest import CoroutineMock
-import asynctest
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -159,6 +159,11 @@ def player_factory():
 
         p = Player(ratings=ratings, game_count=games, **kwargs)
         p.state = state
+
+        # lobby_connection is a weak reference, but we want the mock
+        # to live for the full lifetime of the player object
+        p.__owned_lobby_connection = asynctest.create_autospec(LobbyConnection)
+        p.lobby_connection = p.__owned_lobby_connection
         return p
 
     return make

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -1,4 +1,5 @@
 insert into login (id, login, email, password, steamid, create_time) values
+    (10,  'friends', 'friends@example.com', SHA2('friends', 256), null, '2000-01-01 00:00:00'),
     (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
     (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null,  '2000-01-01 00:00:00'),
     (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
@@ -69,7 +70,8 @@ insert into game_player_stats (gameId, playerId, AI, faction, color, team, place
 
 delete from friends_and_foes where user_id = 1 and subject_id = 2;
 insert into friends_and_foes (user_id, subject_id, status) values
-    (2, 1, 'FRIEND');
+    (2, 1, 'FRIEND'),
+    (10, 1, 'FRIEND');
 
 
 insert into `mod` (id, display_name, author) values

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -110,7 +110,7 @@ async def perform_login(
 ) -> None:
     login, pw = credentials
     pw_hash = hashlib.sha256(pw.encode('utf-8'))
-    proto.send_message({
+    await proto.send_message({
         'command': 'hello',
         'version': '1.0.0-dev',
         'user_agent': 'faf-client',
@@ -118,7 +118,6 @@ async def perform_login(
         'password': pw_hash.hexdigest(),
         'unique_id': 'some_id'
     })
-    await proto.drain()
 
 
 async def read_until(
@@ -139,8 +138,7 @@ async def read_until_command(proto: QDataStreamProtocol, command: str) -> Dict[s
 
 
 async def get_session(proto):
-    proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.11.16'})
-    await proto.drain()
+    await proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.11.16'})
     msg = await read_until_command(proto, 'session')
 
     return msg['session']

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -19,19 +19,17 @@ async def queue_players_for_matchmaking(lobby_server):
     await read_until_command(proto1, 'game_info')
     await read_until_command(proto2, 'game_info')
 
-    proto1.send_message({
+    await proto1.send_message({
         'command': 'game_matchmaking',
         'state': 'start',
         'faction': 'uef'
     })
-    await proto1.drain()
 
-    proto2.send_message({
+    await proto2.send_message({
         'command': 'game_matchmaking',
         'state': 'start',
         'faction': 1  # Python client sends factions as numbers
     })
-    await proto2.drain()
 
     # If the players did not match, this will fail due to a timeout error
     await read_until_command(proto1, 'match_found')
@@ -46,7 +44,7 @@ async def test_game_matchmaking(lobby_server):
 
     # The player that queued last will be the host
     msg2 = await read_until_command(proto2, 'game_launch')
-    proto2.send_message({
+    await proto2.send_message({
         'command': 'GameState',
         'target': 'game',
         'args': ['Lobby']
@@ -95,8 +93,7 @@ async def test_command_matchmaker_info(lobby_server, mocker):
 
     await read_until_command(proto, "game_info")
 
-    proto.send_message({"command": "matchmaker_info"})
-    await proto.drain()
+    await proto.send_message({"command": "matchmaker_info"})
 
     msg = await read_until_command(proto, "matchmaker_info")
     assert msg == {
@@ -120,7 +117,7 @@ async def test_matchmaker_info_message_on_cancel(lobby_server):
 
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'game_matchmaking',
         'state': 'start',
         'faction': 'uef'
@@ -132,7 +129,7 @@ async def test_matchmaker_info_message_on_cancel(lobby_server):
     assert msg["queues"][0]["queue_name"] == "ladder1v1"
     assert len(msg["queues"][0]["boundary_80s"]) == 1
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'game_matchmaking',
         'state': 'stop',
     })

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -56,7 +56,7 @@ async def test_game_matchmaking(lobby_server):
     assert msg2['mod'] == 'ladder1v1'
 
 
-@fast_forward(1000)
+@fast_forward(100)
 async def test_matchmaker_info_message(lobby_server, mocker):
     mocker.patch('server.matchmaker.pop_timer.time', return_value=1_562_000_000)
 

--- a/tests/integration_tests/test_modvault.py
+++ b/tests/integration_tests/test_modvault.py
@@ -1,5 +1,6 @@
-from .conftest import connect_and_sign_in, read_until_command
 import pytest
+
+from .conftest import connect_and_sign_in, read_until_command
 
 pytestmark = pytest.mark.asyncio
 
@@ -12,11 +13,10 @@ async def test_modvault_start(lobby_server):
 
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'modvault',
         'type': 'start'
     })
-    await proto.drain()
 
     # Make sure all 5 mod version messages are sent
     for _ in range(5):
@@ -31,12 +31,11 @@ async def test_modvault_like(lobby_server):
 
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'modvault',
         'type': 'like',
         'uid': 'FFF'
     })
-    await proto.drain()
 
     msg = await read_until_command(proto, 'modvault_info')
     # Not going to verify the date

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -1,9 +1,9 @@
 import asyncio
-from unittest import mock
 
 import pytest
 from server import VisibilityState
 from server.db.models import ban
+from tests.utils import fast_forward
 
 from .conftest import (
     connect_and_sign_in, connect_client, perform_login, read_until,
@@ -128,6 +128,14 @@ async def test_server_double_login(lobby_server):
     proto.close()
     proto2.close()
     await lobby_server.wait_closed()
+
+
+@fast_forward(50)
+async def test_ping_message(lobby_server):
+    _, _, proto = await connect_and_sign_in(('test', 'test_password'), lobby_server)
+
+    # We should receive the message every 45 seconds
+    await asyncio.wait_for(read_until_command(proto, 'ping'), 46)
 
 
 async def test_player_info_broadcast(lobby_server):

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -17,15 +17,13 @@ TEST_ADDRESS = ('127.0.0.1', None)
 async def test_server_deprecated_client(lobby_server):
     proto = await connect_client(lobby_server)
 
-    proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.0.0'})
-    await proto.drain()
+    await proto.send_message({'command': 'ask_session', 'user_agent': 'faf-client', 'version': '0.0.0'})
     msg = await proto.read_message()
 
     assert msg['command'] == 'notice'
 
     proto = await connect_client(lobby_server)
-    proto.send_message({'command': 'ask_session', 'version': '0.0.0'})
-    await proto.drain()
+    await proto.send_message({'command': 'ask_session', 'version': '0.0.0'})
     msg = await proto.read_message()
 
     assert msg['command'] == 'notice'
@@ -155,13 +153,12 @@ async def test_info_broadcast_authenticated(lobby_server):
 
     await perform_login(proto1, ('test', 'test_password'))
     await perform_login(proto2, ('Rhiza', 'puff_the_magic_dragon'))
-    proto1.send_message({
+    await proto1.send_message({
         "command": "game_matchmaking",
         "state": "start",
         "mod": "ladder1v1",
         "faction": "uef"
     })
-    await proto1.drain()
     # Will timeout if the message is never received
     await read_until_command(proto2, "matchmaker_info")
     with pytest.raises(asyncio.TimeoutError):
@@ -181,13 +178,12 @@ async def test_game_host_authenticated(lobby_server, user):
     _, _, proto = await connect_and_sign_in(user, lobby_server)
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'game_host',
         'title': 'My Game',
         'mod': 'faf',
         'visibility': 'public',
     })
-    await proto.drain()
 
     msg = await read_until_command(proto, 'game_launch')
 
@@ -205,13 +201,12 @@ async def test_host_missing_fields(event_loop, lobby_server, player_service):
 
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({
+    await proto.send_message({
         'command': 'game_host',
         'mod': '',
         'visibility': VisibilityState.to_string(VisibilityState.PUBLIC),
         'title': ''
     })
-    await proto.drain()
 
     msg = await read_until_command(proto, 'game_info')
 
@@ -229,8 +224,7 @@ async def test_coop_list(lobby_server):
 
     await read_until_command(proto, 'game_info')
 
-    proto.send_message({"command": "coop_list"})
-    await proto.drain()
+    await proto.send_message({"command": "coop_list"})
 
     msg = await read_until_command(proto, "coop_info")
     assert "name" in msg
@@ -261,8 +255,7 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
             )
         )
 
-    proto.send_message({"command": command})
-    await proto.drain()
+    await proto.send_message({"command": command})
 
     msg = await proto.read_message()
     assert msg == {

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -1,12 +1,10 @@
 import asyncio
-from asynctest import exhaust_callbacks
-import pytest
 from unittest import mock
 
-from server import ServerContext
+import pytest
+from asynctest import exhaust_callbacks
+from server import ServerContext, fake_statsd
 from server.protocol import QDataStreamProtocol
-from server import fake_statsd
-
 
 pytestmark = pytest.mark.asyncio
 
@@ -45,8 +43,7 @@ def mock_context(event_loop, request, mock_server):
 async def test_serverside_abort(event_loop, mock_context, mock_server):
     (reader, writer) = await asyncio.open_connection(*mock_context.sockets[0].getsockname())
     proto = QDataStreamProtocol(reader, writer)
-    proto.send_message({"some_junk": True})
-    await writer.drain()
+    await proto.send_message({"some_junk": True})
     await exhaust_callbacks(event_loop)
 
     mock_server.on_connection_lost.assert_any_call()

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -19,7 +19,15 @@ def lobbythread():
 
 
 @pytest.fixture
-def game_connection(request, database, game, players, game_service, player_service):
+def game_connection(
+    request,
+    database,
+    game,
+    players,
+    game_service,
+    player_service,
+    event_loop
+):
     from server import GameConnection
     conn = GameConnection(
         database=database,
@@ -33,7 +41,7 @@ def game_connection(request, database, game, players, game_service, player_servi
     conn.finished_sim = False
 
     def fin():
-        conn.abort()
+        event_loop.run_until_complete(conn.abort())
 
     request.addfinalizer(fin)
     return conn

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,14 +1,14 @@
 from unittest import mock
 
+import asynctest
 import pytest
+from asynctest import CoroutineMock
 from server import GameStatsService
 from server.game_service import GameService
 from server.gameconnection import GameConnection, GameConnectionState
 from server.games import Game
 from server.geoip_service import GeoIpService
 from server.ladder_service import LadderService
-import asynctest
-from asynctest import CoroutineMock
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -31,7 +31,7 @@ async def test_abort(game_connection: GameConnection, game: Game, players):
     game_connection.player = players.hosting
     game_connection.game = game
 
-    game_connection.abort()
+    await game_connection.abort()
 
     game.remove_game_connection.assert_called_with(game_connection)
 
@@ -91,7 +91,7 @@ async def test_handle_action_GameState_idle_non_searching_player_aborts(
 ):
     game_connection.player = players.hosting
     game_connection.lobby = mock.Mock()
-    game_connection.abort = mock.Mock()
+    game_connection.abort = CoroutineMock()
     players.hosting.state = PlayerState.IDLE
 
     await game_connection.handle_action('GameState', ['Idle'])
@@ -330,7 +330,7 @@ async def test_handle_action_TeamkillHappened(game: Game, game_connection: GameC
 
 async def test_handle_action_TeamkillHappened_AI(game: Game, game_connection: GameConnection, database):
     # Should fail with a sql constraint error if this isn't handled correctly
-    game_connection.abort = mock.Mock()
+    game_connection.abort = CoroutineMock()
     await game_connection.handle_action('TeamkillHappened', ['200', 0, 'Dostya', '0', 'Rhiza'])
     game_connection.abort.assert_not_called()
 

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -1,13 +1,11 @@
-import asyncio
 from unittest import mock
-import pytest
-import asynctest
 
+import pytest
+from asynctest import CoroutineMock, exhaust_callbacks
 from server import GameConnection
 from server.games import Game
 from server.games.game import ValidityState, Victory
 from server.players import PlayerState
-from asynctest import CoroutineMock, exhaust_callbacks
 
 pytestmark = pytest.mark.asyncio
 
@@ -233,12 +231,12 @@ async def test_handle_action_TeamkillReport(game: Game, game_connection: GameCon
         result = await conn.execute("select game_id,id from moderation_report where reporter_id=2 and game_id=%s and game_incident_timecode=200", (game.id))
         report = await result.fetchone()
         assert game.id == report["game_id"]
-        
+
         reported_user_query = await conn.execute("select player_id from reported_user where report_id=%s", (report["id"]))
         data = await reported_user_query.fetchone()
         assert data["player_id"] == 3
-        
-        
+
+
 async def test_handle_action_TeamkillReport_invalid_ids(game: Game, game_connection: GameConnection, database):
     game.launch = CoroutineMock()
     await game_connection.handle_action('TeamkillReport', ['230', 0, 'Dostya', 0, 'Rhiza'])
@@ -247,7 +245,7 @@ async def test_handle_action_TeamkillReport_invalid_ids(game: Game, game_connect
         result = await conn.execute("select game_id,id from moderation_report where reporter_id=2 and game_id=%s and game_incident_timecode=230", (game.id))
         report = await result.fetchone()
         assert game.id == report["game_id"]
-        
+
         reported_user_query = await conn.execute("select player_id from reported_user where report_id=%s", (report["id"]))
         data = await reported_user_query.fetchone()
         assert data["player_id"] == 3

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -157,7 +157,7 @@ async def test_start_game_called_on_match(ladder_service: LadderService,
     await ladder_service.start_search(p1, Search([p1]), 'ladder1v1')
     await ladder_service.start_search(p2, Search([p2]), 'ladder1v1')
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(2)
 
     ladder_service.inform_player.assert_called()
     ladder_service.start_game.assert_called_once()

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -1,12 +1,11 @@
 import asyncio
 from unittest import mock
-from asynctest import exhaust_callbacks
 
 import pytest
+from asynctest import CoroutineMock, exhaust_callbacks
 from server import GameService, LadderService
 from server.matchmaker import Search
 from server.players import PlayerState
-from asynctest import CoroutineMock
 from tests.utils import fast_forward
 
 pytestmark = pytest.mark.asyncio
@@ -16,11 +15,6 @@ async def test_start_game(ladder_service: LadderService, game_service:
                           GameService, player_factory):
     p1 = player_factory('Dostya', player_id=1)
     p2 = player_factory('Rhiza', player_id=2)
-
-    mock_lc1 = mock.Mock()
-    mock_lc2 = mock.Mock()
-    p1.lobby_connection = mock_lc1
-    p2.lobby_connection = mock_lc2
 
     game_service.ladder_maps = [(1, 'scmp_007', 'maps/scmp_007.zip')]
 
@@ -37,11 +31,6 @@ async def test_start_game_timeout(ladder_service: LadderService, game_service:
     p1 = player_factory('Dostya', player_id=1)
     p2 = player_factory('Rhiza', player_id=2)
 
-    mock_lc1 = mock.Mock()
-    mock_lc2 = mock.Mock()
-    p1.lobby_connection = mock_lc1
-    p2.lobby_connection = mock_lc2
-
     game_service.ladder_maps = [(1, 'scmp_007', 'maps/scmp_007.zip')]
 
     await ladder_service.start_game(p1, p2)
@@ -56,19 +45,16 @@ async def test_start_game_timeout(ladder_service: LadderService, game_service:
 async def test_inform_player(ladder_service: LadderService, player_factory):
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(1500, 500))
 
-    mock_lc = mock.Mock()
-    p1.lobby_connection = mock_lc
-
-    ladder_service.inform_player(p1)
+    await ladder_service.inform_player(p1)
 
     # Message is sent after the first call
     p1.lobby_connection.send.assert_called_once()
-    ladder_service.inform_player(p1)
+    await ladder_service.inform_player(p1)
     p1.lobby_connection.send.reset_mock()
     # But not after the second
     p1.lobby_connection.send.assert_not_called()
     ladder_service.on_connection_lost(p1)
-    ladder_service.inform_player(p1)
+    await ladder_service.inform_player(p1)
 
     # But it is called if the player relogs
     p1.lobby_connection.send.assert_called_once()
@@ -78,12 +64,9 @@ async def test_start_and_cancel_search(ladder_service: LadderService,
                                        player_factory, event_loop):
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(1500, 500), ladder_games=0)
 
-    mock_lc = mock.Mock()
-    p1.lobby_connection = mock_lc
-
     search = Search([p1])
 
-    ladder_service.start_search(p1, search, 'ladder1v1')
+    await ladder_service.start_search(p1, search, 'ladder1v1')
     await exhaust_callbacks(event_loop)
 
     assert p1.state == PlayerState.SEARCHING_LADDER
@@ -100,12 +83,9 @@ async def test_start_search_cancels_previous_search(
         ladder_service: LadderService, player_factory, event_loop):
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(1500, 500), ladder_games=0)
 
-    mock_lc = mock.Mock()
-    p1.lobby_connection = mock_lc
-
     search1 = Search([p1])
 
-    ladder_service.start_search(p1, search1, 'ladder1v1')
+    await ladder_service.start_search(p1, search1, 'ladder1v1')
     await exhaust_callbacks(event_loop)
 
     assert p1.state == PlayerState.SEARCHING_LADDER
@@ -113,7 +93,7 @@ async def test_start_search_cancels_previous_search(
 
     search2 = Search([p1])
 
-    ladder_service.start_search(p1, search2, 'ladder1v1')
+    await ladder_service.start_search(p1, search2, 'ladder1v1')
     await exhaust_callbacks(event_loop)
 
     assert p1.state == PlayerState.SEARCHING_LADDER
@@ -126,12 +106,9 @@ async def test_cancel_all_searches(ladder_service: LadderService,
                                    player_factory, event_loop):
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(1500, 500), ladder_games=0)
 
-    mock_lc = mock.Mock()
-    p1.lobby_connection = mock_lc
-
     search = Search([p1])
 
-    ladder_service.start_search(p1, search, 'ladder1v1')
+    await ladder_service.start_search(p1, search, 'ladder1v1')
     await exhaust_callbacks(event_loop)
 
     assert p1.state == PlayerState.SEARCHING_LADDER
@@ -149,16 +126,11 @@ async def test_cancel_twice(ladder_service: LadderService, player_factory):
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(1500, 500), ladder_games=0)
     p2 = player_factory('Brackman', player_id=2, ladder_rating=(2000, 500), ladder_games=0)
 
-    mock_lc1 = mock.Mock()
-    mock_lc2 = mock.Mock()
-    p1.lobby_connection = mock_lc1
-    p2.lobby_connection = mock_lc2
-
     search = Search([p1])
     search2 = Search([p2])
 
-    ladder_service.start_search(p1, search, 'ladder1v1')
-    ladder_service.start_search(p2, search2, 'ladder1v1')
+    await ladder_service.start_search(p1, search, 'ladder1v1')
+    await ladder_service.start_search(p2, search2, 'ladder1v1')
 
     searches = ladder_service._cancel_existing_searches(p1)
     assert search.is_cancelled
@@ -179,16 +151,11 @@ async def test_start_game_called_on_match(ladder_service: LadderService,
     p1 = player_factory('Dostya', player_id=1, ladder_rating=(2300, 64), ladder_games=0)
     p2 = player_factory('QAI', player_id=2, ladder_rating=(2350, 125), ladder_games=0)
 
-    mock_lc1 = mock.Mock()
-    mock_lc2 = mock.Mock()
-    p1.lobby_connection = mock_lc1
-    p2.lobby_connection = mock_lc2
-
     ladder_service.start_game = CoroutineMock()
-    ladder_service.inform_player = mock.Mock()
+    ladder_service.inform_player = CoroutineMock()
 
-    ladder_service.start_search(p1, Search([p1]), 'ladder1v1')
-    ladder_service.start_search(p2, Search([p2]), 'ladder1v1')
+    await ladder_service.start_search(p1, Search([p1]), 'ladder1v1')
+    await ladder_service.start_search(p2, Search([p2]), 'ladder1v1')
 
     await asyncio.sleep(1)
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -322,8 +322,8 @@ async def test_send_game_list(mocker, database, lobbyconnection, game_stats_serv
     })
 
 
-async def test_send_coop_maps(mocker, lobbyconnection):
-    await lobbyconnection.send_coop_maps()
+async def test_coop_list(mocker, lobbyconnection):
+    await lobbyconnection.command_coop_list({})
 
     args = lobbyconnection.protocol.send_messages.call_args_list
     assert len(args) == 1

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock
 
+import asynctest
 import pytest
 from aiohttp import web
 from asynctest import CoroutineMock
@@ -71,7 +72,7 @@ def mock_games(database, mock_players, game_stats_service):
 
 @pytest.fixture
 def mock_protocol():
-    return mock.create_autospec(QDataStreamProtocol(mock.Mock(), mock.Mock()))
+    return asynctest.create_autospec(QDataStreamProtocol(mock.Mock(), mock.Mock()))
 
 
 @pytest.fixture
@@ -95,6 +96,7 @@ def lobbyconnection(event_loop, database, mock_protocol, mock_games, mock_player
     lc.player_service.get_permission_group.return_value = 0
     lc.player_service.fetch_player_data = CoroutineMock()
     lc.peer_address = Address('127.0.0.1', 1234)
+    lc._authenticated = True
     return lc
 
 
@@ -130,8 +132,6 @@ async def test_command_game_host_creates_game(lobbyconnection,
                                               test_game_info,
                                               players):
     lobbyconnection.player = players.hosting
-    lobbyconnection.protocol = mock.Mock()
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_host",
         **test_game_info
@@ -152,8 +152,8 @@ async def test_launch_game(lobbyconnection, game, player_factory):
 
     lobbyconnection.player = player_factory()
     lobbyconnection.game_connection = old_game_conn
-    lobbyconnection.send = mock.Mock()
-    lobbyconnection.launch_game(game)
+    lobbyconnection.send = CoroutineMock()
+    await lobbyconnection.launch_game(game)
 
     # Verify all side effects of launch_game here
     old_game_conn.abort.assert_called_with("Player launched a new game")
@@ -170,10 +170,8 @@ async def test_command_game_host_creates_correct_game(
         lobbyconnection, game_service, test_game_info, players):
     lobbyconnection.player = players.hosting
     lobbyconnection.game_service = game_service
-    lobbyconnection.launch_game = mock.Mock()
+    lobbyconnection.launch_game = CoroutineMock()
 
-    lobbyconnection.protocol = mock.Mock()
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_host",
         **test_game_info
@@ -192,7 +190,6 @@ async def test_command_game_join_calls_join_game(mocker,
                                                  players,
                                                  game_stats_service):
     lobbyconnection.game_service = game_service
-    mock_protocol = mocker.patch.object(lobbyconnection, 'protocol')
     game = mock.create_autospec(Game(42, database, game_service, game_stats_service))
     game.state = GameState.LOBBY
     game.password = None
@@ -202,7 +199,6 @@ async def test_command_game_join_calls_join_game(mocker,
     lobbyconnection.player = players.hosting
     test_game_info['uid'] = 42
 
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_join",
         **test_game_info
@@ -213,7 +209,7 @@ async def test_command_game_join_calls_join_game(mocker,
         'uid': 42,
         'args': ['/numgames {}'.format(players.hosting.game_count[RatingType.GLOBAL])]
     }
-    mock_protocol.send_message.assert_called_with(expected_reply)
+    lobbyconnection.protocol.send_message.assert_called_with(expected_reply)
 
 
 async def test_command_game_join_uid_as_str(mocker,
@@ -224,7 +220,6 @@ async def test_command_game_join_uid_as_str(mocker,
                                             players,
                                             game_stats_service):
     lobbyconnection.game_service = game_service
-    mock_protocol = mocker.patch.object(lobbyconnection, 'protocol')
     game = mock.create_autospec(Game(42, database, game_service, game_stats_service))
     game.state = GameState.LOBBY
     game.password = None
@@ -234,7 +229,6 @@ async def test_command_game_join_uid_as_str(mocker,
     lobbyconnection.player = players.hosting
     test_game_info['uid'] = '42'  # Pass in uid as string
 
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_join",
         **test_game_info
@@ -245,7 +239,7 @@ async def test_command_game_join_uid_as_str(mocker,
         'uid': 42,
         'args': ['/numgames {}'.format(players.hosting.game_count[RatingType.GLOBAL])]
     }
-    mock_protocol.send_message.assert_called_with(expected_reply)
+    lobbyconnection.protocol.send_message.assert_called_with(expected_reply)
 
 
 async def test_command_game_join_without_password(lobbyconnection,
@@ -254,7 +248,7 @@ async def test_command_game_join_without_password(lobbyconnection,
                                                   test_game_info,
                                                   players,
                                                   game_stats_service):
-    lobbyconnection.send = mock.Mock()
+    lobbyconnection.send = CoroutineMock()
     lobbyconnection.game_service = game_service
     game = mock.create_autospec(Game(42, database, game_service, game_stats_service))
     game.state = GameState.LOBBY
@@ -266,7 +260,6 @@ async def test_command_game_join_without_password(lobbyconnection,
     test_game_info['uid'] = 42
     del test_game_info['password']
 
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_join",
         **test_game_info
@@ -279,12 +272,11 @@ async def test_command_game_join_game_not_found(lobbyconnection,
                                                 game_service,
                                                 test_game_info,
                                                 players):
-    lobbyconnection.send = mock.Mock()
+    lobbyconnection.send = CoroutineMock()
     lobbyconnection.game_service = game_service
     lobbyconnection.player = players.hosting
     test_game_info['uid'] = 42
 
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_join",
         **test_game_info
@@ -295,12 +287,9 @@ async def test_command_game_join_game_not_found(lobbyconnection,
 
 async def test_command_game_host_calls_host_game_invalid_title(lobbyconnection,
                                                                mock_games,
-                                                               test_game_info_invalid,
-                                                               players):
-    lobbyconnection.send = mock.Mock()
+                                                               test_game_info_invalid):
+    lobbyconnection.send = CoroutineMock()
     mock_games.create_game = mock.Mock()
-    lobbyconnection.player = players.hosting
-    lobbyconnection._authenticated = True
     await lobbyconnection.on_message_received({
         "command": "game_host",
         **test_game_info_invalid
@@ -311,33 +300,31 @@ async def test_command_game_host_calls_host_game_invalid_title(lobbyconnection,
 
 
 async def test_abort(mocker, lobbyconnection):
-    proto = mocker.patch.object(lobbyconnection, 'protocol')
-
+    lobbyconnection.protocol.writer.close = mock.Mock()
     lobbyconnection.abort()
 
-    proto.writer.close.assert_any_call()
+    lobbyconnection.protocol.writer.close.assert_any_call()
 
 
 async def test_send_game_list(mocker, database, lobbyconnection, game_stats_service):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
     games = mocker.patch.object(lobbyconnection, 'game_service')  # type: GameService
     game1, game2 = mock.create_autospec(Game(42, database, mock.Mock(), game_stats_service)), \
                    mock.create_autospec(Game(22, database, mock.Mock(), game_stats_service))
 
     games.open_games = [game1, game2]
 
-    lobbyconnection.send_game_list()
+    await lobbyconnection.send_game_list()
 
-    protocol.send_message.assert_any_call({'command': 'game_info',
-                                           'games': [game1.to_dict(), game2.to_dict()]})
+    lobbyconnection.protocol.send_message.assert_any_call({
+        'command': 'game_info',
+        'games': [game1.to_dict(), game2.to_dict()]
+    })
 
 
 async def test_send_coop_maps(mocker, lobbyconnection):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
-
     await lobbyconnection.send_coop_maps()
 
-    args = protocol.send_messages.call_args_list
+    args = lobbyconnection.protocol.send_messages.call_args_list
     assert len(args) == 1
     coop_maps = args[0][0][0]
     for info in coop_maps:
@@ -394,7 +381,7 @@ async def test_command_admin_closelobby(mocker, lobbyconnection):
     tuna.id = 55
     lobbyconnection.player_service = {1: player, 55: tuna}
 
-    await lobbyconnection.command_admin({
+    await lobbyconnection.on_message_received({
         'command': 'admin',
         'action': 'closelobby',
         'user_id': 55
@@ -411,7 +398,6 @@ async def test_command_admin_closelobby_with_ban(mocker, lobbyconnection, databa
     banme = mock.Mock()
     banme.id = 200
     lobbyconnection.player_service = {1: player, banme.id: banme}
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'admin',
@@ -443,7 +429,6 @@ async def test_command_admin_closelobby_with_ban_but_already_banned(mocker, lobb
     banme = mock.Mock()
     banme.id = 200
     lobbyconnection.player_service = {1: player, banme.id: banme}
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'admin',
@@ -482,7 +467,6 @@ async def test_command_admin_closelobby_with_ban_but_already_banned(mocker, lobb
 
 
 async def test_command_admin_closelobby_with_ban_duration_no_period(mocker, lobbyconnection, database):
-    mocker.patch.object(lobbyconnection, 'protocol')
     player = mocker.patch.object(lobbyconnection, 'player')
     player.login = 'Sheeo'
     player.id = 1
@@ -490,7 +474,6 @@ async def test_command_admin_closelobby_with_ban_duration_no_period(mocker, lobb
     banme = mock.Mock()
     banme.id = 200
     lobbyconnection.player_service = {1: player, banme.id: banme}
-    lobbyconnection._authenticated = True
 
     mocker.patch('server.lobbyconnection.func.now', return_value=text('FROM_UNIXTIME(1000)'))
     await lobbyconnection.on_message_received({
@@ -515,13 +498,11 @@ async def test_command_admin_closelobby_with_ban_duration_no_period(mocker, lobb
 
 
 async def test_command_admin_closelobby_with_ban_bad_period(mocker, lobbyconnection, database):
-    proto = mocker.patch.object(lobbyconnection, 'protocol')
     player = mocker.patch.object(lobbyconnection, 'player')
     player.admin = True
     banme = mock.Mock()
     banme.id = 1
     lobbyconnection.player_service = {1: player, banme.id: banme}
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'admin',
@@ -535,7 +516,7 @@ async def test_command_admin_closelobby_with_ban_bad_period(mocker, lobbyconnect
     })
 
     banme.lobbyconnection.kick.assert_not_called()
-    proto.send_message.assert_called_once_with({
+    lobbyconnection.protocol.send_message.assert_called_once_with({
         'command': 'notice',
         'style': 'error',
         'text': "Period ') INJECTED!' is not allowed!"
@@ -550,13 +531,11 @@ async def test_command_admin_closelobby_with_ban_bad_period(mocker, lobbyconnect
 
 
 async def test_command_admin_closelobby_with_ban_injection(mocker, lobbyconnection, database):
-    proto = mocker.patch.object(lobbyconnection, 'protocol')
     player = mocker.patch.object(lobbyconnection, 'player')
     player.admin = True
     banme = mock.Mock()
     banme.id = 1
     lobbyconnection.player_service = {1: player, banme.id: banme}
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'admin',
@@ -570,7 +549,7 @@ async def test_command_admin_closelobby_with_ban_injection(mocker, lobbyconnecti
     })
 
     banme.lobbyconnection.kick.assert_not_called()
-    proto.send_message.assert_called_once_with({
+    lobbyconnection.protocol.send_message.assert_called_once_with({
         'command': 'notice',
         'style': 'error',
         'text': "Period ') INJECTED!' is not allowed!"
@@ -585,7 +564,6 @@ async def test_command_admin_closelobby_with_ban_injection(mocker, lobbyconnecti
 
 
 async def test_command_admin_closeFA(mocker, lobbyconnection):
-    mocker.patch.object(lobbyconnection, 'protocol')
     mocker.patch.object(lobbyconnection, '_logger')
     player = mocker.patch.object(lobbyconnection, 'player')
     player.login = 'Sheeo'
@@ -593,7 +571,6 @@ async def test_command_admin_closeFA(mocker, lobbyconnection):
     player.id = 42
     tuna = mock.Mock()
     tuna.id = 55
-    lobbyconnection._authenticated = True
     lobbyconnection.player_service = {42: player, 55: tuna}
 
     await lobbyconnection.on_message_received({
@@ -622,15 +599,15 @@ async def test_game_subscription(lobbyconnection: LobbyConnection):
 
 
 async def test_command_avatar_list(mocker, lobbyconnection: LobbyConnection, mock_player: Player):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
     lobbyconnection.player = mock_player
     lobbyconnection.player.id = 2  # Dostya test user
 
-    await lobbyconnection.command_avatar({
+    await lobbyconnection.on_message_received({
+        'command': 'avatar',
         'action': 'list_avatar'
     })
 
-    protocol.send_message.assert_any_call({
+    lobbyconnection.protocol.send_message.assert_any_call({
         "command": "avatar",
         "avatarlist": [{'url': 'http://content.faforever.com/faf/avatars/qai2.png', 'tooltip': 'QAI'}, {'url': 'http://content.faforever.com/faf/avatars/UEF.png', 'tooltip': 'UEF'}]
     })
@@ -639,7 +616,6 @@ async def test_command_avatar_list(mocker, lobbyconnection: LobbyConnection, moc
 async def test_command_avatar_select(mocker, database, lobbyconnection: LobbyConnection, mock_player: Player):
     lobbyconnection.player = mock_player
     lobbyconnection.player.id = 2  # Dostya test user
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'avatar',
@@ -670,7 +646,6 @@ async def get_friends(player_id, database):
 async def test_command_social_add_friend(lobbyconnection, mock_player, database):
     lobbyconnection.player = mock_player
     lobbyconnection.player.id = 1
-    lobbyconnection._authenticated = True
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == []
@@ -687,7 +662,6 @@ async def test_command_social_add_friend(lobbyconnection, mock_player, database)
 async def test_command_social_remove_friend(lobbyconnection, mock_player, database):
     lobbyconnection.player = mock_player
     lobbyconnection.player.id = 2
-    lobbyconnection._authenticated = True
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == [1]
@@ -702,7 +676,6 @@ async def test_command_social_remove_friend(lobbyconnection, mock_player, databa
 
 
 async def test_broadcast(lobbyconnection: LobbyConnection, mocker):
-    mocker.patch.object(lobbyconnection, 'protocol')
     player = mocker.patch.object(lobbyconnection, 'player')
     player.login = 'Sheeo'
     player.admin = True
@@ -710,7 +683,7 @@ async def test_broadcast(lobbyconnection: LobbyConnection, mocker):
     tuna.id = 55
     lobbyconnection.player_service = [player, tuna]
 
-    await lobbyconnection.command_admin({
+    await lobbyconnection.on_message_received({
         'command': 'admin',
         'action': 'broadcast',
         'message': "This is a test message"
@@ -721,16 +694,18 @@ async def test_broadcast(lobbyconnection: LobbyConnection, mocker):
 
 
 async def test_game_connection_not_restored_if_no_such_game_exists(lobbyconnection: LobbyConnection, mocker, mock_player):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
     lobbyconnection.player = mock_player
     del lobbyconnection.player.game_connection
     lobbyconnection.player.state = PlayerState.IDLE
-    lobbyconnection.command_restore_game_session({'game_id': 123})
+    await lobbyconnection.on_message_received({
+        'command': 'restore_game_session',
+        'game_id': 123
+    })
 
     assert not lobbyconnection.player.game_connection
     assert lobbyconnection.player.state == PlayerState.IDLE
 
-    protocol.send_message.assert_any_call({
+    lobbyconnection.protocol.send_message.assert_any_call({
         "command": "notice",
         "style": "info",
         "text": "The game you were connected to does no longer exist"
@@ -741,7 +716,6 @@ async def test_game_connection_not_restored_if_no_such_game_exists(lobbyconnecti
 async def test_game_connection_not_restored_if_game_state_prohibits(lobbyconnection: LobbyConnection, game_service: GameService,
                                                                     game_stats_service, game_state, mock_player, mocker,
                                                                     database):
-    protocol = mocker.patch.object(lobbyconnection, 'protocol')
     lobbyconnection.player = mock_player
     del lobbyconnection.player.game_connection
     lobbyconnection.player.state = PlayerState.IDLE
@@ -753,12 +727,15 @@ async def test_game_connection_not_restored_if_game_state_prohibits(lobbyconnect
     game.id = 42
     game_service.games[42] = game
 
-    lobbyconnection.command_restore_game_session({'game_id': 42})
+    await lobbyconnection.on_message_received({
+        'command': 'restore_game_session',
+        'game_id': 42
+    })
 
     assert not lobbyconnection.game_connection
     assert lobbyconnection.player.state == PlayerState.IDLE
 
-    protocol.send_message.assert_any_call({
+    lobbyconnection.protocol.send_message.assert_any_call({
         "command": "notice",
         "style": "info",
         "text": "The game you were connected to is no longer available"
@@ -779,7 +756,10 @@ async def test_game_connection_restored_if_game_exists(lobbyconnection: LobbyCon
     game.id = 42
     game_service.games[42] = game
 
-    lobbyconnection.command_restore_game_session({'game_id': 42})
+    await lobbyconnection.on_message_received({
+        'command': 'restore_game_session',
+        'game_id': 42
+    })
 
     assert lobbyconnection.game_connection
     assert lobbyconnection.player.state == PlayerState.PLAYING
@@ -788,7 +768,6 @@ async def test_game_connection_restored_if_game_exists(lobbyconnection: LobbyCon
 async def test_command_game_matchmaking(lobbyconnection, mock_player):
     lobbyconnection.player = mock_player
     lobbyconnection.player.id = 1
-    lobbyconnection._authenticated = True
 
     await lobbyconnection.on_message_received({
         'command': 'game_matchmaking',

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -154,6 +154,16 @@ async def test_bad_command_calls_abort(lobbyconnection):
     lobbyconnection.abort.assert_called_once_with("Error processing command")
 
 
+async def test_command_pong_does_nothing(lobbyconnection):
+    lobbyconnection.send = CoroutineMock()
+
+    await lobbyconnection.on_message_received({
+        "command": "pong"
+    })
+
+    lobbyconnection.send.assert_not_called()
+
+
 async def test_command_create_account_returns_error(lobbyconnection):
     lobbyconnection.send = CoroutineMock()
 


### PR DESCRIPTION
This refactors the old callback interface for message sending to use async/await native instead. Not only is the coroutine interface cleaner and more intuitive, it also helps to ensure that the code behaves as we expect it to (for instance backpressure handling) without us needing to even think about edge cases.

Also adds a few additional test cases.