### PR TITLE
[Postponed until after TMM] Protocol Documentation

### DIFF
--- a/server/clientmessages.py
+++ b/server/clientmessages.py
@@ -1,0 +1,527 @@
+from enum import Enum, auto
+import functools
+from typing import NamedTuple, Optional
+
+
+class Target(Enum):
+    """
+    Valid entries for the `'target'` field in a message from the client.
+    """
+
+    none = 0
+    game = 1
+    connectivity = 2  # deprecated
+
+
+class ActionField(Enum):
+    """
+    Valid entries for the `'action'` field in a message from the client.
+    """
+
+    list_avatar = 1
+    select = 2
+
+
+class CommandField(Enum):
+    """
+    Valid entries for the required `'command'` field in a message from the client.
+    """
+
+    admin = auto()
+    ask_session = auto()
+    avatar = auto()
+    coop_list = auto()
+    create_account = auto()
+    game_host = auto()
+    game_join = auto()
+    game_matchmaking = auto()
+    hello = auto()
+    ice_servers = auto()
+    matchmaker_info = auto()
+    modvault = auto()
+    ping = auto()
+    pong = auto()
+    restore_game_session = auto()
+    social_add = auto()
+    social_remove = auto()
+    Bottleneck = auto()
+
+
+class Message():
+    """
+    Common base class for parsed messages from and to the client.
+    """
+
+    pass
+
+
+class MessageFromClient(Message):
+    """
+    Common base class for parsed messages from the client.
+    """
+    
+    pass
+
+
+class MessageToClient(Message):
+    """
+    Common base class for parsed messages to the client.
+    """
+
+    pass
+
+
+class LobbyTargetMessage(MessageFromClient):
+    """
+    Common base class for messages without `target` entry  or entry `'none'`.
+
+    To be handled by a `LobbyConnection`.
+    """
+
+    @staticmethod
+    def build(lobbyconnection, message):
+        command = MessageParser.parse_command(message)
+        return COMMAND_TO_CLASS[command].build(message)
+
+
+class ConnectivityTargetMessage(MessageFromClient):
+    """
+    Deprecated functionality for `target` entry `'connectivity'`.
+
+    Will ask client to update to the newest version.
+    """
+
+    @staticmethod
+    async def __init__(self, lobbyconnection=None, message=None):
+        lobbyconnection.register_connectivity_test()
+
+    async def handle(self):
+        raise ClientError(
+            f"Your client version is no longer supported."
+            f"Please update to the newest version: https://faforever.com"
+        )
+
+
+class GameTargetMessage(MessageFromClient):
+    """
+    Common base class for messages with `target` entry `'game'`.
+
+    To be handled by a `GameConnection`.
+    """
+
+    @staticmethod
+    async def build(lobbyconnection=None, message=None):
+        # need to make a distinction on command, arguments
+        # should fail if passed lobbyconnection does not have a game_connection
+        # message entry 'args' needs to be passed along
+        # previous code:
+        #   if target == 'game':
+        #       if not self.game_connection:
+        #           return
+        #
+        #       await self.game_connection.handle_action(cmd, message.get('args', []))
+        #       return
+        raise NotImplementedError("TODO")
+
+
+class PingMessage(LobbyTargetMessage):
+    """
+    Returns a 'PONG' message.
+
+    Does not require the client to be authenticated.
+
+    Required fields:
+
+     - `command`: `ping`
+    """
+    command: str = "ping"
+    _command_enum = CommandField.ping
+
+
+class PongMessage(LobbyTargetMessage):
+    """
+    Does nothing.
+
+    Does not require the client to be authenticated.
+
+    Required fields:
+
+     - `command`: `pong`
+    """
+    command: str = "pong"
+
+    @classmethod
+    def build(cls, message):
+        return PongMessage()
+
+
+
+class AccountCreationMessage(LobbyTargetMessage):
+    """
+
+    Required fields:
+
+     - `command`: `create_account`
+    """
+    command: str = "create_account"
+
+    @classmethod
+    def build(cls, message):
+        return AccountCreationMessage()
+
+class CoopListMessage(LobbyTargetMessage):
+    """
+    Asks server for the list of coop maps.
+
+    Requires the client to be authenticated.
+
+    Required fields:
+
+     - `command`: `coop_list`
+    """
+    commad: str = "coop_list"
+
+    @classmethod
+    def build(cls, message):
+        return CoopListMessage()
+
+
+class MatchmakerInfoMessage(LobbyTargetMessage):
+    """
+    TODO: Description
+
+    Requires the client to be authenticated.
+
+    Required fields:
+
+     - `command`: `matchmaker_info`
+    """
+    command: str = "matchmaker_info"
+    _command_enum = CommandField.matchmaker_info
+
+
+class SocialRemoveMessage(NamedTuple, LobbyTargetMessage):
+    """
+    Remove someone from your friend list or foe list.
+
+    Requires the client to be authenticated.
+
+    Required fields:  
+
+      - `command`: `social_remove`  
+
+    And at least one of the following:
+
+     - `friend`: `id` of player to remove from friend list
+     - `foe`: `id` of player to remove from foe list
+
+    If both `friend` and `foe` are specified, only the friend will be removed.
+    """
+    command: str
+    id_to_remove: int
+
+    @classmethod
+    def build(cls, message):
+        if "friend" in message:
+            id_to_remove = message["friend"]
+        elif "foe" in message:
+            id_to_remove = message["foe"]
+        else:
+            raise MessageParsingError(
+                f"Message to remove friend or foe "
+                f"must contain at least one of 'friend' or 'foe' fields. "
+                f"Offending message: {message}."
+            )
+
+        return cls(
+            "social_remove",
+            id_to_remove,
+        )
+
+
+class SocialAddMessage(NamedTuple, LobbyTargetMessage):
+    """
+    Add someone to your friend list or foe list.
+
+    Requires the client to be authenticated.
+
+    Required fields:  
+
+      - `command`: `social_add`  
+
+    And at least one of the following:
+
+     - `friend`: `id` of player to add to friend list
+     - `foe`: `id` of player to add to foe list
+
+    If both `friend` and `foe` are specified, only the friend will be added.
+    """
+    command: str
+    id_to_add: int
+    adding_a_friend: bool
+
+    @classmethod
+    def build(cls, message):
+        if "friend" in message:
+            adding_a_friend = True
+            id_to_add = message["friend"]
+        elif "foe" in message:
+            adding_a_friend = False
+            id_to_add = message["foe"]
+        else:
+            raise MessageParsingError(
+                f"Message to add friend or foe "
+                f"must contain at least one of 'friend' or 'foe' fields. "
+                f"Offending message: {message}."
+            )
+
+        return cls(
+            "social_add",
+            id_to_add,
+            adding_a_friend,
+        )
+
+
+class BottleneckMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class AdminMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class HelloMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class GameMatchmakingMessage(NamedTuple, LobbyTargetMessage):
+    """
+    Queue up for matchmaking or cancel matchmaking search.
+
+    Requires the client to be authenticated.
+
+    Required fields:  
+
+      - `command`: `game_matchmaking`  
+      - `state`: `start` or `stop`
+
+    Optional fields:
+      - `mod`: Currently discarded. If `state` is `start`, this  might at some
+        point specify in which queue to start matchmaking. Default `ladder1v1`
+        if empty.
+    """
+    command: str
+    mod: str
+    state: str
+
+
+    @classmethod
+    def build(cls, message):
+        # NOTE: copied str conversions from previous
+        # lobbyconnection.LobbyConnection.command_game_matchmaking,
+        # but not sure if needed.
+        mod = str(message.get("mod", "ladder1v1")),
+
+        if str(message.get("state")) not in ["start", "stop"]:
+            raise MessageParsingError(
+                f"Message with command 'game_matchmaking' "
+                f"must contain the field 'state' set to 'start' or 'stop'. "
+                f"Offending message: {message}."
+            )
+        state = str(message["state"])
+
+        return cls(
+            "game_matchmaking",
+            mod,
+            state,
+        )
+
+
+class GameHostMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class GameJoinMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class ICEServersMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class ModvaultMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+
+class RestoreGameSessionMessage(LobbyTargetMessage):
+    """
+    Not yet implemented
+    """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        raise NotImplementedError
+
+class AvatarMessage(NamedTuple, LobbyTargetMessage):
+    """
+    Asks server to either return a list of avatars for the current user
+    or select a new avatar.
+
+    Requires the client to be authenticated.
+
+    Required fields:  
+
+      - `command`: `avatar`  
+      - `action`: `select` or `list_avatar` (default: `list_avatar`)
+      - `avatar`: url of new avatar or `null` for default avatar (?) (default: `null`)
+    """
+    command: str
+    action: str
+    url: Optional[str]
+
+    @classmethod
+    def build(cls, message):
+        avatar_url = message.get("avatar", None)
+        if avatar_url == "null":
+            avatar_url = None
+
+        action = message.get("action", "list_avatar")
+        if action not in ["select", "list_avatar"]:
+            raise MessageParsingError(
+                f"Command 'avatar' needs field 'action' "
+                f"to be either 'select' or 'list_avatar'. "
+                f"Offending message: {message}"
+            )
+
+        return cls(
+            "avatar",
+            action,
+            avatar_url,
+        )
+
+
+class AskSessionMessage(LobbyTargetMessage):
+    """
+    TODO: Description
+
+    Requires the client to be authenticated.
+
+    Required fields:
+
+     - `command`: `ask_session`
+
+    Expected fields:
+     - `user_agent`: TODO probably `'downlords-faf-client'`
+     - `version`: TODO probably version number of downlords-faf-client
+     """
+
+    def __init__(self, lobbyconnection=None, message=None):
+        self._connection = lobbyconnection
+        self._message = message
+        self._command = CommandField.ask_session
+
+        self._user_agent = message.get("user_agent")
+        self._version = message.get("version")
+
+
+    async def handle(self):
+        self._connection.command_ask_session()
+
+
+class MessageParser:
+    """
+    Assembles a `Message` object from received json-like dict.
+    """
+
+    @staticmethod
+    def parse(lobbyconnection, message):
+        if "command" not in message:
+            raise MessageParsingError(
+                f"Message did not contain required 'command' field. "
+                f"Offending message: {message}"
+            )
+        target = Target[message.get("target", "none")]
+
+        if target is Target.game:
+            return GameTargetMessage.build(lobbyconnection, message)
+        elif target is Target.connectivity:
+            return ConnectivityTargetMessage(lobbyconnection, message)
+        else:
+            return LobbyTargetMessage.build(lobbyconnection, message)
+
+    @staticmethod
+    def parse_command(message):
+        if "command" not in message:
+            raise MessageParsingError(
+                f"Message did not contain required 'command' field. "
+                f"Offending message: {message}"
+            )
+        try:
+            return CommandField[message["command"]]
+        except KeyError:
+            raise MessageParsingError(
+                f"'command' field of message {message} is invalid."
+            )
+
+
+class MessageParsingError(Exception):
+    """
+    Raised if trying to parse a message with invalid format.
+    """
+
+    pass
+
+COMMAND_TO_CLASS = {
+        CommandField.admin: AdminMessage,
+        CommandField.ask_session: AskSessionMessage,
+        CommandField.avatar: AvatarMessage,
+        CommandField.coop_list: CoopListMessage,
+        CommandField.create_account: AccountCreationMessage,
+        CommandField.game_host: GameHostMessage,
+        CommandField.game_join: GameJoinMessage,
+        CommandField.game_matchmaking: GameMatchmakingMessage,
+        CommandField.hello: HelloMessage,
+        CommandField.ice_servers: ICEServersMessage,
+        CommandField.matchmaker_info: MatchmakerInfoMessage,
+        CommandField.modvault: ModvaultMessage,
+        CommandField.ping: PingMessage,
+        CommandField.pong: PongMessage,
+        CommandField.restore_game_session: RestoreGameSessionMessage,
+        CommandField.social_add: SocialAddMessage,
+        CommandField.social_remove: SocialRemoveMessage,
+        CommandField.Bottleneck: BottleneckMessage,
+}

