### PR TITLE
Fixed some more places where coroutines were not awaited

### DIFF
--- a/server.py
+++ b/server.py
@@ -114,7 +114,7 @@ if __name__ == '__main__':
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
         loop.run_until_complete(done)
-        players_online.broadcast_shutdown()
+        loop.run_until_complete(players_online.broadcast_shutdown())
         ladder_service.shutdown_queues()
 
         # Close DB connections

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -150,12 +150,14 @@ class PlayerService:
         tasks = []
         for player in self:
             try:
-                tasks.append(player.lobby_connection.send_warning(
-                    "The server has been shut down for maintenance, "
-                    "but should be back online soon. "
-                    "If you experience any problems, please restart your client. "
-                    "<br/><br/>We apologize for this interruption."
-                ))
+                tasks.append(
+                    player.lobby_connection.send_warning(
+                        "The server has been shut down for maintenance, "
+                        "but should be back online soon. If you experience any "
+                        "problems, please restart your client. <br/><br/>"
+                        "We apologize for this interruption."
+                    )
+                )
             except Exception as ex:
                 self._logger.debug(
                     "Could not send shutdown message to %s: %s", player, ex

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -146,17 +146,18 @@ class PlayerService:
             if row is not None:
                 self.client_version_info = (row[0], row[1])
 
-    def broadcast_shutdown(self):
+    async def broadcast_shutdown(self):
+        tasks = []
         for player in self:
             try:
-                if player.lobby_connection:
-                    player.lobby_connection.send_warning(
-                        "The server has been shut down for maintenance, "
-                        "but should be back online soon. "
-                        "If you experience any problems, please restart your client. "
-                        "<br/><br/>We apologize for this interruption."
-                    )
+                tasks.append(player.lobby_connection.send_warning(
+                    "The server has been shut down for maintenance, "
+                    "but should be back online soon. "
+                    "If you experience any problems, please restart your client. "
+                    "<br/><br/>We apologize for this interruption."
+                ))
             except Exception as ex:
                 self._logger.debug(
                     "Could not send shutdown message to %s: %s", player, ex
                 )
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/server/stats/game_stats_service.py
+++ b/server/stats/game_stats_service.py
@@ -109,7 +109,7 @@ class GameStatsService:
 
             await self._event_service.execute_batch_update(player.id, e_queue)
             if player.lobby_connection is not None:
-                player.lobby_connection.send_updated_achievements(updated_achievements)
+                await player.lobby_connection.send_updated_achievements(updated_achievements)
 
     def _category_stats(self, unit_stats, survived, achievements_queue, events_queue):
         built_air = unit_stats['air'].get('built', 0)

--- a/tests/unit_tests/test_game_stats_service.py
+++ b/tests/unit_tests/test_game_stats_service.py
@@ -1,13 +1,15 @@
 from unittest.mock import Mock
 
+import asynctest
 import pytest
+from asynctest import CoroutineMock
 from server.factions import Faction
 from server.games import Game
 from server.games.game_results import GameOutcome, GameResult, GameResults
+from server.lobbyconnection import LobbyConnection
 from server.stats import achievement_service as ach
 from server.stats import event_service as ev
 from server.stats.game_stats_service import GameStatsService
-from asynctest import CoroutineMock
 
 pytestmark = pytest.mark.asyncio
 
@@ -113,7 +115,7 @@ async def test_process_game_stats(
     with open("tests/data/game_stats_full_example.json", "r") as stats_file:
         stats = stats_file.read()
 
-    mock_lconn = Mock()
+    mock_lconn = asynctest.create_autospec(LobbyConnection)
     player.lobby_connection = mock_lconn
 
     await game_stats_service.process_game_stats(player, game, stats)

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -1,5 +1,7 @@
-from mock import Mock
+import asynctest
 import pytest
+from mock import Mock
+from server.lobbyconnection import LobbyConnection
 from server.rating import RatingType
 
 pytestmark = pytest.mark.asyncio
@@ -85,23 +87,23 @@ async def test_update_data(player_factory, player_service):
 
 async def test_broadcast_shutdown(player_factory, player_service):
     player = player_factory()
-    lconn = Mock()
+    lconn = asynctest.create_autospec(LobbyConnection)
     player.lobby_connection = lconn
     player_service[0] = player
 
-    player_service.broadcast_shutdown()
+    await player_service.broadcast_shutdown()
 
     player.lobby_connection.send_warning.assert_called_once()
 
 
 async def test_broadcast_shutdown_error(player_factory, player_service):
     player = player_factory()
-    lconn = Mock()
+    lconn = asynctest.create_autospec(LobbyConnection)
     lconn.send_warning.side_effect = ValueError
     player.lobby_connection = lconn
 
     player_service[0] = player
 
-    player_service.broadcast_shutdown()
+    await player_service.broadcast_shutdown()
 
     player.lobby_connection.send_warning.assert_called_once()


### PR DESCRIPTION
I was wondering why the test server stopped sending the usual shutdown message... Also changed the tests to use `create_autospec` so this sort of thing doesn't get missed in the future.