### PR TITLE
Fix exception handling

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -99,25 +99,31 @@ def run_lobby_server(
 
     @at_interval(DIRTY_REPORT_INTERVAL)
     async def do_report_dirties():
-        try:
-            dirty_games = games.dirty_games
-            dirty_queues = games.dirty_queues
-            dirty_players = player_service.dirty_players
-            games.clear_dirty()
-            player_service.clear_dirty()
+        dirty_games = games.dirty_games
+        dirty_queues = games.dirty_queues
+        dirty_players = player_service.dirty_players
+        games.clear_dirty()
+        player_service.clear_dirty()
 
+        try:
             if dirty_queues:
                 await ctx.broadcast_raw(
                     encode_queues(dirty_queues),
                     lambda lobby_conn: lobby_conn.authenticated
                 )
+        except Exception as e:
+            logging.getLogger().exception(e)
 
+        try:
             if dirty_players:
                 await ctx.broadcast_raw(
                     encode_players(dirty_players),
                     lambda lobby_conn: lobby_conn.authenticated
                 )
+        except Exception as e:
+            logging.getLogger().exception(e)
 
+        try:
             # TODO: This spams squillions of messages: we should implement per-
             # connection message aggregation at the next abstraction layer down :P
             tasks = []

--- a/server/async_functions.py
+++ b/server/async_functions.py
@@ -10,7 +10,7 @@ async def gather_without_exceptions(
     *exceptions: Type[BaseException],
 ) -> List[Any]:
     """
-    Run coroutines in parallell, raising the first exception that dosen't
+    Run coroutines in parallel, raising the first exception that dosen't
     match any of the specified exception classes.
     """
     results = []

--- a/server/async_functions.py
+++ b/server/async_functions.py
@@ -10,7 +10,7 @@ async def gather_without_exceptions(
     *exceptions: Type[BaseException],
 ) -> List[Any]:
     """
-    Call gather on a list of tasks, raising the first exception that dosen't
+    Run coroutines in parallell, raising the first exception that dosen't
     match any of the specified exception classes.
     """
     results = []

--- a/server/async_functions.py
+++ b/server/async_functions.py
@@ -2,23 +2,21 @@
 Some helper functions for common async tasks.
 """
 import asyncio
-from typing import Any, List
+from typing import Any, List, Type
 
 
 async def gather_without_exceptions(
     tasks: List[asyncio.Task],
-    *exceptions: type,
+    *exceptions: Type[BaseException],
 ) -> List[Any]:
     """
     Call gather on a list of tasks, raising the first exception that dosen't
     match any of the specified exception classes.
     """
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for result in results:
-        if isinstance(result, Exception):
-            # Check if this exception is an instance (maybe subclass) that
-            # should be ignored
-            for exc_type in exceptions:
-                if not isinstance(result, exc_type):
-                    raise result
+    results = []
+    for fut in asyncio.as_completed(tasks):
+        try:
+            results.append(await fut)
+        except exceptions:
+            pass
     return results

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -971,13 +971,14 @@ class LobbyConnection:
         await self.protocol.send_message(message)
 
     async def drain(self):
-        await self.protocol.drain()
+        # TODO: Remove me, QDataStreamProtocol no longer has a drain method
+        pass
 
     async def on_connection_lost(self):
-        async def nopdrain(message):
+        async def nop(*args, **kwargs):
             return
-        self.drain = nopdrain
-        self.send = lambda m: None
+        self.drain = nop
+        self.send = nop
         if self.game_connection:
             self._logger.debug(
                 "Lost lobby connection killing game connection for player {}".format(self.game_connection.player.id))

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -342,7 +342,7 @@ class LobbyConnection:
                             player.lobby_connection.send_warning(message_text)
                         )
 
-                await gather_without_exceptions(tasks, ConnectionError)
+                await gather_without_exceptions(tasks, Exception)
 
         if self.player.mod:
             if action == "join_channel":
@@ -358,7 +358,7 @@ class LobbyConnection:
                             "autojoin": [channel]
                         }))
 
-                await gather_without_exceptions(tasks, ConnectionError)
+                await gather_without_exceptions(tasks, Exception)
 
     async def check_user_login(self, conn, username, password):
         # TODO: Hash passwords server-side so the hashing actually *does* something.

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -342,6 +342,10 @@ class LobbyConnection:
                             player.lobby_connection.send_warning(message_text)
                         )
 
+                self._logger.info(
+                    "%s broadcasting message to all players: %s",
+                    self.player.login, message_text
+                )
                 await gather_without_exceptions(tasks, Exception)
 
         if self.player.mod:

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -60,7 +60,7 @@ class ServerContext:
             if validate_fn(conn):
                 tasks.append(proto.send_raw(message))
 
-        await gather_without_exceptions(tasks, ConnectionError)
+        await gather_without_exceptions(tasks, Exception)
 
     async def client_connected(self, stream_reader, stream_writer):
         self._logger.debug("%s: Client connected", self)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -894,6 +894,16 @@ async def test_connection_lost(lobbyconnection):
     lobbyconnection.player_service.remove_player.assert_called_once_with(lobbyconnection.player)
 
 
+async def test_connection_lost_send(lobbyconnection, mock_protocol):
+    await lobbyconnection.on_connection_lost()
+
+    await lobbyconnection.send({"command": "Some Message"})
+
+    mock_protocol.send_message.assert_not_called()
+    mock_protocol.send_messages.assert_not_called()
+    mock_protocol.send_raw.assert_not_called()
+
+
 async def test_check_policy_conformity(lobbyconnection, policy_server):
     host, port = policy_server
     with mock.patch(


### PR DESCRIPTION
When broadcasting ignore all exception classes. Possible exceptions that we tend to run into:
    -  ConnectionError: When a user disconnects in a mostly normal way
    - TimeoutError: When the connection times out.
    - OSError (no route to host)

In `do_report_dirties` wrap each broadcast in its own try/except block so that a failure in one block will not prevent the other logic from running.

Rewrite `gather_without_exceptions` using `asyncio.as_completed`. This makes it a lot easier to understand.