### PR TITLE
Asyncio drain fix

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from server.db import FAFDatabase
-from sqlalchemy import text, select, or_
+from sqlalchemy import or_, select, text
 
 from .abc.base_game import GameConnectionState
 from .config import TRACE
@@ -170,6 +170,8 @@ class GameConnection(GpgNetServerProtocol):
             )
         except (TypeError, ValueError) as e:
             self._logger.exception("Bad command arguments: %s", e)
+        except ConnectionError as e:
+            raise e
         except Exception as e:  # pragma: no cover
             self._logger.exception(e)
             self._logger.exception("Something awful happened in a game thread!")

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -163,6 +163,9 @@ class LobbyConnection:
         except (KeyError, ValueError) as ex:
             self._logger.exception(ex)
             await self.abort("Garbage command: {}".format(message))
+        except ConnectionError as e:
+            # Propagate connection errors to the ServerContext error handler.
+            raise e
         except Exception as ex:  # pragma: no cover
             await self.send({'command': 'invalid'})
             self._logger.exception(ex)

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -25,6 +25,11 @@ class ServerContext:
 
     async def listen(self, host, port):
         self._logger.debug("ServerContext.listen(%s, %s)", host, port)
+        # TODO: Use tags so we don't need to manually reset each one
+        server.stats.gauge('user.agents.None', 0)
+        server.stats.gauge('user.agents.downlords_faf_client', 0)
+        server.stats.gauge('user.agents.faf_client', 0)
+
         self._server = await asyncio.start_server(
             self.client_connected,
             host=host,

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -410,3 +410,12 @@ async def test_handle_action_OperationComplete_invalid(ugame: Game, game_connect
         row = await result.fetchone()
 
     assert row is None
+
+
+async def test_handle_action_invalid(game_connection: GameConnection):
+    game_connection.abort = CoroutineMock()
+
+    await game_connection.handle_action('ThisDoesntExist', [1, 2, 3])
+
+    game_connection.abort.assert_not_called()
+    game_connection.protocol.send_message.assert_not_called()

--- a/tests/unit_tests/test_protocol.py
+++ b/tests/unit_tests/test_protocol.py
@@ -1,10 +1,9 @@
-from asyncio import StreamReader
-
 import asyncio
-from unittest import mock
-import pytest
 import struct
+from asyncio import StreamReader
+from unittest import mock
 
+import pytest
 from server.protocol import QDataStreamProtocol
 
 pytestmark = pytest.mark.asyncio
@@ -14,21 +13,23 @@ pytestmark = pytest.mark.asyncio
 def reader(event_loop):
     return StreamReader(loop=event_loop)
 
+
 @pytest.fixture
 def writer():
     return mock.Mock()
+
 
 @pytest.fixture
 def protocol(reader, writer):
     return QDataStreamProtocol(reader, writer)
 
 
-async def test_QDataStreamProtocol_recv_small_message(protocol,reader):
+async def test_QDataStreamProtocol_recv_small_message(protocol, reader):
     data = QDataStreamProtocol.pack_block(b''.join([QDataStreamProtocol.pack_qstring('{"some_header": true}'),
                                                     QDataStreamProtocol.pack_qstring('Goodbye')]))
     reader.feed_data(data)
 
-    message =await protocol.read_message()
+    message = await protocol.read_message()
 
     assert message == {'some_header': True, 'legacy': ['Goodbye']}
 
@@ -60,3 +61,7 @@ async def test_unpacks_evil_qstring(protocol, reader):
     message = await protocol.read_message()
 
     assert message == {'command': 'ask_session'}
+
+
+async def test_many_simultaneous_writes(protocol):
+    pass


### PR DESCRIPTION
The server logs are plagued with the following error:
```
Traceback (most recent call last):
  File "/code/server/__init__.py", line 148, in do_report_dirties
    await asyncio.gather(*tasks)
  File "/code/server/servercontext.py", line 56, in broadcast_raw
    await asyncio.gather(*tasks)
  File "/code/server/protocol/qdatastreamprotocol.py", line 150, in send_raw
    await self.writer.drain()
  File "/usr/local/lib/python3.6/asyncio/streams.py", line 339, in drain
    yield from self._protocol._drain_helper()
  File "/usr/local/lib/python3.6/asyncio/streams.py", line 214, in _drain_helper
    assert waiter is None or waiter.cancelled()
AssertionError
```

It appears that this is caused by `drain` being awaited by multiple coroutines. As a result this is non-trivial to reproduce on the test server as it requires a lot of messages to be sent at the same time. As far as I can tell this behavior is considered a bug in asyncio, as it is not mentioned in the documentation. A workaround, which is employed by the `websockets` project, is to serialize the calls to drain with a mutex. 

I don't expect the addition of a lock to have a noticeable effect on performance as typically the calls to drain were intended to serve as a way of serializing messages per connection anyways (applying backpressure), the only place where this wouldn't naturally occur was in the broadcast functions, which are the reason for occasionally getting concurrent calls to drain.