### PR TITLE
Two player FFA

### DIFF
--- a/server/games/game_rater.py
+++ b/server/games/game_rater.py
@@ -44,6 +44,10 @@ class GameRater(object):
         example output: [ {p1: Rating, p2: Rating}, {p3: Rating, p4: Rating} ]
         """
         if FFA_TEAM in self._players_by_team:
+            number_of_players = sum([
+                len(self._players_by_team[team])
+                for team in self._players_by_team
+            ])
             if (
                 len(self._players_by_team[FFA_TEAM]) == 2
                 and len(self._players_by_team) == 1
@@ -51,11 +55,11 @@ class GameRater(object):
                 return [{
                     player: Rating(*player.ratings[self._rating_type])
                 } for player in self._players_by_team[FFA_TEAM]]
-            else:
+            elif number_of_players != 2:
                 raise GameRatingError(
                     f"Attempted to rate FFA game with other than two players: {{team: players}} = {self._players_by_team}"
                 )
-        elif len(self._players_by_team) == 2:
+        if len(self._players_by_team) == 2:
             return [{
                 player: Rating(*player.ratings[self._rating_type])
                 for player in team

--- a/server/games/game_rater.py
+++ b/server/games/game_rater.py
@@ -44,10 +44,10 @@ class GameRater(object):
         example output: [ {p1: Rating, p2: Rating}, {p3: Rating, p4: Rating} ]
         """
         if FFA_TEAM in self._players_by_team:
