### PR TITLE
Issue/#346 game length too long

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -83,8 +83,8 @@ class GameConnection(GpgNetServerProtocol):
         """
         message['target'] = "game"
 
-        await self.protocol.send_message(message)
         self._logger.log(TRACE, ">> %s: %s", self.player.login, message)
+        await self.protocol.send_message(message)
 
     async def _handle_idle_state(self):
         """

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -278,20 +278,10 @@ class GameConnection(GpgNetServerProtocol):
 
     async def handle_game_result(self, army, result):
         army = int(army)
-        result = str(result)
+        result = str(result).lower()
         try:
-            if not any([result.startswith(possible_result)
-                        for possible_result in ['score', 'defeat', 'victory', 'draw']]):
-                raise ValueError()  # pragma: no cover
-            result = result.split(' ')
-
-            # This is the most common way for the player's sim to end
-            # We should add a reliable message to lua in the future
-            if result[0] in ['victory', 'draw'] and not self.finished_sim:
-                self.finished_sim = True
-                await self.game.check_sim_end()
-
-            await self.game.add_result(self.player.id, army, result[0], int(result[1]))
+            label, score = result.split(" ")
+            await self.game.add_result(self.player.id, army, label, int(score))
         except (KeyError, ValueError):  # pragma: no cover
             self._logger.warning("Invalid result for %s reported: %s", army, result)
 
@@ -485,10 +475,10 @@ class GameConnection(GpgNetServerProtocol):
 
     async def handle_game_ended(self, *args):
         """
-        Signals that the simulation has ended. This is currently unused but
-        included for documentation purposes.
+        Signals that the simulation has ended.
         """
-        pass
+        self.finished_sim = True
+        await self.game.check_sim_end()
 
     async def handle_rehost(self, *args):
         """

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -480,6 +480,9 @@ class GameConnection(GpgNetServerProtocol):
         self.finished_sim = True
         await self.game.check_sim_end()
 
+        if self.game.ended:
+            await self.game.on_game_end()
+
     async def handle_rehost(self, *args):
         """
         Signals that the user has rehosted the game. This is currently unused but

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -312,6 +312,7 @@ class Game:
         :param result_type: a string representing the result
         :param score: an arbitrary number assigned with the result
         :return:
+        :raises: ValueError on invalid result_type
         """
         if army not in self.armies:
             self._logger.debug(
@@ -320,9 +321,10 @@ class Game:
             )
             return
 
-        result = GameResult(
-            reporter, army, GameOutcome.from_message(result_type), score
-        )
+        if result_type == "score":
+            result_type = "unknown"
+
+        result = GameResult(reporter, army, GameOutcome(result_type), score)
         self._results.add(result)
         self._logger.info(
             "%s reported result for army %s: %s %s", reporter, army,

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -401,7 +401,9 @@ class Game:
             return (game_connection.player == self.host and
                     self.state is not GameState.LIVE)
 
-        if len(self._connections) == 0 or host_left_lobby():
+        if self.state is not GameState.ENDED and (
+            len(self._connections) == 0 or host_left_lobby()
+        ):
             await self.on_game_end()
         else:
             await self._process_pending_army_stats()

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -312,7 +312,6 @@ class Game:
         :param result_type: a string representing the result
         :param score: an arbitrary number assigned with the result
         :return:
-        :raises: ValueError on invalid result_type
         """
         if army not in self.armies:
             self._logger.debug(
@@ -321,10 +320,12 @@ class Game:
             )
             return
 
-        if result_type == "score":
-            result_type = "unknown"
+        try:
+            outcome = GameOutcome(result_type)
+        except ValueError:
+            outcome = GameOutcome.UNKNOWN
 