--- a/server/clientmessages.py
+++ b/server/clientmessages.py
@@ -84,6 +84,7 @@ class LobbyTargetMessage(MessageFromClient):
 
 class ConnectivityTargetMessage(NamedTuple, MessageFromClient):
     """Deprecated messages with `target` entry `'connectivity'` will be directed here."""
+
     command: Optional[str]
 
     @classmethod
@@ -93,17 +94,18 @@ class ConnectivityTargetMessage(NamedTuple, MessageFromClient):
 
 
 class GameTargetMessage(NamedTuple, MessageFromClient):
-    """ Messages with `target` entry `'game'` will be directed here
-and passed on to a `GameConnection`.
+    """
+    Messages with `target` entry `'game'` will be directed here
+    and passed on to a `GameConnection`.
 
-Required fields:
+    Required fields:
 
-  - `command`: command to be passed on to the `GameConnection`.
+      - `command`: command to be passed on to the `GameConnection`.
 
-Optional fields:
+    Optional fields:
 
-  - `args`: list of arguments to be passed along with the command
-"""
+      - `args`: list of arguments to be passed along with the command
+    """
 
     command: str
     args: list
@@ -124,10 +126,11 @@ Optional fields:
 
 
 class PingMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `ping`
-"""
+     - `command`: `ping`
+    """
 
     command: str = "ping"
 
@@ -137,10 +140,11 @@ class PingMessage(NamedTuple, LobbyTargetMessage):
 
 
 class PongMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `pong`
-"""
+     - `command`: `pong`
+    """
 
     command: str = "pong"
 
@@ -150,10 +154,11 @@ class PongMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AccountCreationMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `create_account`
-"""
+     - `command`: `create_account`
+    """
 
     command: str = "create_account"
 
@@ -163,10 +168,11 @@ class AccountCreationMessage(NamedTuple, LobbyTargetMessage):
 
 
 class CoopListMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `coop_list`
-"""
+     - `command`: `coop_list`
+    """
 
     command: str = "coop_list"
 
@@ -176,10 +182,11 @@ class CoopListMessage(NamedTuple, LobbyTargetMessage):
 
 
 class MatchmakerInfoMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `matchmaker_info`
-"""
+     - `command`: `matchmaker_info`
+    """
 
     command: str = "matchmaker_info"
 
@@ -189,17 +196,18 @@ class MatchmakerInfoMessage(NamedTuple, LobbyTargetMessage):
 
 
 class SocialRemoveMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `social_remove`  
+      - `command`: `social_remove`  
 
-And at least one of the following:
+    And at least one of the following:
 
- - `friend`: `id` of player to remove from friend list
- - `foe`: `id` of player to remove from foe list
+     - `friend`: `id` of player to remove from friend list
+     - `foe`: `id` of player to remove from foe list
 
-If both `friend` and `foe` are specified, the foe will be ignored
-"""
+    If both `friend` and `foe` are specified, the foe will be ignored
+    """
 
     command: str
     id_to_remove: int
