### PR TITLE
Placating flake8

### DIFF
--- a/patcher.py
+++ b/patcher.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
     source = sys.argv[1]
     target = sys.argv[2]
     patchname = sys.argv[3]
-   
+
     patchfile = open(patchname, 'w')
-    subprocess.call(['xdelta3', '-I0','-B134217728', '-P16777216', '-W16777216', '-9', '-s', source, target], stdout = patchfile)
+    subprocess.call(['xdelta3', '-I0', '-B134217728', '-P16777216', '-W16777216', '-9', '-s', source, target], stdout=patchfile)
     patchfile.close()

--- a/server/config.py
+++ b/server/config.py
@@ -35,7 +35,7 @@ API_BASE_URL = os.getenv("API_BASE_URL", "http://api.test.faforever.com/")
 USE_API = os.getenv("USE_API", 'true').lower() == 'true'
 
 FAF_POLICY_SERVER_BASE_URL = os.getenv("FAF_POLICY_SERVER_BASE_URL", "http://faf-policy-server")
-FORCE_STEAM_LINK_AFTER_DATE = int(os.getenv('FORCE_STEAM_LINK_AFTER_DATE', 1536105599)) # 5 september 2018 by default
+FORCE_STEAM_LINK_AFTER_DATE = int(os.getenv('FORCE_STEAM_LINK_AFTER_DATE', 1536105599))  # 5 september 2018 by default
 FORCE_STEAM_LINK = os.getenv('FORCE_STEAM_LINK', 'false').lower() == 'true'
 
 # How long we wait for a connection to read our messages before we consider

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -71,16 +71,16 @@ friends_and_foes = Table(
 
 game_featuredMods = Table(
     'game_featuredMods', metadata,
-    Column('id',            Integer,    primary_key=True),
-    Column('gamemod',       String,     unique=True),
-    Column('description',   Text,       nullable=False),
-    Column('name',          String,     nullable=False),
-    Column('publish',       Boolean,    nullable=False, server_default='f'),
-    Column('order',         Integer,    nullable=False, server_default='0'),
-    Column('git_url',       String),
-    Column('git_branch',    String),
-    Column('file_extension',String),
-    Column('allow_override',Boolean)
+    Column('id',             Integer,    primary_key=True),
+    Column('gamemod',        String,     unique=True),
+    Column('description',    Text,       nullable=False),
+    Column('name',           String,     nullable=False),
+    Column('publish',        Boolean,    nullable=False, server_default='f'),
+    Column('order',          Integer,    nullable=False, server_default='0'),
+    Column('git_url',        String),
+    Column('git_branch',     String),
+    Column('file_extension', String),
+    Column('allow_override', Boolean)
 )
 
 game_player_stats = Table(

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -116,10 +116,10 @@ class GameService:
         self,
         game_mode: str,
         visibility=VisibilityState.PUBLIC,
-        host: Optional[Player]=None,
-        name: Optional[str]=None,
-        mapname: Optional[str]=None,
-        password: Optional[str]=None
+        host: Optional[Player] = None,
+        name: Optional[str] = None,
+        mapname: Optional[str] = None,
+        password: Optional[str] = None
     ):
         """
         Main entrypoint for creating new games

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -534,7 +534,7 @@ class GameConnection(GpgNetServerProtocol):
         if self.game:
             self.game_service.mark_dirty(self.game)
 
-    async def abort(self, log_message: str=''):
+    async def abort(self, log_message: str = ''):
         """
         Abort the connection
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -503,26 +503,26 @@ class LobbyConnection:
                 )
             })
             await self.send_warning("Your computer seems to be a virtual machine.<br><br>In order to "
-                              "log in from a VM, you have to link your account to Steam: <a href='" +
-                              config.WWW_URL + "/account/link'>" +
-                              config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
-                                               "admin or moderator on the forums", fatal=True)
+                                    "log in from a VM, you have to link your account to Steam: <a href='" +
+                                    config.WWW_URL + "/account/link'>" +
+                                    config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
+                                                     "admin or moderator on the forums", fatal=True)
 
         if response.get('result', '') == 'already_associated':
             self._logger.warning("UID hit: %d: %s", player_id, uid_hash)
             await self.send_warning("Your computer is already associated with another FAF account.<br><br>In order to "
-                              "log in with an additional account, you have to link it to Steam: <a href='" +
-                              config.WWW_URL + "/account/link'>" +
-                              config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
-                                               "admin or moderator on the forums", fatal=True)
+                                    "log in with an additional account, you have to link it to Steam: <a href='" +
+                                    config.WWW_URL + "/account/link'>" +
+                                    config.WWW_URL + "/account/link</a>.<br>If you need an exception, please contact an "
+                                                     "admin or moderator on the forums", fatal=True)
             return False
 
         if response.get('result', '') == 'fraudulent':
             self._logger.info("Banning player %s for fraudulent looking login.", player_id)
             await self.send_warning("Fraudulent login attempt detected. As a precautionary measure, your account has been "
-                              "banned permanently. Please contact an admin or moderator on the forums if you feel this is "
-                              "a false positive.",
-                              fatal=True)
+                                    "banned permanently. Please contact an admin or moderator on the forums if you feel this is "
+                                    "a false positive.",
+                                    fatal=True)
 
             async with self._db.acquire() as conn:
                 try:

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -966,7 +966,7 @@ class LobbyConnection:
             'ttl': ttl
         })
 
