### PR TITLE
Issue/#535 Add username or session id to trace messages

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -71,7 +71,7 @@ class GameConnection(GpgNetServerProtocol):
     async def send_message(self, message):
         message['target'] = "game"
 
-        self._logger.log(TRACE, ">>: %s", message)
+        self._logger.log(TRACE, ">> %s: %s", self.player.login, message)
         await self.protocol.send_message(message)
 
     async def _handle_idle_state(self):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -92,6 +92,13 @@ class LobbyConnection:
     def authenticated(self):
         return self._authenticated
 
+    def get_user_identifier(self) -> str:
+        """For logging purposes"""
+        if self.player:
+            return self.player.login
+
+        return str(self.session)
+
     @asyncio.coroutine
     def on_connection_made(self, protocol: QDataStreamProtocol, peername: Address):
         self.protocol = protocol
@@ -126,7 +133,7 @@ class LobbyConnection:
         """
         Dispatches incoming messages
         """
-        self._logger.log(TRACE, "<<: %s", message)
+        self._logger.log(TRACE, "<< %s: %s", self.get_user_identifier(), message)
 
         try:
             cmd = message['command']
@@ -971,7 +978,7 @@ class LobbyConnection:
         :param message:
         :return:
         """
-        self._logger.log(TRACE, ">>: %s", message)
+        self._logger.log(TRACE, ">> %s: %s", self.get_user_identifier(), message)
         await self.protocol.send_message(message)
 
     async def drain(self):


### PR DESCRIPTION
The trace messages will log the username if the user has logged in, otherwise they'll log the session id.

```
DEBUG    Feb 26  19:12:56 ServerContext                  ServerContext(LobbyServer): Client connected
DEBUG    Feb 26  19:12:56 LobbyConnection                LobbyConnection initialized
TRACE    Feb 26  19:12:58 LobbyConnection                << 2715862830: {'command': 'ask_session', 'user_agent': 'askaholics-faf-cli', 'version': '1.0.0'}
TRACE    Feb 26  19:12:58 LobbyConnection                >> 2715862830: {'command': 'notice', 'style': 'info', 'text': 'You are using an unofficial client version! Some features might not work as expected. If you experience any problems please download the latest version of the official client from <a href="https://www.faforever.com">https://www.faforever.com</a>'}
TRACE    Feb 26  19:12:58 LobbyConnection                >> 2715862830: {'command': 'session', 'session': 2715862830}
TRACE    Feb 26  19:12:58 LobbyConnection                << 2715862830: {'command': 'hello', 'login': 'test', 'password': '10a6e6cc8311a3e2bcc09bf6c199adecd5dd59408c343e926b129c4914f3cb01', 'unique_id': '<snip>'}
DEBUG    Feb 26  19:12:58 LobbyConnection                Login from: 1, test, 2715862830
ERROR    Feb 26  19:12:58 LobbyConnection                Failure updating NickServ password for test
TRACE    Feb 26  19:12:58 LobbyConnection                >> test: {'command': 'welcome', 'me': {'id': 1, 'login': 'test', 'global_rating': (2000.0, 125.0), 'ladder_rating': (2000.0, 125.0), 'number_of_games': 5, 'country': '', 'clan': '678'}, 'id': 1, 'login': 'test'}
TRACE    Feb 26  19:12:58 LobbyConnection                >> test: {'command': 'player_info', 'players': [{'id': 1, 'login': 'test', 'global_rating': (2000.0, 125.0), 'ladder_rating': (2000.0, 125.0), 'number_of_games': 5, 'country': '', 'clan': '678'}]}
TRACE    Feb 26  19:12:58 LobbyConnection                >> test: {'command': 'social', 'autojoin': ['#moderators', '#678_clan'], 'channels': ['#moderators', '#678_clan'], 'friends': [], 'foes': [3], 'power': 2}
TRACE    Feb 26  19:12:58 LobbyConnection                >> test: {'command': 'game_info', 'games': []}
```

closes #535 