@@ -221,17 +229,18 @@ If both `friend` and `foe` are specified, the foe will be ignored
 
 
 class SocialAddMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `social_add`  
+      - `command`: `social_add`  
 
-And at least one of the following:
+    And at least one of the following:
 
- - `friend`: `id` of player to add to friend list
- - `foe`: `id` of player to add to foe list
- 
-If both `friend` and `foe` are specified, the `foe` will be ignored.
-"""
+     - `friend`: `id` of player to add to friend list
+     - `foe`: `id` of player to add to foe list
+     
+    If both `friend` and `foe` are specified, the `foe` will be ignored.
+    """
 
     command: str
     id_to_add: int
@@ -256,8 +265,9 @@ If both `friend` and `foe` are specified, the `foe` will be ignored.
 
 
 class BottleneckMessage(NamedTuple, LobbyTargetMessage):
-    """TODO: Unsure what this does. Will it still be sent? How does lobbyconnection handle it?
-"""
+    """
+    TODO: Unsure what this does. Will it still be sent? How does lobbyconnection handle it?
+    """
 
     command: str = "Bottleneck"
 
@@ -267,32 +277,33 @@ class BottleneckMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AdminMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `admin`  
-  - `action`: one of `closeFA`, `closelobby`,`broadcast`, `join_channel`
+      - `command`: `admin`  
+      - `action`: one of `closeFA`, `closelobby`,`broadcast`, `join_channel`
 
-Required if `action` is `closeFA` or `closelobby`:
+    Required if `action` is `closeFA` or `closelobby`:
 
- - `user_id`: user id of target player
+     - `user_id`: user id of target player
 
-Optional if `action` is `closelobby`:
+    Optional if `action` is `closelobby`:
 
- - `ban`: json containing ban details
+     - `ban`: json containing ban details
 
-Ban json should contain fiels `reason`, `duration`, and `period`.
-Defaults are currently `Unspecified`, 1, and `SECOND`.
-Admissible periods are `SECOND`, `DAY`, `WEEK`, `MONTH`.
+    Ban json should contain fiels `reason`, `duration`, and `period`.
+    Defaults are currently `Unspecified`, 1, and `SECOND`.
+    Admissible periods are `SECOND`, `DAY`, `WEEK`, `MONTH`.
 
-Required if `action` is `broadcast`:
+    Required if `action` is `broadcast`:
 
- - `message`: message to broadcast
+     - `message`: message to broadcast
 
-Required if `action` is `join_channel`:
+    Required if `action` is `join_channel`:
 
- - `channel`: ? probably some kind of channel id
- - `user_ids`: ? probably ids of all users that will join the channel?
-"""
+     - `channel`: ? probably some kind of channel id
+     - `user_ids`: ? probably ids of all users that will join the channel?
+    """
 
     command: str
     action: str
@@ -355,8 +366,9 @@ Required if `action` is `join_channel`:
 
 
 class HelloMessage(NamedTuple, LobbyTargetMessage):
-    """TODO Description
-"""
+    """
+    TODO Description
+    """
 
     command: str
     login: str
@@ -379,18 +391,19 @@ class HelloMessage(NamedTuple, LobbyTargetMessage):
 
 
 class GameMatchmakingMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `game_matchmaking`  
-  - `state`: `start` or `stop`
+      - `command`: `game_matchmaking`  
+      - `state`: `start` or `stop`
 
-Optional fields:
-  - `faction`: faction of the player if `state` is `start`. Defailt `uef`.
-    Can either be the name (e.g. 'uef') or the enum value (e.g. 1).
-  - `mod`: Currently discarded. If `state` is `start`, this  might at some
-    point specify in which queue to start matchmaking. Default `ladder1v1`
-    if empty.
-"""
+    Optional fields:
+      - `faction`: faction of the player if `state` is `start`. Defailt `uef`.
+        Can either be the name (e.g. 'uef') or the enum value (e.g. 1).
+      - `mod`: Currently discarded. If `state` is `start`, this  might at some
+        point specify in which queue to start matchmaking. Default `ladder1v1`
+        if empty.
+    """
 
     command: str
     mod: str
@@ -418,18 +431,19 @@ Optional fields:
 
 
 class GameHostMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `game_matchmaking`  
+      - `command`: `game_matchmaking`  
 
-Optional fields:
+    Optional fields:
 
-  - `title`: title of the game (default: set by LobbyConnection.command_game_host)  
-  - `mod`: (default: `faf`)  
-  - `mapname`: (default `scmp_007`)  
-  - `password`: (default: none)  
-  - `visibility`: according to games.VisibilityState  
-"""
+      - `title`: title of the game (default: set by LobbyConnection.command_game_host)  
+      - `mod`: (default: `faf`)  
+      - `mapname`: (default `scmp_007`)  
+      - `password`: (default: none)  
+      - `visibility`: according to games.VisibilityState  
+    """
 
     command: str
     title: str
@@ -452,14 +466,15 @@ Optional fields:
 
 
 class GameJoinMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `game_join`  
-  - `uid`: id of game to join
+      - `command`: `game_join`  
+      - `uid`: id of game to join
 
-Optional fields:
-  - `password`: (default: none)
-"""
+    Optional fields:
+      - `password`: (default: none)
+    """
 
     command: str
     uid: int
@@ -538,15 +553,16 @@ class RestoreGameSessionMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AvatarMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:  
+    """
+    Required fields:  
 
-  - `command`: `avatar`  
-  - `action`: `select` or `list_avatar` (default: `list_avatar`)
+      - `command`: `avatar`  
+      - `action`: `select` or `list_avatar` (default: `list_avatar`)
 
-Optional fields:
+    Optional fields:
 
-  - `avatar`: url of new avatar or `null` for default avatar (?) (default: `null`)
-"""
+      - `avatar`: url of new avatar or `null` for default avatar (?) (default: `null`)
+    """
 
     command: str
     action: str
@@ -570,14 +586,15 @@ Optional fields:
 
 
 class AskSessionMessage(NamedTuple, LobbyTargetMessage):
-    """Required fields:
+    """
+    Required fields:
 
- - `command`: `ask_session`
+     - `command`: `ask_session`
 
-Expected fields:
-- `user_agent`: TODO probably `'downlords-faf-client'`
-- `version`: TODO probably version number of downlords-faf-client
-"""
+    Expected fields:
+    - `user_agent`: TODO probably `'downlords-faf-client'`
+    - `version`: TODO probably version number of downlords-faf-client
+    """
 
     command: str
     user_agent: str

--- a/server/clientmessages.py
+++ b/server/clientmessages.py
@@ -389,13 +389,28 @@ class AdminMessage(NamedTuple, LobbyTargetMessage):
         )
 
 
-class HelloMessage(LobbyTargetMessage):
+class HelloMessage(NamedTuple, LobbyTargetMessage):
     """
-    Not yet implemented
+    TODO Description
     """
+    command: str
+    login: str
+    password: str
+    unique_id: int
 
-    def __init__(self, lobbyconnection=None, message=None):
-        raise NotImplementedError
+    @classmethod
+    def build(cls, message):
+        try:
+            login = message["login"].strip()
+            password = message["password"]
+            unique_id = message["unique_id"]
+        except KeyError:
+            raise MessageParsingError(
+                f"Command 'hello' needs fields `login`, `password`, "
+                f"and `unique_id`. "
+                f"Offending message: {message}."
+            )
+        return cls("hello", login, password, unique_id)
 
 
 class GameMatchmakingMessage(NamedTuple, LobbyTargetMessage):
@@ -583,7 +598,7 @@ class AvatarMessage(NamedTuple, LobbyTargetMessage):
         return cls("avatar", action, avatar_url)
 
 
-class AskSessionMessage(LobbyTargetMessage):
+class AskSessionMessage(NamedTuple, LobbyTargetMessage):
     """
     TODO: Description
 