-        result = GameResult(reporter, army, GameOutcome(result_type), score)
+        result = GameResult(reporter, army, outcome, score)
         self._results.add(result)
         self._logger.info(
             "%s reported result for army %s: %s %s", reporter, army,

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -14,13 +14,6 @@ class GameOutcome(Enum):
     UNKNOWN = 'unknown'
     CONFLICTING = 'conflicting'
 
-    @classmethod
-    def from_message(cls, msg: str):
-        try:
-            return cls(msg.lower())
-        except ValueError:
-            return cls.UNKNOWN
-
 
 class GameResult(NamedTuple):
     """

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -999,8 +999,8 @@ class LobbyConnection:
         :param message:
         :return:
         """
-        await self.protocol.send_message(message)
         self._logger.log(TRACE, ">> %s: %s", self.get_user_identifier(), message)
+        await self.protocol.send_message(message)
 
     async def drain(self):
         # TODO: Remove me, QDataStreamProtocol no longer has a drain method

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -50,11 +50,11 @@ class ServerContext:
         return connection in self.connections.keys()
 
     def write_broadcast(self, message, validate_fn=lambda a: True):
+        self._logger.log(TRACE, "]]: %s", message)
         self.write_broadcast_raw(
             QDataStreamProtocol.encode_message(message),
             validate_fn
         )
-        self._logger.log(TRACE, "]]: %s", message)
 
     def write_broadcast_raw(self, data, validate_fn=lambda a: True):
         metrics.server_broadcasts.inc()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -158,8 +158,15 @@ async def read_until(
             pass
 
 
-async def read_until_command(proto: QDataStreamProtocol, command: str) -> Dict[str, Any]:
-    return await read_until(proto, lambda msg: msg.get('command') == command)
+async def read_until_command(
+    proto: QDataStreamProtocol,
+    command: str,
+    timeout: float = 60
+) -> Dict[str, Any]:
+    return await asyncio.wait_for(
+        read_until(proto, lambda msg: msg.get('command') == command),
+        timeout=timeout
+    )
 
 
 async def get_session(proto):

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 from aiohttp import web
+from asynctest import exhaust_callbacks
 from server import GameService, PlayerService, run_lobby_server
 from server.db.models import login
 from server.ladder_service import LadderService
@@ -56,6 +57,7 @@ def lobby_server(
             ctx.close()
             ladder_service.shutdown_queues()
             event_loop.run_until_complete(ctx.wait_closed())
+            event_loop.run_until_complete(exhaust_callbacks(event_loop))
 
         request.addfinalizer(fin)
 

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 import pytest
-from server.protocol import DisconnectedError, QDataStreamProtocol
+from server.protocol import QDataStreamProtocol
 from tests.utils import fast_forward
 
 from .conftest import connect_and_sign_in, read_until_command

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -53,6 +53,8 @@ async def join_game(proto: QDataStreamProtocol, uid: int):
         "command": "GameState",
         "args": ["Lobby"]
     })
+    # HACK: Yield long enough for the server to process our message
+    await asyncio.sleep(0.5)
 
 
 async def get_player_ratings(proto, *names):
@@ -152,7 +154,4 @@ async def test_game_ended_rates_game(lobby_server):
 
     # The game should only be rated once
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(
-            read_until_command(host_proto, "player_info"),
-            timeout=10
-        )
+        await read_until_command(host_proto, "player_info", timeout=10)

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -1,0 +1,158 @@
+import asyncio
+import logging
+
+import pytest
+from server.protocol import DisconnectedError, QDataStreamProtocol
+from tests.utils import fast_forward
+
+from .conftest import connect_and_sign_in, read_until_command
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+async def host_game(proto: QDataStreamProtocol) -> int:
+    await proto.send_message({
+        "command": "game_host",
+        "mod": "faf",
+        "visibility": "public"
+    })
+    msg = await read_until_command(proto, "game_launch")
+    game_id = int(msg["uid"])
+
+    # Simulate FA opening
+    await proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Idle"]
+    })
+    await proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Lobby"]
+    })
+
+    return game_id
+
+
+async def join_game(proto: QDataStreamProtocol, uid: int):
+    await proto.send_message({
+        "command": "game_join",
+        "uid": uid
+    })
+    await read_until_command(proto, "game_launch")
+
+    # Simulate FA opening
+    await proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Idle"]
+    })
+    await proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Lobby"]
+    })
+
+
+async def get_player_ratings(proto, *names):
+    """
+    Wait for `player_info` messages until all player names have been found.
+    Then return a dictionary containing all those players ratings
+    """
+    ratings = {}
+    while set(ratings.keys()) != set(names):
+        msg = await read_until_command(proto, "player_info")
+        ratings.update({
+            player_info["login"]: player_info["global_rating"]
+            for player_info in msg["players"]
+        })
+    return ratings
+
+
+async def send_player_options(proto, *options):
+    for option in options:
+        await proto.send_message({
+            "target": "game",
+            "command": "PlayerOption",
+            "args": list(option)
+        })
+
+
+@fast_forward(20)
+async def test_game_ended_rates_game(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    await read_until_command(host_proto, "game_info")
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(guest_proto, "game_info")
+    ratings = await get_player_ratings(host_proto, "test", "Rhiza")
+
+    # Set up the game
+    game_id = await host_game(host_proto)
+    await join_game(guest_proto, game_id)
+    # Set player options
+    await send_player_options(
+        host_proto,
+        [host_id, "Army", 1],
+        [host_id, "Team", 1],
+        [guest_id, "Army", 2],
+        [guest_id, "Team", 1]
+    )
+
+    # Launch game
+    await host_proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Launching"]
+    })
+    await host_proto.send_message({
+        "target": "game",
+        "command": "EnforceRating",
+        "args": []
+    })
+
+    # End the game
+    # Reports results
+    for proto in (host_proto, guest_proto):
+        await proto.send_message({
+            "target": "game",
+            "command": "GameResult",
+            "args": [1, "victory 10"]
+        })
+        await proto.send_message({
+            "target": "game",
+            "command": "GameResult",
+            "args": [2, "defeat -10"]
+        })
+    # Report GameEnded
+    for proto in (host_proto, guest_proto):
+        await proto.send_message({
+            "target": "game",
+            "command": "GameEnded",
+            "args": []
+        })
+
+    # Check that the ratings were updated
+    new_ratings = await get_player_ratings(host_proto, "test", "Rhiza")
+
+    assert ratings["test"][0] < new_ratings["test"][0]
+    assert ratings["Rhiza"][0] > new_ratings["Rhiza"][0]
+
+    # Now disconnect both players
+    for proto in (host_proto, guest_proto):
+        await proto.send_message({
+            "target": "game",
+            "command": "GameState",
+            "args": ["Ended"]
+        })
+
+    # The game should only be rated once
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            read_until_command(host_proto, "player_info"),
+            timeout=10
+        )

