### PR TITLE
Await async sending functions in command_admin

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -352,8 +352,6 @@ class LobbyConnection:
                         }))
 
                 await asyncio.gather(*tasks, return_exceptions=True)
-        else:
-            self._logger.debug("Wrong premissions!")
 
     async def check_user_login(self, conn, username, password):
         # TODO: Hash passwords server-side so the hashing actually *does* something.

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -274,7 +274,7 @@ class LobbyConnection:
                 player = self.player_service[message['user_id']]
                 if player:
                     self._logger.warning('Administrative action: %s closed game for %s', self.player, player)
-                    player.lobby_connection.send({
+                    await player.lobby_connection.send({
                         "command": "notice",
                         "style": "kill",
                     })
@@ -320,30 +320,39 @@ class LobbyConnection:
                                 raise ClientError('Your ban attempt upset the database: {}'.format(e))
                     else:
                         self._logger.warning('Administrative action: %s closed client for %s', self.player, player)
-                    player.lobby_connection.kick()
+                    await player.lobby_connection.kick()
                     if ban_fail:
                         raise ClientError("Kicked the player, but he was already banned!")
 
             elif action == "broadcast":
+                message_text = message.get('message')
+                if not message_text:
+                    return
+
                 for player in self.player_service:
                     try:
                         if player.lobby_connection:
-                            await player.lobby_connection.send_warning(message.get('message'))
+                            await player.lobby_connection.send_warning(message_text)
                     except Exception as ex:
                         self._logger.debug("Could not send broadcast message to %s: %s".format(player, ex))
 
-        elif self.player.mod:
+        if self.player.mod:
             if action == "join_channel":
                 user_ids = message['user_ids']
                 channel = message['channel']
 
+                tasks = []
                 for user_id in user_ids:
-                    player = self.player_service[message[user_id]]
+                    player = self.player_service[user_id]
                     if player:
-                        player.lobby_connection.send({
+                        tasks.append(player.lobby_connection.send({
                             "command": "social",
                             "autojoin": [channel]
-                        })
+                        }))
+
+                await asyncio.gather(*tasks)
+        else:
+            self._logger.debug("Wrong premissions!")
 
     async def check_user_login(self, conn, username, password):
         # TODO: Hash passwords server-side so the hashing actually *does* something.

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -329,12 +329,13 @@ class LobbyConnection:
                 if not message_text:
                     return
 
+                tasks = []
                 for player in self.player_service:
-                    try:
-                        if player.lobby_connection:
-                            await player.lobby_connection.send_warning(message_text)
-                    except Exception as ex:
-                        self._logger.debug("Could not send broadcast message to %s: %s".format(player, ex))
+                    if player.lobby_connection:
+                        tasks.append(
+                            player.lobby_connection.send_warning(message_text)
+                        )
+                await asyncio.gather(*tasks, return_exceptions=True)
 
         if self.player.mod:
             if action == "join_channel":
@@ -350,7 +351,7 @@ class LobbyConnection:
                             "autojoin": [channel]
                         }))
 
-                await asyncio.gather(*tasks)
+                await asyncio.gather(*tasks, return_exceptions=True)
         else:
             self._logger.debug("Wrong premissions!")
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -331,10 +331,15 @@ class LobbyConnection:
 
                 tasks = []
                 for player in self.player_service:
-                    if player.lobby_connection:
+                    try:
                         tasks.append(
                             player.lobby_connection.send_warning(message_text)
                         )
+                    except AttributeError:
+                        self._logger.debug("Failed to send broadcast to %s", player)
+                    except Exception:
+                        self._logger.exception("Failed to send broadcast to %s", player)
+
                 await asyncio.gather(*tasks, return_exceptions=True)
 
         if self.player.mod:
@@ -346,10 +351,15 @@ class LobbyConnection:
                 for user_id in user_ids:
                     player = self.player_service[user_id]
                     if player:
-                        tasks.append(player.lobby_connection.send({
-                            "command": "social",
-                            "autojoin": [channel]
-                        }))
+                        try:
+                            tasks.append(player.lobby_connection.send({
+                                "command": "social",
+                                "autojoin": [channel]
+                            }))
+                        except AttributeError:
+                            self._logger.debug("Failed to send join_channel to %s", player)
+                        except Exception:
+                            self._logger.exception("Failed to send join_channel to %s", player)
 
                 await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/tests/integration_tests/test_admin.py