@@ -594,20 +609,19 @@ class AskSessionMessage(LobbyTargetMessage):
      - `command`: `ask_session`
 
     Expected fields:
-     - `user_agent`: TODO probably `'downlords-faf-client'`
-     - `version`: TODO probably version number of downlords-faf-client
-     """
+    - `user_agent`: TODO probably `'downlords-faf-client'`
+    - `version`: TODO probably version number of downlords-faf-client
+    """
+    command: str
+    user_agent: str
+    version: str
 
-    def __init__(self, lobbyconnection=None, message=None):
-        self._connection = lobbyconnection
-        self._message = message
-        self._command = CommandField.ask_session
+    @classmethod
+    def build(cls, message):
+        user_agent = message.get("user_agent")
+        version = message.get("version")
 
-        self._user_agent = message.get("user_agent")
-        self._version = message.get("version")
-
-    async def handle(self):
-        self._connection.command_ask_session()
+        return cls("ask_session", user_agent, version)
 
 
 class MessageParser:

--- a/server/clientmessages.py
+++ b/server/clientmessages.py
@@ -74,8 +74,6 @@ class MessageToClient(Message):
 class LobbyTargetMessage(MessageFromClient):
     """
     Common base class for messages without `target` entry  or entry `'none'`.
-
-    To be handled by a `LobbyConnection`.
     """
 
     @staticmethod
@@ -85,11 +83,7 @@ class LobbyTargetMessage(MessageFromClient):
 
 
 class ConnectivityTargetMessage(NamedTuple, MessageFromClient):
-    """
-    Deprecated functionality for `target` entry `'connectivity'`.
-
-    Will ask client to update to the newest version.
-    """
+    """Deprecated messages with `target` entry `'connectivity'` will be directed here."""
     command: Optional[str]
 
     @classmethod
@@ -99,11 +93,17 @@ class ConnectivityTargetMessage(NamedTuple, MessageFromClient):
 
 
 class GameTargetMessage(NamedTuple, MessageFromClient):
-    """
-    Common base class for messages with `target` entry `'game'`.
+    """ Messages with `target` entry `'game'` will be directed here
+and passed on to a `GameConnection`.
 
-    To be handled by a `GameConnection`.
-    """
+Required fields:
+
+  - `command`: command to be passed on to the `GameConnection`.
+
+Optional fields:
+
+  - `args`: list of arguments to be passed along with the command
+"""
 
     command: str
     args: list
@@ -124,15 +124,10 @@ class GameTargetMessage(NamedTuple, MessageFromClient):
 
 
 class PingMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Returns a 'PONG' message.
+    """Required fields:
 
-    Does not require the client to be authenticated.
-
-    Required fields:
-
-     - `command`: `ping`
-    """
+ - `command`: `ping`
+"""
 
     command: str = "ping"
 
@@ -142,15 +137,10 @@ class PingMessage(NamedTuple, LobbyTargetMessage):
 
 
 class PongMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Does nothing.
+    """Required fields:
 
-    Does not require the client to be authenticated.
-
-    Required fields:
-
-     - `command`: `pong`
-    """
+ - `command`: `pong`
+"""
 
     command: str = "pong"
 
@@ -160,12 +150,10 @@ class PongMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AccountCreationMessage(NamedTuple, LobbyTargetMessage):
-    """
+    """Required fields:
 
-    Required fields:
-
-     - `command`: `create_account`
-    """
+ - `command`: `create_account`
+"""
 
     command: str = "create_account"
 
@@ -175,15 +163,10 @@ class AccountCreationMessage(NamedTuple, LobbyTargetMessage):
 
 
 class CoopListMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Asks server for the list of coop maps.
+    """Required fields:
 
-    Requires the client to be authenticated.
-
-    Required fields:
-
-     - `command`: `coop_list`
-    """
+ - `command`: `coop_list`
+"""
 
     command: str = "coop_list"
 
@@ -193,15 +176,10 @@ class CoopListMessage(NamedTuple, LobbyTargetMessage):
 
 
 class MatchmakerInfoMessage(NamedTuple, LobbyTargetMessage):
-    """
-    TODO: Description
+    """Required fields:
 
-    Requires the client to be authenticated.
-
-    Required fields:
-
-     - `command`: `matchmaker_info`
-    """
+ - `command`: `matchmaker_info`
+"""
 
     command: str = "matchmaker_info"
 
@@ -211,22 +189,17 @@ class MatchmakerInfoMessage(NamedTuple, LobbyTargetMessage):
 
 
 class SocialRemoveMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Remove someone from your friend list or foe list.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `social_remove`  
 
-    Required fields:  
+And at least one of the following:
 
-      - `command`: `social_remove`  
+ - `friend`: `id` of player to remove from friend list
+ - `foe`: `id` of player to remove from foe list
 
-    And at least one of the following:
-
-     - `friend`: `id` of player to remove from friend list
-     - `foe`: `id` of player to remove from foe list
-
-    If both `friend` and `foe` are specified, only the friend will be removed.
-    """
+If both `friend` and `foe` are specified, the foe will be ignored
+"""
 
     command: str
     id_to_remove: int
@@ -248,22 +221,17 @@ class SocialRemoveMessage(NamedTuple, LobbyTargetMessage):
 
 
 class SocialAddMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Add someone to your friend list or foe list.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `social_add`  
 
-    Required fields:  
+And at least one of the following:
 
-      - `command`: `social_add`  
-
-    And at least one of the following:
-
-     - `friend`: `id` of player to add to friend list
-     - `foe`: `id` of player to add to foe list
-
-    If both `friend` and `foe` are specified, only the friend will be added.
-    """
+ - `friend`: `id` of player to add to friend list
+ - `foe`: `id` of player to add to foe list
+ 
+If both `friend` and `foe` are specified, the `foe` will be ignored.
+"""
 
     command: str
     id_to_add: int
@@ -288,9 +256,8 @@ class SocialAddMessage(NamedTuple, LobbyTargetMessage):
 
 
 class BottleneckMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Not yet implemented
-    """
+    """TODO: Unsure what this does. Will it still be sent? How does lobbyconnection handle it?
+"""
 
     command: str = "Bottleneck"
 
@@ -300,37 +267,32 @@ class BottleneckMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AdminMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Various admin functionality crammed into a single command
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `admin`  
+  - `action`: one of `closeFA`, `closelobby`,`broadcast`, `join_channel`
 
-    Required fields:  
+Required if `action` is `closeFA` or `closelobby`:
 
-      - `command`: `admin`  
-      - `action`: one of `closeFA`, `closelobby`,`broadcast`, `join_channel`
+ - `user_id`: user id of target player
 
-    Required if `action` is `closeFA` or `closelobby`:
+Optional if `action` is `closelobby`:
 
-     - `user_id`: user id of target player
+ - `ban`: json containing ban details
 
-    Optional if `action` is `closelobby`:
+Ban json should contain fiels `reason`, `duration`, and `period`.
+Defaults are currently `Unspecified`, 1, and `SECOND`.
+Admissible periods are `SECOND`, `DAY`, `WEEK`, `MONTH`.
 
