### PR TITLE
Don't echo DB operations to log

### DIFF
--- a/server/db/__init__.py
+++ b/server/db/__init__.py
@@ -7,8 +7,7 @@ class FAFDatabase:
         self.engine = None
 
     async def connect(self, host='localhost', port=3306, user='root',
-                      password='', db='faf_test', minsize=1, maxsize=1,
-                      echo=True):
+                      password='', db='faf_test', minsize=1, maxsize=1):
         if self.engine is not None:
             raise ValueError("DB is already connected!")
         self.engine = await create_engine(
@@ -21,7 +20,6 @@ class FAFDatabase:
             loop=self._loop,
             minsize=minsize,
             maxsize=maxsize,
-            echo=echo
         )
 
     def acquire(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,8 +103,7 @@ class MockDatabase:
         self._done = Event()
 
     async def connect(self, host='localhost', port=3306, user='root',
-                      password='', db='faf_test', minsize=1, maxsize=1,
-                      echo=True):
+                      password='', db='faf_test', minsize=1, maxsize=1):
         if self.engine is not None:
             raise ValueError("DB is already connected!")
         self.engine = await create_engine(
@@ -117,7 +116,7 @@ class MockDatabase:
             loop=self._loop,
             minsize=minsize,
             maxsize=maxsize,
-            echo=echo
+            echo=True
         )
         self._keep = self._loop.create_task(self._keep_connection())
         await self._conn_present.wait()


### PR DESCRIPTION
This makes the log slightly less informative, but no longer leaks
sensitive info, so we can actually access the thing without huge hassle.

Signed-off-by: Igor Kotrasinski <i.kotrasinsk@gmail.com>