### PR TITLE
Issue/#503 contact policy server

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -528,13 +528,15 @@ class LobbyConnection():
                     "player_id": player_id
                 })
 
-            if not self.player_service.is_uniqueid_exempt(player_id):
-                conforms_policy = await self.check_policy_conformity(
-                    player_id, message['unique_id'], self.session,
-                    ignore_result=steamid is not None
+            conforms_policy = await self.check_policy_conformity(
+                player_id, message['unique_id'], self.session,
+                ignore_result=(
+                    steamid is not None or
+                    self.player_service.is_uniqueid_exempt(player_id)
                 )
-                if not conforms_policy:
-                    return
+            )
+            if not conforms_policy:
+                return
 
             # Update the user's IRC registration (why the fuck is this here?!)
             m = hashlib.md5()

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -1,14 +1,15 @@
-insert into login (id, login, email, password, create_time) values
-    (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), '2000-01-01 00:00:00'),
-    (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), '2000-01-01 00:00:00'),
-    (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), '2000-01-01 00:00:00'),
-    (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), '2000-01-01 00:00:00'),
-    (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), '2000-01-01 00:00:00'),
-    (102, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), '2000-01-01 00:00:00'),
-    (200, 'banme', 'banme@example.com', SHA2('banme', 256), '2000-01-01 00:00:00'),
-    (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), '2000-01-01 00:00:00'),
-    (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), '2000-01-01 00:00:00'),
-    (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), '2000-01-01 00:00:00')
+insert into login (id, login, email, password, steamid, create_time) values
+    (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
+    (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null,  '2000-01-01 00:00:00'),
+    (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
+    (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
+    (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
+    (102, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
+    (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
+    (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
+    (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
+    (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
+    (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
 ;
 
 delete from clan_membership where player_id = 50;

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -30,28 +30,34 @@ def ladder_service(mocker, database, game_service):
 
 
 @pytest.fixture
-def lobby_server(request, event_loop, database, player_service, game_service,
-                 geoip_service, ladder_service):
-    ctx = run_lobby_server(
-        address=('127.0.0.1', None),
-        database=database,
-        geoip_service=geoip_service,
-        player_service=player_service,
-        games=game_service,
-        ladder_service=ladder_service,
-        nts_client=None,
-        loop=event_loop
-    )
-    player_service.is_uniqueid_exempt = lambda id: True
+def lobby_server(
+    request, event_loop, database, player_service, game_service,
+    geoip_service, ladder_service, policy_server
+):
+    with mock.patch(
+        'server.lobbyconnection.FAF_POLICY_SERVER_BASE_URL',
+        f'http://{policy_server.host}:{policy_server.port}'
+    ):
+        ctx = run_lobby_server(
+            address=('127.0.0.1', None),
+            database=database,
+            geoip_service=geoip_service,
+            player_service=player_service,
+            games=game_service,
+            ladder_service=ladder_service,
+            nts_client=None,
+            loop=event_loop
+        )
+        player_service.is_uniqueid_exempt = lambda id: True
 
-    def fin():
-        ctx.close()
-        ladder_service.shutdown_queues()
-        event_loop.run_until_complete(ctx.wait_closed())
+        def fin():
+            ctx.close()
+            ladder_service.shutdown_queues()
+            event_loop.run_until_complete(ctx.wait_closed())
 
-    request.addfinalizer(fin)
+        request.addfinalizer(fin)
 
-    return ctx
+        yield ctx
 
 
 @pytest.fixture

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -91,10 +91,17 @@ async def test_server_valid_login(lobby_server):
                    'login': 'test'}
 
 
-async def test_policy_server_contacted(lobby_server, policy_server, player_service):
+@pytest.mark.parametrize("user", [
+    ("test", "test_password"),
+    ("ban_revoked", "ban_revoked"),
+    ("ban_expired", "ban_expired"),
+    ("No_UID", "his_pw"),
+    ("steam_id", "steam_id")
+])
+async def test_policy_server_contacted(lobby_server, policy_server, player_service, user):
     player_service.is_uniqueid_exempt = lambda _: False
 
-    _, _, proto = await connect_and_sign_in(("steam_id", "steam_id"), lobby_server)
+    _, _, proto = await connect_and_sign_in(user, lobby_server)
     await read_until_command(proto, 'game_info')
 
     policy_server.verify.assert_called_once()

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -94,14 +94,10 @@ async def test_server_valid_login(lobby_server):
 async def test_policy_server_contacted(lobby_server, policy_server, player_service):
     player_service.is_uniqueid_exempt = lambda _: False
 
-    with mock.patch(
-        'server.lobbyconnection.FAF_POLICY_SERVER_BASE_URL',
-        f'http://{policy_server.host}:{policy_server.port}'
-    ):
-        _, _, proto = await connect_and_sign_in(("steam_id", "steam_id"), lobby_server)
-        await read_until_command(proto, 'game_info')
+    _, _, proto = await connect_and_sign_in(("steam_id", "steam_id"), lobby_server)
+    await read_until_command(proto, 'game_info')
 
-        policy_server.verify.assert_called_once()
+    policy_server.verify.assert_called_once()
 
 
 async def test_server_double_login(lobby_server):


### PR DESCRIPTION
We always contact the policy server on login, but if the user has linked their account to steam, or is in the unique id exempt list, then the result is ignored.

Closes #503.