### PR TITLE
Added intermitent profiling

### DIFF
--- a/server.py
+++ b/server.py
@@ -76,16 +76,17 @@ if __name__ == '__main__':
         players_online = PlayerService(database)
 
         if config.PROFILING_INTERVAL > 0:
-            logger.warning("Profiling enabled! This can cause significant load.")
+            logger.warning("Profiling enabled! This will create additional load.")
             import cProfile
             pr = cProfile.Profile()
             profiled_count = 0
+            max_count = 200
 
             @at_interval(config.PROFILING_INTERVAL, loop=loop)
             async def run_profiler():
                 global profiled_count
 
-                if profiled_count >= 200:
+                if profiled_count >= max_count or len(players_online) > 1000:
                     return
 
                 logger.info("Starting profiler")
@@ -94,7 +95,7 @@ if __name__ == '__main__':
                 pr.disable()
                 profiled_count += 1
 
-                logging.info("Done profiling %i/200", profiled_count)
+                logging.info("Done profiling %i/%i", profiled_count, max_count)
                 pr.dump_stats("profile.txt")
 
         twilio_nts = None

--- a/server.py
+++ b/server.py
@@ -80,13 +80,17 @@ if __name__ == '__main__':
             import cProfile
             pr = cProfile.Profile()
             profiled_count = 0
-            max_count = 200
+            max_count = 300
 
             @at_interval(config.PROFILING_INTERVAL, loop=loop)
             async def run_profiler():
                 global profiled_count
+                global pr
 
-                if profiled_count >= max_count or len(players_online) > 1000:
+                if len(players_online) > 1000:
+                    return
+                elif profiled_count >= max_count:
+                    pr = None
                     return
 
                 logger.info("Starting profiler")

--- a/server/config.py
+++ b/server/config.py
@@ -10,6 +10,7 @@ logging.getLogger('aiomeasures').setLevel(logging.INFO)
 
 # Environment
 LOG_LEVEL = logging.getLevelName(os.getenv('LOG_LEVEL', 'DEBUG'))
+PROFILING_INTERVAL = int(os.getenv('PROFILING_INTERVAL', -1))
 
 # Credit to Axle for parameter changes, see: http://forums.faforever.com/viewtopic.php?f=45&t=11698#p119599
 # Optimum values for ladder here, using them for global as well.


### PR DESCRIPTION
So we can figure out what needs to be optimized.

I think I will make the profiler only run when we have less than 1100 users online. I'd like to get profiling data when there are as many users as possible, but we don't want to add the performance cost of profiling during the highest load times.