-     - `ban`: json containing ban details
+Required if `action` is `broadcast`:
 
-    Ban json should contain fiels `reason`, `duration`, and `period`.
-    Defaults are currently `Unspecified`, 1, and `SECOND`.
-    Admissible periods are `SECOND`, `DAY`, `WEEK`, `MONTH`.
+ - `message`: message to broadcast
 
-    Required if `action` is `broadcast`:
+Required if `action` is `join_channel`:
 
-     - `message`: message to broadcast
-
-    Required if `action` is `join_channel`:
-
-     - `channel`: ? probably some kind of channel id
-     - `user_ids`: ? probably ids of all users that will join the channel?
-    """
+ - `channel`: ? probably some kind of channel id
+ - `user_ids`: ? probably ids of all users that will join the channel?
+"""
 
     command: str
     action: str
@@ -393,9 +355,8 @@ class AdminMessage(NamedTuple, LobbyTargetMessage):
 
 
 class HelloMessage(NamedTuple, LobbyTargetMessage):
-    """
-    TODO Description
-    """
+    """TODO Description
+"""
 
     command: str
     login: str
@@ -418,23 +379,18 @@ class HelloMessage(NamedTuple, LobbyTargetMessage):
 
 
 class GameMatchmakingMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Queue up for matchmaking or cancel matchmaking search.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `game_matchmaking`  
+  - `state`: `start` or `stop`
 
-    Required fields:  
-
-      - `command`: `game_matchmaking`  
-      - `state`: `start` or `stop`
-
-    Optional fields:
-      - `faction`: faction of the player if `state` is `start`. Defailt `uef`.
-        Can either be the name (e.g. 'uef') or the enum value (e.g. 1).
-      - `mod`: Currently discarded. If `state` is `start`, this  might at some
-        point specify in which queue to start matchmaking. Default `ladder1v1`
-        if empty.
-    """
+Optional fields:
+  - `faction`: faction of the player if `state` is `start`. Defailt `uef`.
+    Can either be the name (e.g. 'uef') or the enum value (e.g. 1).
+  - `mod`: Currently discarded. If `state` is `start`, this  might at some
+    point specify in which queue to start matchmaking. Default `ladder1v1`
+    if empty.
+"""
 
     command: str
     mod: str
@@ -462,24 +418,18 @@ class GameMatchmakingMessage(NamedTuple, LobbyTargetMessage):
 
 
 class GameHostMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Host a game.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `game_matchmaking`  
 
-    Required fields:  
+Optional fields:
 
-      - `command`: `game_matchmaking`  
-
-    Optional fields:
-      - `title`: title of the game (default: set by LobbyConnection.command_game_host)
-      - `mod`: (default: `faf`)
-      - `mapname`: (default `scmp_007`)
-      - `password`: (default: none)
-    password: Optional[str]
-
-      - `visibility`: according to games.VisibilityState
-    """
+  - `title`: title of the game (default: set by LobbyConnection.command_game_host)  
+  - `mod`: (default: `faf`)  
+  - `mapname`: (default `scmp_007`)  
+  - `password`: (default: none)  
+  - `visibility`: according to games.VisibilityState  
+"""
 
     command: str
     title: str
@@ -502,19 +452,14 @@ class GameHostMessage(NamedTuple, LobbyTargetMessage):
 
 
 class GameJoinMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Join a game.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `game_join`  
+  - `uid`: id of game to join
 
-    Required fields:  
-
-      - `command`: `game_join`  
-      - `uid`: id of game to join
-
-    Optional fields:
-      - `password`: (default: none)
-    """
+Optional fields:
+  - `password`: (default: none)
+"""
 
     command: str
     uid: int
@@ -536,9 +481,7 @@ class GameJoinMessage(NamedTuple, LobbyTargetMessage):
 
 
 class ICEServersMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Not yet implemented
-    """
+    """ TODO: Description """
 
     command: str
 
@@ -548,9 +491,7 @@ class ICEServersMessage(NamedTuple, LobbyTargetMessage):
 
 
 class ModvaultMessage(NamedTuple, LobbyTargetMessage):
-    """
-    TODO: Description
-    """
+    """ TODO: Description """
 
     command: str
     type_field: str
@@ -578,9 +519,7 @@ class ModvaultMessage(NamedTuple, LobbyTargetMessage):
 
 
 class RestoreGameSessionMessage(NamedTuple, LobbyTargetMessage):
-    """
-    TODO Description
-    """
+    """ TODO Description """
 
     command: str
     game_id: int
@@ -599,18 +538,15 @@ class RestoreGameSessionMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AvatarMessage(NamedTuple, LobbyTargetMessage):
-    """
-    Asks server to either return a list of avatars for the current user
-    or select a new avatar.
+    """Required fields:  
 
-    Requires the client to be authenticated.
+  - `command`: `avatar`  
+  - `action`: `select` or `list_avatar` (default: `list_avatar`)
 
-    Required fields:  
+Optional fields:
 
-      - `command`: `avatar`  
-      - `action`: `select` or `list_avatar` (default: `list_avatar`)
-      - `avatar`: url of new avatar or `null` for default avatar (?) (default: `null`)
-    """
+  - `avatar`: url of new avatar or `null` for default avatar (?) (default: `null`)
+"""
 
     command: str
     action: str
@@ -634,19 +570,14 @@ class AvatarMessage(NamedTuple, LobbyTargetMessage):
 
 
 class AskSessionMessage(NamedTuple, LobbyTargetMessage):
-    """
-    TODO: Description
+    """Required fields:
 
-    Requires the client to be authenticated.
+ - `command`: `ask_session`
 
-    Required fields:
-
-     - `command`: `ask_session`
-
-    Expected fields:
-    - `user_agent`: TODO probably `'downlords-faf-client'`
-    - `version`: TODO probably version number of downlords-faf-client
-    """
+Expected fields:
+- `user_agent`: TODO probably `'downlords-faf-client'`
+- `version`: TODO probably version number of downlords-faf-client
+"""
 
     command: str
     user_agent: str
@@ -661,9 +592,7 @@ class AskSessionMessage(NamedTuple, LobbyTargetMessage):
 
 
 class MessageParser:
-    """
-    Assembles a `Message` object from received json-like dict.
-    """
+    """Assembles a `Message` object from received json-like dict."""
 
     @staticmethod
     def parse(message):
@@ -687,9 +616,7 @@ class MessageParser:
 
 
 class MessageParsingError(Exception):
-    """
-    Raised if trying to parse a message with invalid format.
-    """
+    """Raised if trying to parse a message with invalid format."""
 
     pass
 

--- a/server/clientmessages.py
+++ b/server/clientmessages.py
@@ -84,16 +84,18 @@ class LobbyTargetMessage(MessageFromClient):
         return COMMAND_TO_CLASS[command].build(message)
 
 
-class ConnectivityTargetMessage(MessageFromClient):
+class ConnectivityTargetMessage(NamedTuple, MessageFromClient):
     """
     Deprecated functionality for `target` entry `'connectivity'`.
 
     Will ask client to update to the newest version.
     """
+    command: Optional[str]
 
-    @staticmethod
-    def build(message):
-        raise NotImplementedError("TODO")
+    @classmethod
+    def build(cls, message):
+        command = message.get("command")
+        return cls(command)
 
 
 class GameTargetMessage(NamedTuple, MessageFromClient):
@@ -677,7 +679,7 @@ class MessageParser:
         if target is Target.game:
             return GameTargetMessage.build(message)
         elif target is Target.connectivity:
-            return ConnectivityTargetMessage(message)
+            return ConnectivityTargetMessage.build(message)
         else:
             return LobbyTargetMessage.parse(message)
 

--- a/server/docstrings.py
+++ b/server/docstrings.py
@@ -1,0 +1,28 @@
+def trim_docstring(docstring: str) -> str: #pragma: no cover
+    """
+    Trims indents of docstrings according to PEP 257
+    Code origin: https://www.python.org/dev/peps/pep-0257/
+    """
+    if not docstring:
+        return ''
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = float("inf")
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < float("inf"):
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return '\n'.join(trimmed)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -451,7 +451,7 @@ class LobbyConnection:
 
                 self._logger.info(
                     "%s broadcasting message to all players: %s",
-                    self.player.login, message_text
+                    self.player.login, broadcast_text
                 )
                 await gather_without_exceptions(tasks, Exception)
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -1081,6 +1081,17 @@ class LobbyConnection:
             'ttl': ttl
         })
 
+    @handler(ConnectivityTargetMessage)
+    @Decorators.require_auth
+    async def handle_connectivity_messages(self, parsed_message):
+        if parsed_message.command == "InitiateTest":
+            self._register_connectivity_test()
+            raise ClientError(
+                f"Your client version is no longer supported. "
+                f"Please update to the newest version: https://faforever.com"
+            )
+
+
     async def send_warning(self, message: str, fatal: bool=False):
         """
         Display a warning message to the client