--- a/tests/integration_tests/test_load.py
+++ b/tests/integration_tests/test_load.py
@@ -69,8 +69,9 @@ async def test_game_info_broadcast_on_connection_error(
     # Set up our game hosts
     host_protos = []
     for _ in range(NUM_HOSTS):
+        user = await tmp_user("Host")
         _, _, proto = await connect_and_sign_in(
-            await tmp_user("Host"), lobby_server
+            user, lobby_server
         )
         host_protos.append(proto)
     await asyncio.gather(*(

--- a/tests/integration_tests/test_load.py
+++ b/tests/integration_tests/test_load.py
@@ -42,6 +42,7 @@ async def write_without_reading(proto):
             "command": "matchmaker_info",
             "This is just to increase the message size": "DATA" * 1024
         })
+        await asyncio.sleep(0)
 
     pytest.fail("The server did not apply backpressure to a spammer")
 

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -1,10 +1,10 @@
-import pytest
 import time
 
+import pytest
 from server.games import CustomGame
 from server.games.game import GameState, ValidityState
-from tests.unit_tests.conftest import add_connected_players
 from server.rating import RatingType
+from tests.unit_tests.conftest import add_connected_players
 
 pytestmark = pytest.mark.asyncio
 
@@ -26,7 +26,7 @@ async def test_rate_game_early_abort_no_enforce(
     custom_game.set_player_option(1, 'Team', 2)
     custom_game.set_player_option(2, 'Team', 3)
     await custom_game.launch()
-    await custom_game.add_result(0, 1, 'VICTORY', 5)
+    await custom_game.add_result(0, 1, 'victory', 5)
 
     custom_game.launched_at = time.time() - 60  # seconds
 
@@ -46,7 +46,7 @@ async def test_rate_game_early_abort_with_enforce(
     custom_game.set_player_option(2, 'Team', 3)
     await custom_game.launch()
     custom_game.enforce_rating = True
-    await custom_game.add_result(0, 1, 'VICTORY', 5)
+    await custom_game.add_result(0, 1, 'victory', 5)
 
     custom_game.launched_at = time.time() - 60  # seconds
 
@@ -65,7 +65,7 @@ async def test_rate_game_late_abort_no_enforce(
     custom_game.set_player_option(1, 'Team', 2)
     custom_game.set_player_option(2, 'Team', 3)
     await custom_game.launch()
-    await custom_game.add_result(0, 1, 'VICTORY', 5)
+    await custom_game.add_result(0, 1, 'victory', 5)
 
     custom_game.launched_at = time.time() - 600     # seconds
 

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -117,7 +117,7 @@ async def test_ffa_not_rated(game, game_add_players):
     game.state = GameState.LOBBY
     game_add_players(game, 5, team=1)
     await game.launch()
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     game.launched_at = time.time() - 60 * 20    # seconds
     await game.on_game_end()
     assert game.validity == ValidityState.FFA_NOT_RANKED
@@ -127,7 +127,7 @@ async def test_two_player_ffa_is_rated(game, game_add_players):
     game.state = GameState.LOBBY
     game_add_players(game, 2, team=1)
     await game.launch()
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     game.launched_at = time.time() - 60 * 20    # seconds
     await game.on_game_end()
     assert game.validity == ValidityState.VALID
@@ -139,7 +139,7 @@ async def test_multi_team_not_rated(game, game_add_players):
     game_add_players(game, 2, team=3)
     game_add_players(game, 2, team=4)
     await game.launch()
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     game.launched_at = time.time() - 60 * 20    # seconds
     await game.on_game_end()
     assert game.validity == ValidityState.MULTI_TEAM
@@ -161,7 +161,7 @@ async def test_has_ai_players_not_rated(game, game_add_players):
         }
     }
     await game.launch()
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     game.launched_at = time.time() - 60 * 20    # seconds
     await game.on_game_end()
     assert game.validity == ValidityState.HAS_AI_PLAYERS
@@ -172,7 +172,7 @@ async def test_uneven_teams_not_rated(game, game_add_players):
     game_add_players(game, 2, team=2)
     game_add_players(game, 3, team=3)
     await game.launch()
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     game.launched_at = time.time() - 60 * 20    # seconds
     await game.on_game_end()
     assert game.validity == ValidityState.UNEVEN_TEAMS_NOT_RANKED
@@ -816,7 +816,7 @@ async def test_persist_results_not_called_with_one_player(
     add_connected_players(game, players)
     await game.launch()
     assert len(game.players) == 1
-    await game.add_result(0, 1, 'VICTORY', 5)
+    await game.add_result(0, 1, 'victory', 5)
     await game.on_game_end()
 
     game.persist_results.assert_not_called()

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -113,6 +113,14 @@ async def check_game_settings(
         game.gameOptions[key] = old
 
 
+async def test_add_result_unknown(game, game_add_players):
+    game.state = GameState.LOBBY
+    players = game_add_players(game, 5, team=1)
+    await game.launch()
+    await game.add_result(0, 1, 'something invalid', 5)
+    assert game.get_player_outcome(players[0]) is GameOutcome.UNKNOWN
+
+
 async def test_ffa_not_rated(game, game_add_players):
     game.state = GameState.LOBBY
     game_add_players(game, 5, team=1)

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -405,10 +405,24 @@ async def test_handle_action_GameEnded_ends_sim(
     game: Game,
     game_connection: GameConnection
 ):
+    game.ended = False
     await game_connection.handle_action('GameEnded', [])
 
     assert game_connection.finished_sim
-    assert game.check_sim_end.called
+    game.check_sim_end.assert_called_once()
+    game.on_game_end.assert_not_called()
+
+
+async def test_handle_action_GameEnded_ends_game(
+    game: Game,
+    game_connection: GameConnection
+):
+    game.ended = True
+    await game_connection.handle_action('GameEnded', [])
+
+    assert game_connection.finished_sim
+    game.check_sim_end.assert_called_once()
+    game.on_game_end.assert_called_once()
 
 
 async def test_handle_action_OperationComplete(ugame: Game, game_connection: GameConnection, database):

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -401,23 +401,11 @@ async def test_handle_action_TeamkillHappened_AI(game: Game, game_connection: Ga
     game_connection.abort.assert_not_called()
 
 
-async def test_handle_action_GameResult_victory_ends_sim(
+async def test_handle_action_GameEnded_ends_sim(
     game: Game,
     game_connection: GameConnection
 ):
-    game_connection.connect_to_host = CoroutineMock()
-    await game_connection.handle_action('GameResult', [0, 'victory'])
-
-    assert game_connection.finished_sim
-    assert game.check_sim_end.called
-
-
-async def test_handle_action_GameResult_draw_ends_sim(
-    game: Game,
-    game_connection: GameConnection
-):
-    game_connection.connect_to_host = CoroutineMock()
-    await game_connection.handle_action('GameResult', [0, 'draw'])
+    await game_connection.handle_action('GameEnded', [])
 
     assert game_connection.finished_sim
     assert game.check_sim_end.called


### PR DESCRIPTION
Instead of relying on players sending a `victory` or `draw` score (which sometimes doesn't happen) for deciding when the game is over and ready to be rated, use the `GameEnded` message. Hopefully this message is always sent when the sim ends. 

This PR also allows `mutual_draw` as a valid game result, which was accepted by the Game class, but would never make it to that point as `GameConnection` was denying it.

Scenarios we should test:
- [x] One player is defeated, but the game continues on. When does that player send `GameEnded`?
    - *It is sent at the end by all players when the sim finishes*
    - *It is send BEFORE the score screen*
- [x] Game ends in mutual_draw.
- [x] Game ends in mutual ACU explosion.
- [ ] What happens in a ladder game?

Fixes #346
Fixes #263 
Closes #316