-    async def send_warning(self, message: str, fatal: bool=False):
+    async def send_warning(self, message: str, fatal: bool = False):
         """
         Display a warning message to the client
         :param message: Warning message to display

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -80,7 +80,6 @@ class StableMarriage(MatchmakingPolicy):
 
         return self.matches
 
-
     def _register_unmatched_searches(self):
         """
         Tells all unmatched searches that they went through a failed matching
@@ -96,7 +95,6 @@ class StableMarriage(MatchmakingPolicy):
                 "Search %s remained unmatched at threshold %f in attempt number %i",
                 search, search.match_threshold, search.failed_matching_attempts
             )
-
 
     def _propose(self, search: Search, preferred: Search):
         """ An unmatched search proposes to it's preferred opponent.

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -42,7 +42,7 @@ class MatchmakingPolicy(object):
 
 class StableMarriage(MatchmakingPolicy):
     def find(self) -> Dict[Search, Search]:
-        """Perform SM_NUM_TO_RANK runs of the stable matching algorithm. 
+        """Perform SM_NUM_TO_RANK runs of the stable matching algorithm.
         Assumes that _MatchingGraph.build_sparse() only returns edges whose matches are acceptable
         to both parties."""
         ranks = _MatchingGraph.build_sparse(self.searches)

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -139,7 +139,7 @@ class RandomlyMatchNewbies(MatchmakingPolicy):
             opponent = next((
                 search for search in self.searches
                 if search != newbie and search not in self.matches
-                   and search.is_single_party() and search.has_no_top_player()
+                and search.is_single_party() and search.has_no_top_player()
             ), default_if_no_available_opponent)
             if opponent is not default_if_no_available_opponent:
                 self._match(newbie, opponent)

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -20,8 +20,8 @@ class Search:
     def __init__(
         self,
         players: List[Player],
-        start_time: Optional[float]=None,
-        rating_type: RatingType=RatingType.LADDER_1V1
+        start_time: Optional[float] = None,
+        rating_type: RatingType = RatingType.LADDER_1V1
     ):
         """
         Default ctor for a search

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -132,7 +132,6 @@ class Search:
 
         self._failed_matching_attempts += 1
 
-
     @property
     def match_threshold(self) -> float:
         """
@@ -215,5 +214,6 @@ class Search:
 
     def __str__(self):
         return "Search({}, {}, {})".format(self.players, self.match_threshold, self.search_expansion)
+
 
 Match = Tuple[Search, Search]

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -92,7 +92,7 @@ class Search:
         different game qualities.
         """
         mu, _ = self.ratings[0]  # Takes the rating of the first player, only works for 1v1
-        rounded_mu = int(math.ceil(mu / 10) * 10) # Round to 10
+        rounded_mu = int(math.ceil(mu / 10) * 10)  # Round to 10
         return rounded_mu - delta, rounded_mu + delta
 
     @property

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -118,7 +118,7 @@ class Search:
         The threshold will expand linearly with every failed matching attempt
         until it reaches the specified MAX.
         """