@@ -1154,7 +1165,7 @@ class LobbyConnection:
                            f"Reason :\n "
                            f"{reason}"), recoverable=False)
 
-    def register_connectivity_test(self):
+    def _register_connectivity_test(self):
         self._attempted_connectivity_test = True
 
     @property

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -179,10 +179,7 @@ class LobbyConnection:
         self._logger.log(TRACE, "<<: %s", message)
 
         try:
-            parsed_message = MessageParser.parse(
-                self,
-                message
-            )
+            parsed_message = MessageParser.parse(message)
 
             await self._handle_message(parsed_message)
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -38,6 +38,7 @@ from .protocol import QDataStreamProtocol
 from .rating import RatingType
 from .types import Address
 from  .clientmessages import *
+from .docstrings import trim_docstring
 
 
 __pdoc__ = {}
@@ -48,7 +49,7 @@ def handler(handling_class):
         COMMAND_HANDLERS[handling_class] = function
 
         func_string = function.__doc__ or "[Method description missing]"
-        func_string = str(func_string).lstrip()
+        func_string = trim_docstring(func_string)
 
         if hasattr(function, "_requires_auth") and function._requires_auth:
             auth_string = "Requires the client to be authenticated."
@@ -56,7 +57,7 @@ def handler(handling_class):
             auth_string = "Does not require the client to be authenticated."
         
         class_string = handling_class.__doc__ or "[Message description missing]"
-        class_string = str(class_string).lstrip()
+        class_string = trim_docstring(class_string)
 
         new_docstring = "\n\n".join([func_string, auth_string, class_string])
         __pdoc__[f"LobbyConnection.{function.__name__}"] = new_docstring

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -63,15 +63,6 @@ class ClientError(Exception):
         self.recoverable = recoverable
 
 
-class MessageHandlingError(Exception):
-    """
-    A ValueError for the fields of a clientmessages.Message
-    """
-    def __init__(self, message, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.message = message
-
-
 class AuthenticationError(Exception):
     def __init__(self, message, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1164,7 +1155,3 @@ class LobbyConnection:
 
     def _register_connectivity_test(self):
         self._attempted_connectivity_test = True
-
-    @property
-    def is_authenticated(self):
-        return self._is_authenticated

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -419,7 +419,11 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
             )
         )
 
