### PR TITLE
Issue/#513 New geoip database download URL

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -52,8 +52,9 @@ COTURN_KEYS = os.getenv('COTURN_KEYS', "").split(',')
 GEO_IP_DATABASE_PATH = os.getenv("GEO_IP_DATABASE_PATH", "GeoLite2-Country.mmdb")
 GEO_IP_DATABASE_URL = os.getenv(
     "GEO_IP_DATABASE_URL",
-    "http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz"
+    "https://download.maxmind.com/app/geoip_download"
 )
+GEO_IP_LICENSE_KEY = os.getenv("GEO_IP_LICENSE_KEY")
 GEO_IP_DATABASE_MAX_AGE_DAYS = int(os.getenv('GEO_IP_DATABASE_MAX_AGE_DAYS', 22))
 
 CONTROL_SERVER_PORT = int(os.getenv('CONTROL_SERVER_PORT', 4000))

--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -1,7 +1,8 @@
 import asyncio
-import gzip
+import hashlib
 import os
 import shutil
+import tarfile
 from datetime import datetime
 
 import aiocron
@@ -69,23 +70,45 @@ class GeoIpService(object):
             Download the geoip database to a file. If the downloaded file is not
         a valid gzip file, then it does NOT overwrite the old file.
         """
+        if not config.GEO_IP_LICENSE_KEY:
+            self._logger.warning(
+                "GEO_IP_LICENSE_KEY not set! Unable to download GeoIP database!"
+            )
+            return
 
         self._logger.info("Downloading new geoip database")
 
         # Download new file to a temp location
-        temp_file_path = "/tmp/geoip.mmdb.gz"
-        await self._download_file(config.GEO_IP_DATABASE_URL, temp_file_path)
+        temp_file_path = "/tmp/geoip.mmdb.tar.gz"
+        await self._download_file(
+            config.GEO_IP_DATABASE_URL,
+            config.GEO_IP_LICENSE_KEY,
+            temp_file_path
+        )
+
+        def get_db_member(tar: tarfile.TarFile) -> str:
+            for name in tar.getnames():
+                if name.endswith("GeoLite2-Country.mmdb"):
+                    return name
+
+            # Because we verified the checksum earlier, this should only be
+            # possible if maxmind actually served us a bad file
+            raise Exception("Tar archive did not contain the database file!")
 
         # Unzip the archive and overwrite the old file
         try:
-            with gzip.open(temp_file_path, 'rb') as f_in:
+            with tarfile.open(temp_file_path, 'r:gz') as tar:
+                name = get_db_member(tar)
                 with open(self.file_path, 'wb') as f_out:
+                    f_in = tar.extractfile(name)
+                    assert f_in is not None
                     shutil.copyfileobj(f_in, f_out)
-        except OSError:    # pragma: no cover
-            self._logger.warning("Failed to unzip downloaded file!")
+        except (tarfile.TarError) as e:    # pragma: no cover
+            self._logger.warning("Failed to extract downloaded file!")
+            raise e
         self._logger.info("New database download complete")
 
-    async def _download_file(self, url: str, file_path: str) -> None:
+    async def _download_file(self, url: str, license_key: str, file_path: str) -> None:
         """
             Download a file using aiohttp and save it to a file.
 
@@ -94,14 +117,42 @@ class GeoIpService(object):
         """
 
         chunk_size = 1024
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=60 * 20) as resp:
+        params = {
+            "edition_id": "GeoLite2-Country",
+            "license_key": license_key,
+            "suffix": "tar.gz"
+        }
+
+        async def get_checksum(session):
+            async with session.get(url, params={
+                **params,
+                "suffix": f"{params['suffix']}.md5"
+            }, timeout=60 * 20) as resp:
+                return await resp.text()
+
+        async def get_db_file_with_checksum(session):
+            hasher = hashlib.md5()
+            async with session.get(url, params=params, timeout=60 * 20) as resp:
                 with open(file_path, 'wb') as f:
                     while True:
                         chunk = await resp.content.read(chunk_size)
                         if not chunk:
                             break
                         f.write(chunk)
+                        hasher.update(chunk)
+
+            return hasher.hexdigest()
+
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
+            checksum, our_hash = await asyncio.gather(
+                get_checksum(session),
+                get_db_file_with_checksum(session)
+            )
+
+        if checksum != our_hash:
+            raise Exception(
+                f"Hashes did not match! Expected {checksum} got {our_hash}"
+            )
 
     def load_db(self) -> None:
         """

