### PR TITLE
Send game configuration options to the client in game_launch

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -844,6 +844,11 @@ class LobbyConnection:
             "uid": game.id,
             "mod": game.game_mode,
             "mapname": use_map,
+            # Following parameters are not used by the client yet. They are
+            # needed for setting up auto-lobby style matches such as ladder, gw,
+            # and team machmaking where the server decides what these game
+            # options are. Currently, options for ladder are hardcoded into the
+            # client.
             "name": game.name,
             "team": game.get_player_option(self.player, "Team"),
             "faction": game.get_player_option(self.player, "Faction"),

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -840,13 +840,20 @@ class LobbyConnection:
         self.player.game = game
         cmd = {
             "command": "game_launch",
-            "mod": game.game_mode,
+            "args": ["/numgames", self.player.game_count[RatingType.GLOBAL]],
             "uid": game.id,
-            "args": ["/numgames " + str(self.player.game_count[RatingType.GLOBAL])]
+            "mod": game.game_mode,
+            "mapname": use_map,
+            "name": game.name,
+            "team": game.get_player_option(self.player, "Team"),
+            "faction": game.get_player_option(self.player, "Faction"),
+            "expected_players": len(game.players) or None,
+            "map_position": game.get_player_option(self.player, "StartSpot"),
+            "init_mode": game.init_mode.value,
         }
-        if use_map:
-            cmd['mapname'] = use_map
-        await self.send(cmd)
+
+        # Remove args with None value
+        await self.send({k: v for k, v in cmd.items() if v is not None})
 
     async def command_modvault(self, message):
         type = message["type"]

--- a/server/protocol/gpgnet.py
+++ b/server/protocol/gpgnet.py
@@ -22,12 +22,12 @@ class GpgNetServerProtocol(metaclass=ABCMeta):
         """
         await self.send_gpgnet_message('JoinGame', [remote_player_name, remote_player_uid])
 
-    async def send_HostGame(self, map):
+    async def send_HostGame(self, map_path):
         """
         Tells the game to start listening for incoming connections as a host
-        :param map: Which scenario to use
+        :param map_path: Which scenario to use
         """
-        await self.send_gpgnet_message('HostGame', [str(map)])
+        await self.send_gpgnet_message('HostGame', [str(map_path)])
 
     async def send_DisconnectFromPeer(self, id: int):
         """
@@ -38,7 +38,7 @@ class GpgNetServerProtocol(metaclass=ABCMeta):
         """
         await self.send_gpgnet_message('DisconnectFromPeer', [id])
 
-    async def send_gpgnet_message(self, command_id, arguments):
+    async def send_gpgnet_message(self, command_id: str, arguments: List[Union[int, str, bool]]):
         message = {"command": command_id, "args": arguments}
         await self.send_message(message)
 


### PR DESCRIPTION
Pulling some stuff out of #428 that doesn't need to wait. I think these changes are backwards compatible with the current client. A client implementation exists on the gw-on-ice branch: https://github.com/FAForever/downlords-faf-client/commit/97f72147d48537ca98a7cc37faad591f612fc6b8