-    await proto.send_message({"command": command})
+    command_message = {"command": command}
+    if command == "game_join":
+        command_message["uid"] = 1
+
+    await proto.send_message(command_message)
 
     msg = await proto.read_message()
     assert msg == {

--- a/tests/unit_tests/test_clientmessages.py
+++ b/tests/unit_tests/test_clientmessages.py
@@ -1,0 +1,516 @@
+import server.clientmessages as clientmessages
+from server.clientmessages import MessageParsingError
+import pytest
+
+
+def test_game_target_message_without_command():
+    message = {}
+    with pytest.raises(MessageParsingError):
+        clientmessages.GameTargetMessage.build(message)
+
+
+def test_game_target_message_default_arguments_empty():
+    command = "fake_command"
+    message = {"command": command}
+    parsed_message = clientmessages.GameTargetMessage.build(message)
+
+    assert parsed_message == clientmessages.GameTargetMessage(command, [])
+
+
+def test_game_target_message():
+    command = "fake_command"
+    arguments = [1, 2, 3]
+    message = {"command": command, "args": arguments}
+    parsed_message = clientmessages.GameTargetMessage.build(message)
+
+    assert parsed_message == clientmessages.GameTargetMessage(command, arguments)
+
+
+def test_ping_message():
+    parsed_message = clientmessages.PingMessage.build({})
+    assert parsed_message.command == "ping"
+
+
+def test_pong_message():
+    parsed_message = clientmessages.PongMessage.build({})
+    assert parsed_message.command == "pong"
+
+
+def test_account_creation_message():
+    parsed_message = clientmessages.AccountCreationMessage.build({})
+    assert parsed_message.command == "create_account"
+
+
+def test_coop_list_message():
+    parsed_message = clientmessages.CoopListMessage.build({})
+    assert parsed_message.command == "coop_list"
+
+
+def test_matchmaker_info_message():
+    parsed_message = clientmessages.MatchmakerInfoMessage.build({})
+    assert parsed_message.command == "matchmaker_info"
+
+
+def test_bottleneck_message():
+    parsed_message = clientmessages.BottleneckMessage.build({})
+    assert parsed_message.command == "Bottleneck"
+
+
+def test_iceservers_message():
+    parsed_message = clientmessages.ICEServersMessage.build({})
+    assert parsed_message.command == "ice_servers"
+
+
+def test_social_remove_message_missing_fields():
+    message = {"command": "social_remove"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.SocialRemoveMessage.build(message)
+
+
+def test_social_remove_message():
+    friend_message = {"command": "social_remove", "friend": 1}
+    foe_message = {"command": "social_remove", "foe": 2}
+
+    parsed_friend_message = clientmessages.SocialRemoveMessage.build(friend_message)
+    parsed_foe_message = clientmessages.SocialRemoveMessage.build(foe_message)
+
+    assert parsed_friend_message.id_to_remove == 1
+    assert parsed_foe_message.id_to_remove == 2
+
+
+def test_social_remove_message_if_both_specified_remove_friend():
+    friend_id, foe_id = 1, 2
+    ambiguous_message = {"command": "social_remove", "friend": friend_id, "foe": foe_id}
+    parsed_message = clientmessages.SocialRemoveMessage.build(ambiguous_message)
+
+    assert parsed_message.id_to_remove == friend_id
+
+
+def test_social_add_message_missing_fields():
+    message = {"command": "social_add"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.SocialAddMessage.build(message)
+
+
+def test_social_add_message():
+    friend_message = {"command": "social_add", "friend": 1}
+    foe_message = {"command": "social_add", "foe": 2}
+
+    parsed_friend_message = clientmessages.SocialAddMessage.build(friend_message)
+    parsed_foe_message = clientmessages.SocialAddMessage.build(foe_message)
+
+    assert parsed_friend_message.id_to_add == 1
+    assert parsed_friend_message.adding_a_friend is True
+
+    assert parsed_foe_message.id_to_add == 2
+    assert parsed_foe_message.adding_a_friend is False
+
+
+def test_admin_message_missing_fields():
+    message = {"command": "admin"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+    message = {"command": "admin", "action": "closeFA"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+    message = {"command": "admin", "action": "closelobby"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+    message = {"command": "admin", "action": "join_channel"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+    message = {"command": "admin", "action": "join_channel", "user_ids": [1, 2, 3]}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+    message = {"command": "admin", "action": "join_channel", "channel": "channel"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+
+def test_admin_message_action_closeFA():
+    user_id = 1
+    message = {"command": "admin", "action": "closeFA", "user_id": user_id}
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.command == "admin"
+    assert parsed_message.action == "closeFA"
+    assert parsed_message.target_user_id == user_id
+
+
+def test_admin_message_action_closelobby():
+    user_id = 1
+    message = {"command": "admin", "action": "closelobby", "user_id": user_id}
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.command == "admin"
+    assert parsed_message.action == "closelobby"
+    assert parsed_message.target_user_id == user_id
+
+
+def test_admin_message_action_broadcast():
+    announcement = "Good luck, Commander."
+    message = {"command": "admin", "action": "broadcast", "message": announcement}
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.command == "admin"
+    assert parsed_message.action == "broadcast"
+    assert parsed_message.broadcast_message == announcement
+
+
+def test_admin_message_action_join_channel():
+    channel_name = "test_channel"
+    channel_users = [1, 2, 3]
+    message = {
+        "command": "admin",
+        "action": "join_channel",
+        "channel": channel_name,
+        "user_ids": channel_users,
+    }
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.command == "admin"
+    assert parsed_message.action == "join_channel"
+    assert parsed_message.channel == channel_name
+    assert parsed_message.channel_users == channel_users
+
+
+def test_admin_message_ban_defaults():
+    message = {"command": "admin", "action": "closelobby", "user_id": 0, "ban": {}}
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.ban_data == {
+        "reason": "Unspecified",
+        "duration": 1,
+        "period": "SECOND",
+    }
+
+
+def test_admin_message_ban():
+    ban_reason = "test ban"
+    ban_duration = 99
+    ban_period = "Month"
+    message = {
+        "command": "admin",
+        "action": "closelobby",
+        "user_id": 0,
+        "ban": {"reason": ban_reason, "duration": ban_duration, "period": ban_period},
+    }
+    parsed_message = clientmessages.AdminMessage.build(message)
+
+    assert parsed_message.ban_data == {
+        "reason": ban_reason,
+        "duration": ban_duration,
+        "period": ban_period.upper(),
+    }
+
+
+def test_admin_message_invalid_action():
+    message = {"command": "admin", "action": "invalid"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AdminMessage.build(message)
+
+
+def test_hello_message_missing_fields():
+    message = {"command": "hello"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.HelloMessage.build(message)
+
+
+def test_hello_message():
+    login, password, uid = "foo", "bar", 0
+    message = {
+        "command": "hello",
+        "login": login,
+        "password": password,
+        "unique_id": uid,
+    }
+    parsed_message = clientmessages.HelloMessage.build(message)
+
+    assert parsed_message.login == login
+    assert parsed_message.password == password
+    assert parsed_message.unique_id == uid
+
+
+def test_hello_message_login_stripped():
+    login, password, uid = "foo   ", "bar", 0
+    message = {
+        "command": "hello",
+        "login": login,
+        "password": password,
+        "unique_id": uid,
+    }
+    parsed_message = clientmessages.HelloMessage.build(message)
+
+    assert parsed_message.login == login.strip()
+
+
+def test_game_matchmaking_message():
+    mod, state, faction = "faf", "start", 2
+    message = {
+        "command": "game_matchmaking",
+        "mod": mod,
+        "state": state,
+        "faction": faction,
+    }
+    parsed_message = clientmessages.GameMatchmakingMessage.build(message)
+
+    assert parsed_message.mod == mod
+    assert parsed_message.state == state
+    assert parsed_message.faction == faction
+
+
+def test_game_matchmaking_message_defaults():
+    message = {"command": "game_matchmaking", "state": "start"}
+    parsed_message = clientmessages.GameMatchmakingMessage.build(message)
+
+    assert parsed_message.mod == "ladder1v1"
+    assert parsed_message.faction == "uef"
+
+
+def test_game_matchmaking_message_invalid_state():
+    message = {"command": "game_matchmaking", "state": "invalid"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.GameMatchmakingMessage.build(message)
+
+
+def test_game_host_message():
+    title, mod, mapname, password, visibility = (
+        "faketitle",
+        "fakemod",
+        "fakemap",
+        "fakepwd",
+        "fakevisibility",
+    )
+    message = {
+        "command": "host_game",
+        "title": title,
+        "mod": mod,
+        "mapname": mapname,
+        "password": password,
+        "visibility": visibility,
+    }
+
+    parsed_message = clientmessages.GameHostMessage.build(message)
+
+    assert parsed_message.title == title
+    assert parsed_message.mod == mod
+    assert parsed_message.mapname == mapname
+    assert parsed_message.password == password
+    assert parsed_message.visibility == visibility
+
+
+def test_game_host_message_defaults():
+    message = {"command": "host_game"}
+
+    parsed_message = clientmessages.GameHostMessage.build(message)
+
+    assert parsed_message.title is None
+    assert parsed_message.mod == "faf"
+    assert parsed_message.mapname == "scmp_007"
+    assert parsed_message.password is None
+    assert parsed_message.visibility is None
+
+
+def test_game_host_message_empty_mod_string_is_replaced_by_default():
+    message = {"command": "host_game", "mod": ""}
+
+    parsed_message = clientmessages.GameHostMessage.build(message)
+
+    assert parsed_message.mod == "faf"
+
+
+def test_game_join_message():
+    uid, password = 0, "foo"
+    message = {"command": "game_join", "uid": uid, "password": password}
+
+    parsed_message = clientmessages.GameJoinMessage.build(message)
+
+    assert parsed_message.uid == uid
+    assert parsed_message.password == password
+
+
+def test_game_join_password_default():
+    message = {"command": "game_join", "uid": 1}
+
+    parsed_message = clientmessages.GameJoinMessage.build(message)
+
+    assert parsed_message.password is None
+
+
+def test_game_join_uid_accepts_string():
+    message = {"command": "game_join", "uid": "1"}
+
+    parsed_message = clientmessages.GameJoinMessage.build(message)
+
+    assert parsed_message.uid == 1
+
+
+def test_game_join_missing_uid():
+    message = {"command": "game_join"}
+
+    with pytest.raises(MessageParsingError):
+        clientmessages.GameJoinMessage.build(message)
+
+
+def test_modvault_message_type_start():
+    message = {"command": "modvault", "type": "start"}
+    parsed_message = clientmessages.ModvaultMessage.build(message)
+
+    assert parsed_message.type_field == "start"
+    assert parsed_message.uid is None
+
+
+@pytest.mark.parametrize("type_string", ["like", "download"])
+def test_modvault_message_other_type(type_string):
+    uid = 0
+    message = {"command": "modvault", "type": type_string, "uid": uid}
+    parsed_message = clientmessages.ModvaultMessage.build(message)
+
+    assert parsed_message.type_field == type_string
+    assert parsed_message.uid == uid
+
+
+@pytest.mark.parametrize("type_string", ["like", "download"])
+def test_modvault_message_other_types_need_uid(type_string):
+    message = {"command": "modvault", "type": type_string}
+    with pytest.raises(MessageParsingError):
+        clientmessages.ModvaultMessage.build(message)
+
+
+def test_modvault_message_invalid_type():
+    message = {"command": "modvault", "type": "invalid"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.ModvaultMessage.build(message)
+
+
+def test_restore_game_message():
+    game_id = 0
+    message = {"command": "game_join", "game_id": game_id}
+
+    parsed_message = clientmessages.RestoreGameSessionMessage.build(message)
+
+    assert parsed_message.game_id == game_id
+
+
+def test_restore_game_id_accepts_string():
+    message = {"command": "game_join", "game_id": "1"}
+
+    parsed_message = clientmessages.RestoreGameSessionMessage.build(message)
+
+    assert parsed_message.game_id == 1
+
+
+def test_restore_game_missing_game_id():
+    message = {"command": "game_join"}
+
+    with pytest.raises(MessageParsingError):
+        clientmessages.RestoreGameSessionMessage.build(message)
+
+
+def test_avatar_message_list():
+    message = {"command": "avatar", "action": "list_avatar"}
+    parsed_message = clientmessages.AvatarMessage.build(message)
+
+    assert parsed_message.action == "list_avatar"
+
+
+def test_avatar_message_select():
+    url = "fake avatar url"
+    message = {"command": "avatar", "action": "select", "avatar": url}
+    parsed_message = clientmessages.AvatarMessage.build(message)
+
+    assert parsed_message.action == "select"
+    assert parsed_message.url == url
+
+
+def test_avatar_message_defaults():
+    message = {"command": "avatar"}
+    parsed_message = clientmessages.AvatarMessage.build(message)
+    assert parsed_message.action == "list_avatar"
+
+    message = {"command": "avatar", "action": "select"}
+    parsed_message = clientmessages.AvatarMessage.build(message)
+    assert parsed_message.url is None
+
+
+def test_avatar_message_url_accepts_null():
+    message = {"command": "avatar", "action": "select", "avatar": "null"}
+    parsed_message = clientmessages.AvatarMessage.build(message)
+
+    assert parsed_message.url is None
+
+
+def test_avatar_message_invalid_action():
+    message = {"command": "avatar", "action": "invalid"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.AvatarMessage.build(message)
+
+
+def test_ask_session_message():
+    agent, version = "downlord", "0.0.1"
+    message = {"command": "ask_session", "user_agent": agent, "version": version}
+    parsed_message = clientmessages.AskSessionMessage.build(message)
+
+    assert parsed_message.user_agent == agent
+    assert parsed_message.version == version
+
+
+def test_ask_session_message_defaults():
+    message = {"command": "ask_session"}
+    parsed_message = clientmessages.AskSessionMessage.build(message)
+
+    assert parsed_message.user_agent is None
+    assert parsed_message.version is None
+
+
+def test_messageparser_game_target():
+    message = {"command": "fake", "target": "game"}
+    parsed_message = clientmessages.MessageParser.parse(message)
+
+    assert isinstance(parsed_message, clientmessages.GameTargetMessage)
+
+
+def test_messageparser_connectivity_target():
+    message = {"target": "connectivity"}
+    parsed_message = clientmessages.MessageParser.parse(message)
+
+    assert isinstance(parsed_message, clientmessages.ConnectivityTargetMessage)
+
+
+@pytest.mark.xfail
+def test_messageparser_no_target_goes_to_lobby():
+    message = {"command": "ping"}
+    parsed_message = clientmessages.MessageParser.parse(message)
+
+    assert issubclass(parsed_message.__class__, clientmessages.LobbyTargetMessage)
+
+
+@pytest.mark.xfail
+def test_messageparser_invalid_target_goes_to_lobby():
+    message = {"command": "ping", "target": "invalid"}
+    parsed_message = clientmessages.MessageParser.parse(message)
+
+    assert issubclass(parsed_message.__class__, clientmessages.LobbyTargetMessage)
+
+
+def test_messageparser_parse_command():
+    message = {"command": "ping"}
+    parsed_command = clientmessages.MessageParser.parse_command(message)
+    assert parsed_command is clientmessages.CommandField.ping
+
+
+def test_messageparser_parse_invalid_command():
+    message = {"command": "invalid"}
+    with pytest.raises(MessageParsingError):
+        clientmessages.MessageParser.parse_command(message)
+
+
+def test_messageparser_parse_missing():
+    message = {}
+    with pytest.raises(MessageParsingError):
+        clientmessages.MessageParser.parse_command(message)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1019,3 +1019,19 @@ async def test_connectivity_tests_registered(lobbyconnection):
     })
 
     assert lobbyconnection._attempted_connectivity_test is True
+
+
+# cannot simply mock-overwrite command_hello, since the routing decorator will
+# direct to the old method
+@pytest.mark.xfail
+async def test_command_hello_routing(lobbyconnection):
+    lobbyconnection.command_hello = CoroutineMock()
+
+    await lobbyconnection.on_message_received({
+        "command": "hello",
+        "login": "foo",
+        "password": "bar",
+        "unique_id": 1,
+    })
+
+    lobbyconnection.command_hello.assert_called_once()

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1008,3 +1008,14 @@ async def test_check_policy_conformity_fatal(lobbyconnection, policy_server):
             honest = await lobbyconnection.check_policy_conformity(1, result, session=100)
             assert honest is False
             lobbyconnection.abort.assert_called_once()
+
+
+async def test_connectivity_tests_registered(lobbyconnection):
+    assert lobbyconnection._attempted_connectivity_test is False
+
+    await lobbyconnection.on_message_received({
+        "command": "InitiateTest",
+        "target": "connectivity"
+    })
+
+    assert lobbyconnection._attempted_connectivity_test is True


### PR DESCRIPTION
Makes explicit what messages the server expects from clients and generates documentation accordingly, see Issue #482.

Parsing logic has been moved from `LobbyConnection.on_message_received`, partially to `clientmessages.MessageParser` and partially to the factory methods of Messages associated with a given command.

To generate documentation, install `pdoc3` and run it from a pipenv shell in the server root:
```
$ pipenv shell
$ pdoc3 --html server
```
The documentation target should be the `server` folder, even if you are only interested in `server/lobbyconnection.py`, to get all imports right.
Pdoc will produce a folder named `html`, to see the protocol documentation open `html/server/lobbyconnection.html`, where every displayed method of `LobbyConnection` reflects one message format (usually uniquely identified by its "command" entry).

Information about what the server does in reaction to a method is stored in the docstring of the handling message (e.g. `LobbyConnection.command_ping`), information about the expected format is stored in the message class doing the parsing (e.g. `clientmessages.PingMessage`). Both are concatenated, along with information on whether the client needs to be authenticated, and overwrite the pdoc docstring by creating an appropriate entry in the `__pdoc__` dict of `lobbymessages`.

The original intent was to document he individual message classes, but since `lobbyconnection` depends on `clientmessages` and the `handler` routing happens in `lobbyconnection`, it is easier to pull the `clientmessages` docstrings into `lobbyconnection` than the other way around.
Let me know if you have thoughts or considerations on generating the documentation differently.

As far as running different protocol versions in parallel goes, I would hope that the `clientmessages` module is modular enough, as long as the signatures of the handling `LobbyConnection` methods don't change. ("Signature" here meaning what fields are expected in the parsed message.)

While `clientmessages` has its own unit tests to document the expected parsing behavior, I am not yet confident that `lobbyconnection` is sufficiently covered, especially regarding error handling. 