-            number_of_players = sum([
-                len(self._players_by_team[team])
-                for team in self._players_by_team
-            ])
+            number_of_parties = (
+                len(self._players_by_team[FFA_TEAM]) +
+                len(self._players_by_team) - 1
+            )
             if (
                 len(self._players_by_team[FFA_TEAM]) == 2
                 and len(self._players_by_team) == 1
@@ -55,10 +55,11 @@ class GameRater(object):
                 return [{
                     player: Rating(*player.ratings[self._rating_type])
                 } for player in self._players_by_team[FFA_TEAM]]
-            elif number_of_players != 2:
+            elif number_of_parties != 2:
                 raise GameRatingError(
-                    f"Attempted to rate FFA game with other than two players: {{team: players}} = {self._players_by_team}"
+                    f"Attempted to rate FFA game with other than two parties: {{team: players}} = {self._players_by_team}"
                 )
+
         if len(self._players_by_team) == 2:
             return [{
                 player: Rating(*player.ratings[self._rating_type])

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -129,3 +129,45 @@ def test_compute_rating():
     for team in result:
         for player, new_rating in team.items():
             assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
+
+
+def test_compute_rating_of_two_player_ffa_match_if_one_chose_a_team():
+    FFA_TEAM = 1
+    p1, p2 = MockPlayer(), MockPlayer()
+    players_by_team = {FFA_TEAM: [p1], 2: [p2]}
+    outcome_py_player = {p1: GameOutcome.VICTORY, p2: GameOutcome.DEFEAT}
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    result = rater.compute_rating()
+    for team in result:
+        for player, new_rating in team.items():
+            assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
+
+
+def test_compute_rating_of_two_player_ffa_match_if_none_chose_a_team():
+    FFA_TEAM = 1
+    p1, p2 = MockPlayer(), MockPlayer()
+    players_by_team = {FFA_TEAM: [p1, p2]}
+    outcome_py_player = {p1: GameOutcome.VICTORY, p2: GameOutcome.DEFEAT}
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    result = rater.compute_rating()
+    for team in result:
+        for player, new_rating in team.items():
+            assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
+
+
+def test_dont_rate_partial_ffa_matches():
+    FFA_TEAM = 1
+    p1, p2, p3, p4 = MockPlayer(), MockPlayer(), MockPlayer(), MockPlayer()
+    players_by_team = {FFA_TEAM: [p1, p3], 2: [p2, p4]}
+    outcome_py_player = {
+            p1: GameOutcome.VICTORY, 
+            p2: GameOutcome.DEFEAT, 
+            p3: GameOutcome.DEFEAT,
+            p4: GameOutcome.DEFEAT,
+    }
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    with pytest.raises(GameRatingError):
+        result = rater.compute_rating()

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -144,6 +144,23 @@ def test_compute_rating_of_two_player_ffa_match_if_one_chose_a_team():
             assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
 
 
+def test_compute_rating_for_single_ffa_player_vs_a_team():
+    FFA_TEAM = 1
+    p1, p2, p3 = MockPlayer(), MockPlayer(), MockPlayer()
+    players_by_team = {FFA_TEAM: [p1], 2: [p2, p3]}
+    outcome_py_player = {
+        p1: GameOutcome.VICTORY,
+        p2: GameOutcome.DEFEAT,
+        p3: GameOutcome.DEFEAT,
+    }
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    result = rater.compute_rating()
+    for team in result:
+        for player, new_rating in team.items():
+            assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
+
+
 def test_compute_rating_of_two_player_ffa_match_if_none_chose_a_team():
     FFA_TEAM = 1
     p1, p2 = MockPlayer(), MockPlayer()
@@ -173,10 +190,25 @@ def test_dont_rate_partial_ffa_matches():
         result = rater.compute_rating()
 
 
-def test_dont_rate_pure_ffa_matches():
+def test_dont_rate_pure_ffa_matches_with_more_than_two_players():
     FFA_TEAM = 1
     p1, p2, p3 = MockPlayer(), MockPlayer(), MockPlayer()
     players_by_team = {FFA_TEAM: [p1, p2, p3]}
+    outcome_py_player = {
+        p1: GameOutcome.VICTORY,
+        p2: GameOutcome.DEFEAT,
+        p3: GameOutcome.DEFEAT,
+    }
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    with pytest.raises(GameRatingError):
+        result = rater.compute_rating()
+
+
+def test_dont_rate_threeway_team_matches():
+    FFA_TEAM = 1
+    p1, p2, p3 = MockPlayer(), MockPlayer(), MockPlayer()
+    players_by_team = {2: [p1], 3: [p2], 4: [p3]}
     outcome_py_player = {
         p1: GameOutcome.VICTORY,
         p2: GameOutcome.DEFEAT,

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -162,10 +162,25 @@ def test_dont_rate_partial_ffa_matches():
     p1, p2, p3, p4 = MockPlayer(), MockPlayer(), MockPlayer(), MockPlayer()
     players_by_team = {FFA_TEAM: [p1, p3], 2: [p2, p4]}
     outcome_py_player = {
-            p1: GameOutcome.VICTORY, 
-            p2: GameOutcome.DEFEAT, 
-            p3: GameOutcome.DEFEAT,
-            p4: GameOutcome.DEFEAT,
+        p1: GameOutcome.VICTORY,
+        p2: GameOutcome.DEFEAT,
+        p3: GameOutcome.DEFEAT,
+        p4: GameOutcome.DEFEAT,
+    }
+
+    rater = GameRater(players_by_team, outcome_py_player)
+    with pytest.raises(GameRatingError):
+        result = rater.compute_rating()
+
+
+def test_dont_rate_pure_ffa_matches():
+    FFA_TEAM = 1
+    p1, p2, p3 = MockPlayer(), MockPlayer(), MockPlayer()
+    players_by_team = {FFA_TEAM: [p1, p2, p3]}
+    outcome_py_player = {
+        p1: GameOutcome.VICTORY,
+        p2: GameOutcome.DEFEAT,
+        p3: GameOutcome.DEFEAT,
     }
 
     rater = GameRater(players_by_team, outcome_py_player)


### PR DESCRIPTION
The `GameRater` would refuse to rate two-player games if one player had chosen a (numbered) team, while the other player remained teamless (the FFA team "-").
This should fix it.

Includes some further unit tests on various distributions of players on FFA and actual teams.