--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -41,6 +41,11 @@ class GeoIpService(object):
         """
             Check if the geoip database is old and update it if so.
         """
+        if not config.GEO_IP_LICENSE_KEY:
+            self._logger.warning(
+                "GEO_IP_LICENSE_KEY not set! Unable to download GeoIP database!"
+            )
+            return
 
         self._logger.debug("Checking if geoip database needs updating")
         try:
@@ -71,11 +76,7 @@ class GeoIpService(object):
             Download the geoip database to a file. If the downloaded file is not
         a valid gzip file, then it does NOT overwrite the old file.
         """
-        if not config.GEO_IP_LICENSE_KEY:
-            self._logger.warning(
-                "GEO_IP_LICENSE_KEY not set! Unable to download GeoIP database!"
-            )
-            return
+        assert config.GEO_IP_LICENSE_KEY is not None
 
         self._logger.info("Downloading new geoip database")
 

--- a/tests/unit_tests/test_geoip_service.py
+++ b/tests/unit_tests/test_geoip_service.py
@@ -29,7 +29,10 @@ async def test_check_update(fake_geoip_service, fake_geoip_path):
     # Set the modified time to unixtime 0
     with open(fake_geoip_path, 'a'):
         os.utime(fake_geoip_path, (0, 0))
+
     server.config.GEO_IP_DATABASE_MAX_AGE_DAYS = 32
+    server.config.GEO_IP_LICENSE_KEY = "Anything"
+
     fake_geoip_service.load_db = Mock()
     fake_geoip_service.download_geoip_db.reset_mock()
 

--- a/tests/unit_tests/test_geoip_service.py
+++ b/tests/unit_tests/test_geoip_service.py
@@ -1,7 +1,9 @@
-import gzip
+import hashlib
 import os
 import random
 import string
+import tarfile
+from io import BytesIO
 from unittest.mock import Mock
 
 import pytest
@@ -39,14 +41,31 @@ async def test_check_update(fake_geoip_service, fake_geoip_path):
 async def test_do_update(fake_geoip_service, fake_geoip_path):
     # Config variables
     PORT = 8137
-    server.config.GEO_IP_DATABASE_URL = 'http://localhost:{}'.format(PORT)
+    server.config.GEO_IP_DATABASE_URL = f"http://localhost:{PORT}"
+    server.config.GEO_IP_LICENSE_KEY = "Anything"
     random_text = ''.join(random.choice(string.ascii_letters) for i in range(20))
+
+    data = BytesIO()
+    tar = tarfile.open(fileobj=data, mode="w:gz")
+    tarinfo = tarfile.TarInfo("GeoLite2-Country.mmdb")
+    tarinfo.size = len(random_text)
+    tar.addfile(tarinfo, BytesIO(random_text.encode()))
+    tar.close()
+    data.seek(0)
+
+    tarred_text = data.read()
+    checksum = hashlib.md5(tarred_text).hexdigest()
 
     # Set up local http server for geoip service to connect to
     async def file_download(request):
+        # md5 hash
+        if request.rel_url.query.get("suffix").endswith("md5"):
+            return web.Response(text=checksum)
+
+        # Fake database
         resp = web.StreamResponse()
         await resp.prepare(request)
-        await resp.write(gzip.compress(random_text.encode()))
+        await resp.write(tarred_text)
         await resp.write_eof()
         return resp
 


### PR DESCRIPTION
Updated the geoip url and added a license key parameter. The license key does not have a default and must be set by a server admin in order for the new database to be downloaded.

The database is now served via a `tar.gz` which contains a copyright and a license text as well as the database. The server now downloads the archive and compares its checksum against the md5 hash available at the same url. Once the archive has been successfully downloaded, the database file is extracted from the archive and copied over the old version of the file (if it exists).

Closes #513 