-        
+
         return min(
             self._failed_matching_attempts * config.LADDER_SEARCH_EXPANSION_STEP,
             config.LADDER_SEARCH_EXPANSION_MAX

--- a/server/stats/unit.py
+++ b/server/stats/unit.py
@@ -8,13 +8,13 @@ class Unit(Enum):
     CYBRAN_ACU = 'url0001'
     UEF_ACU = 'uel0001'
     SERAPHIM_ACU = 'xsl0001'
-    
+
     # ASFs
     CORONA = 'uaa0303'
     GEMINI = 'ura0303'
     WASP = 'uea0303'
     IAZYNE = 'xsa0303'
-    
+
     # Experimentals
     PARAGON = 'xab1401'
     MAVOR = 'ueb2401'
@@ -31,7 +31,7 @@ class Unit(Enum):
     TEMPEST = 'uas0401'
     ATLANTIS = 'ues0401'
     NOVAX_CENTER = 'xeb2402'
-    
+
     # Transporters
     CHARIOT = 'uaa0107'
     ALUMINAR = 'uaa0104'
@@ -48,7 +48,7 @@ class Unit(Enum):
     CYBRAN_SACU = 'url0301'
     UEF_SACU = 'uel0301'
     SERAPHIM_SACU = 'xsl0301'
-    
+
     # Engineers
     AEON_T1_ENGINEER = 'ual0105'
     AEON_T2_ENGINEER = 'ual0208'
@@ -63,7 +63,7 @@ class Unit(Enum):
     SERAPHIM_T1_ENGINEER = 'xsl0105'
     SERAPHIM_T2_ENGINEER = 'xsl0208'
     SERAPHIM_T3_ENGINEER = 'xsl0309'
-    
+
     # Other units
     MERCY = 'daa0206'
     FIRE_BEETLE = 'xrl0302'

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -117,7 +117,7 @@ def add_connected_players(game: Game, players):
 
 @pytest.fixture
 def game_add_players(player_factory):
-    def add(gameobj: Game, n: int, team: int=None):
+    def add(gameobj: Game, n: int, team: int = None):
         game = gameobj
         current = len(game.players)
         players = []

--- a/tests/unit_tests/test_achievement_service.py
+++ b/tests/unit_tests/test_achievement_service.py
@@ -88,7 +88,7 @@ async def test_update_multiple(service: AchievementService):
 
     assert result == achievements_data
 
-    service.api_accessor.update_achievements.assert_called_once_with(queue,42)
+    service.api_accessor.update_achievements.assert_called_once_with(queue, 42)
 
 
 async def test_achievement_zero_steps_increment(service: AchievementService):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -21,6 +21,7 @@ from trueskill import Rating
 
 pytestmark = pytest.mark.asyncio
 
+
 @pytest.yield_fixture
 def game(event_loop, database, game_service, game_stats_service):
     game = Game(42, database, game_service, game_stats_service)

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -80,16 +80,16 @@ def test_team_outcome_victory_has_priority():
 
 def test_ranks():
     rater = GameRater({}, {})
-    assert rater._ranks_from_team_outcomes([GameOutcome.VICTORY, GameOutcome.DEFEAT]) == [0,1]
-    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.VICTORY]) == [1,0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.VICTORY, GameOutcome.DEFEAT]) == [0, 1]
+    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.VICTORY]) == [1, 0]
 
 
 def test_ranks_with_unknown():
     rater = GameRater({}, {})