+++ b/tests/integration_tests/test_admin.py
@@ -1,0 +1,119 @@
+import asyncio
+
+import pytest
+
+from .conftest import connect_and_sign_in, read_until_command
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_closeFA(lobby_server):
+    _, _, proto1 = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    rhiza_id, _, proto2 = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(proto1, "game_info")
+    await read_until_command(proto2, "game_info")
+
+    await proto1.send_message({
+        "command": "admin",
+        "action": "closeFA",
+        "user_id": rhiza_id,
+    })
+
+    msg = await read_until_command(proto2, "notice")
+
+    assert msg == {"command": "notice", "style": "kill"}
+
+
+async def test_closelobby(lobby_server):
+    _, _, proto1 = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    rhiza_id, _, proto2 = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(proto1, "game_info")
+    await read_until_command(proto2, "game_info")
+
+    await proto1.send_message({
+        "command": "admin",
+        "action": "closelobby",
+        "user_id": rhiza_id,
+    })
+
+    msg = await read_until_command(proto2, "notice")
+
+    assert msg == {"command": "notice", "style": "kick"}
+
+
+async def test_broadcast(lobby_server):
+    _, _, proto1 = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    _, _, proto2 = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(proto1, "game_info")
+    await read_until_command(proto2, "game_info")
+
+    await proto1.send_message({
+        "command": "admin",
+        "action": "broadcast",
+        "message": "Test server message",
+    })
+
+    msg = await read_until_command(proto2, "notice")
+
+    assert msg == {
+        "command": "notice",
+        "style": "info",
+        "text": "Test server message"
+    }
+
+
+async def test_broadcast_empty_message(lobby_server):
+    _, _, proto1 = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    _, _, proto2 = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(proto1, "game_info")
+    await read_until_command(proto2, "game_info")
+
+    await proto1.send_message({
+        "command": "admin",
+        "action": "broadcast",
+        "message": "",
+    })
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(read_until_command(proto2, "notice"), 0.5)
+
+
+async def test_join_channel(lobby_server):
+    _, _, proto1 = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    rhiza_id, _, proto2 = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(proto1, "game_info")
+    await read_until_command(proto2, "game_info")
+
+    await proto1.send_message({
+        "command": "admin",
+        "action": "join_channel",
+        "user_ids": [rhiza_id],
+        "channel": "test_channel",
+    })
+
+    msg = await read_until_command(proto2, "social")
+
+    assert msg == {
+        "command": "social",
+        "autojoin": ["test_channel"]
+    }

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-from server import VisibilityState
 from server.db.models import ban
 from tests.utils import fast_forward
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -431,6 +431,7 @@ async def test_command_admin_closelobby(mocker, lobbyconnection):
     player.admin = True
     tuna = mock.Mock()
     tuna.id = 55
+    tuna.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = {1: player, 55: tuna}
 
     await lobbyconnection.on_message_received({
@@ -449,6 +450,7 @@ async def test_command_admin_closelobby_with_ban(mocker, lobbyconnection, databa
     player.admin = True
     banme = mock.Mock()
     banme.id = 200
+    banme.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = {1: player, banme.id: banme}
 
     await lobbyconnection.on_message_received({
@@ -480,6 +482,7 @@ async def test_command_admin_closelobby_with_ban_but_already_banned(mocker, lobb
     player.admin = True
     banme = mock.Mock()
     banme.id = 200
+    banme.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = {1: player, banme.id: banme}
 
     await lobbyconnection.on_message_received({
@@ -525,6 +528,7 @@ async def test_command_admin_closelobby_with_ban_duration_no_period(mocker, lobb
     player.admin = True
     banme = mock.Mock()
     banme.id = 200
+    banme.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = {1: player, banme.id: banme}
 
     mocker.patch('server.lobbyconnection.func.now', return_value=text('FROM_UNIXTIME(1000)'))
@@ -600,7 +604,7 @@ async def test_command_admin_closelobby_with_ban_injection(mocker, lobbyconnecti
         }
     })
 
-    banme.lobbyconnection.kick.assert_not_called()
+    banme.lobby_connection.kick.assert_not_called()
     lobbyconnection.protocol.send_message.assert_called_once_with({
         'command': 'notice',
         'style': 'error',
@@ -623,6 +627,7 @@ async def test_command_admin_closeFA(mocker, lobbyconnection):
     player.id = 42
     tuna = mock.Mock()
     tuna.id = 55
+    tuna.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = {42: player, 55: tuna}
 
     await lobbyconnection.on_message_received({

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -736,8 +736,10 @@ async def test_broadcast(lobbyconnection: LobbyConnection, mocker):
     player = mocker.patch.object(lobbyconnection, 'player')
     player.login = 'Sheeo'
     player.admin = True
+    player.lobby_connection = asynctest.create_autospec(LobbyConnection)
     tuna = mock.Mock()
     tuna.id = 55
+    tuna.lobby_connection = asynctest.create_autospec(LobbyConnection)
     lobbyconnection.player_service = [player, tuna]
 
     await lobbyconnection.on_message_received({


### PR DESCRIPTION
While merging a different PR I noticed that I forgot to await these and there were no tests to catch this error. So now I'm fixing it and adding some tests.

I also refactored the `join_channel` command. I noticed that the logic would not allow admins to use that command (only mods without admin power could use it) and that the method of extracting the user_id's seemed questionable. Before the message would have had to look like:
```json
{
    "user_ids": [1, 2, 3],
    1: 1,
    2: 2,
    3, 3
}
``` 
which seems insane to me and I'm not even sure is valid json, so now it just looks like:

```json
{
    "user_ids": [1, 2, 3]
}
``` 