-    assert rater._ranks_from_team_outcomes([GameOutcome.UNKNOWN, GameOutcome.DEFEAT]) == [0,1]
-    assert rater._ranks_from_team_outcomes([GameOutcome.VICTORY, GameOutcome.UNKNOWN]) == [0,1]
-    assert rater._ranks_from_team_outcomes([GameOutcome.UNKNOWN, GameOutcome.VICTORY]) == [1,0]
-    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.UNKNOWN]) == [1,0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.UNKNOWN, GameOutcome.DEFEAT]) == [0, 1]
+    assert rater._ranks_from_team_outcomes([GameOutcome.VICTORY, GameOutcome.UNKNOWN]) == [0, 1]
+    assert rater._ranks_from_team_outcomes([GameOutcome.UNKNOWN, GameOutcome.VICTORY]) == [1, 0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.UNKNOWN]) == [1, 0]
     with pytest.raises(GameRatingError):
         rater._ranks_from_team_outcomes([GameOutcome.UNKNOWN, GameOutcome.UNKNOWN])
 
@@ -102,14 +102,14 @@ def test_ranks_with_double_victory_is_inconsistent():
 
 def test_ranks_with_double_defeat_treated_as_draw():
     rater = GameRater({}, {})
-    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.DEFEAT]) == [0,0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.DEFEAT, GameOutcome.DEFEAT]) == [0, 0]
 
 
 def test_ranks_with_draw():
     rater = GameRater({}, {})
 
-    assert rater._ranks_from_team_outcomes([GameOutcome.DRAW, GameOutcome.DRAW]) == [0,0]
-    assert rater._ranks_from_team_outcomes([GameOutcome.MUTUAL_DRAW, GameOutcome.MUTUAL_DRAW]) == [0,0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.DRAW, GameOutcome.DRAW]) == [0, 0]
+    assert rater._ranks_from_team_outcomes([GameOutcome.MUTUAL_DRAW, GameOutcome.MUTUAL_DRAW]) == [0, 0]
 
     with pytest.raises(GameRatingError):
         rater._ranks_from_team_outcomes([GameOutcome.VICTORY, GameOutcome.DRAW])

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -187,7 +187,7 @@ def test_dont_rate_partial_ffa_matches():
 
     rater = GameRater(players_by_team, outcome_py_player)
     with pytest.raises(GameRatingError):
-        result = rater.compute_rating()
+        rater.compute_rating()
 
 
 def test_dont_rate_pure_ffa_matches_with_more_than_two_players():
@@ -202,11 +202,10 @@ def test_dont_rate_pure_ffa_matches_with_more_than_two_players():
 
     rater = GameRater(players_by_team, outcome_py_player)
     with pytest.raises(GameRatingError):
-        result = rater.compute_rating()
+        rater.compute_rating()
 
 
 def test_dont_rate_threeway_team_matches():
-    FFA_TEAM = 1
     p1, p2, p3 = MockPlayer(), MockPlayer(), MockPlayer()
     players_by_team = {2: [p1], 3: [p2], 4: [p3]}
     outcome_py_player = {
@@ -217,4 +216,4 @@ def test_dont_rate_threeway_team_matches():
 
     rater = GameRater(players_by_team, outcome_py_player)
     with pytest.raises(GameRatingError):
-        result = rater.compute_rating()
+        rater.compute_rating()

--- a/tests/unit_tests/test_ice.py
+++ b/tests/unit_tests/test_ice.py
@@ -35,7 +35,7 @@ class FakeTwilioServers:
 def test_coturn_tokens(coturn_hmac, coturn_hosts, coturn_credentials):
     servers = coturn_hmac.server_tokens(username='faf-test', ttl=123456)
     comparison_list = []
-    for coturn_host,coturn_cred in zip(coturn_hosts, coturn_credentials):
+    for coturn_host, coturn_cred in zip(coturn_hosts, coturn_credentials):
         comparison_list.append(
             {"host": coturn_host, "cred": coturn_cred}
         )
@@ -62,7 +62,7 @@ async def test_twilio_nts(twilio):
     twilio.client.tokens.create.assert_called_once()
     assert servers == \
         {
-            "urls": ["a","b","c"],
+            "urls": ["a", "b", "c"],
             "username": "d",
             "credential": "e",
             "credentialType": "f"

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -168,7 +168,7 @@ async def test_search_expansion_controlled_by_failed_matching_attempts(matchmake
     for _ in range(100):
         s1.register_failed_matching_attempt()
     e1 = s1.search_expansion
-    
+
     s1.register_failed_matching_attempt()
     assert e1 == s1.search_expansion
     assert e1 == config.LADDER_SEARCH_EXPANSION_MAX

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -54,9 +54,9 @@ async def test_is_single_newbie(matchmaker_players):
 
     assert single_newbie.is_single_ladder_newbie()
     assert single_pro.is_single_ladder_newbie() is False
-    assert two_newbies.is_single_ladder_newbie() == False
-    assert two_pros.is_single_ladder_newbie() == False
-    assert two_mixed.is_single_ladder_newbie() == False
+    assert two_newbies.is_single_ladder_newbie() is False
+    assert two_pros.is_single_ladder_newbie() is False
+    assert two_mixed.is_single_ladder_newbie() is False
 
 
 async def test_newbies_have_adjusted_rating(matchmaker_players):

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -124,9 +124,9 @@ def test_stable_marriage_better_than_greedy(p):
 
     # However, because s1 is first in the list and gets top choice, we end with
     # the following stable configuration
-    assert matches[s1] == s5 # quality: 0.97
-    assert matches[s2] == s3 # quality: 0.93
-    assert matches[s4] == s6 # quality: 0.82
+    assert matches[s1] == s5  # quality: 0.97
+    assert matches[s2] == s3  # quality: 0.93
+    assert matches[s4] == s6  # quality: 0.82
 
 
 def test_stable_marriage_unmatch(p):
@@ -139,7 +139,7 @@ def test_stable_marriage_unmatch(p):
 
     matches = algorithm.StableMarriage(searches).find()
 
-    assert matches[s1] == s4 # quality: 0.96622
+    assert matches[s1] == s4  # quality: 0.96622
     assert matches[s2] == s3  # quality: 0.96623
 
 

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -57,7 +57,6 @@ def test_stable_marriage_produces_symmetric_matchings(p):
         assert matches[opponent] == search
 
 
-
 def test_stable_marriage(p):
     s1 = Search([p(2300, 64, name='p1')])
     s2 = Search([p(1200, 72, name='p2')])
@@ -225,6 +224,7 @@ def test_odd_number_of_unmatched_newbies(p):
 
     assert len(matches) == 4
 
+
 def test_matchmaker(p):
     newbie_that_matches1 = Search([p(1450, 500, ladder_games=1)])
     newbie_that_matches2 = Search([p(1550, 500, ladder_games=1)])
@@ -254,6 +254,7 @@ def test_matchmaker(p):
     for match_pair in match_pairs:
         assert top_player not in match_pair
 
+
 def test_stable_marriage_will_not_match_low_quality_games(p):
     s1 = Search([p(100, 64, name='p1')])
     s2 = Search([p(2000, 64, name='p2')])
@@ -264,6 +265,7 @@ def test_stable_marriage_will_not_match_low_quality_games(p):
 
     assert (s1, s2) not in matches
     assert (s2, s1) not in matches
+
 
 def test_stable_marriage_communicates_failed_attempts(p):
     s1 = Search([p(100, 64, name='p1')])

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -5,7 +5,7 @@ from server.matchmaker import Search, algorithm
 
 @pytest.fixture
 def p(player_factory):
-    def make(mean: int, deviation: int, ladder_games: int=config.NEWBIE_MIN_GAMES+1, name=None):
+    def make(mean: int, deviation: int, ladder_games: int = config.NEWBIE_MIN_GAMES+1, name=None):
         """Make a player with the given ratings"""
         return player_factory(ladder_rating=(mean, deviation),
                               ladder_games=ladder_games)


### PR DESCRIPTION
I thought it's easier to run `flake8` on new PRs, if I first get rid of most of the things on develop that it takes issue with (the majority of which I probably introduced myself...).

the only things left now are:  
`E501` line width
`E999` syntax that flake8 doesn't understand
`E722` bare excepts (that I didn't want to touch here)
(and a few special cases in the tests)

I'm not sure whether we want to adhere to `E252` that puts whitespace around `=` in default parameters that use typing, like 
```python
#what we had before:
def func(x: int, y: int=0):
  pass

# what flake8 wants:
def func(x: int, y: int = 0):
  pass
```