### PR TITLE
Improve broadcast performance

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -44,7 +44,7 @@ FORCE_STEAM_LINK = os.getenv('FORCE_STEAM_LINK', 'false').lower() == 'true'
 CLIENT_STALL_TIME = int(os.getenv('CLIENT_STALL_TIME', 10))
 # Maximum number of bytes we will allow a stalled connection to get behind
 # before we terminate their connection.
-CLIENT_MAX_WRITE_BUFFER_SIZE = int(os.getenv('CLIENT_MAX_WRITE_BUFFER_SIZE', 2**16))
+CLIENT_MAX_WRITE_BUFFER_SIZE = int(os.getenv('CLIENT_MAX_WRITE_BUFFER_SIZE', 2**17))
 
 NEWBIE_BASE_MEAN = int(os.getenv('NEWBIE_BASE_MEAN', 500))
 NEWBIE_MIN_GAMES = int(os.getenv('NEWBIE_MIN_GAMES', 10))

--- a/server/protocol/qdatastreamprotocol.py
+++ b/server/protocol/qdatastreamprotocol.py
@@ -181,4 +181,12 @@ class QDataStreamProtocol(Protocol):
             raise DisconnectedError("Protocol is not connected!")
 
         self.writer.write(data)
-        await self.drain()
+        # NOTE: This try/except is for debugging purposes only. In the log we
+        # are seeing "Task exception was never retrieved" errors for
+        # `send_message` and `send_raw` but the stack trace does not tell us
+        # enough to determine which tasks are generating them. We include the
+        # message contents here to help determine the cause.
+        try:
+            await self.drain()
+        except DisconnectedError as e:
+            raise DisconnectedError(data) from e

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -64,14 +64,14 @@ class ServerContext:
             try:
                 if proto.is_connected() and validate_fn(conn):
                     tasks.append(
-                        self._broadcast_raw_with_stall_handling(proto, message)
+                        self._send_raw_with_stall_handling(proto, message)
                     )
             except Exception:
                 self._logger.exception("Encountered error in broadcast")
 
         await gather_without_exceptions(tasks, DisconnectedError)
 
-    async def _broadcast_raw_with_stall_handling(self, proto, message):
+    async def _send_raw_with_stall_handling(self, proto, message):
         try:
             await asyncio.wait_for(
                 proto.send_raw(message),

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -51,40 +51,30 @@ class ServerContext:
         return connection in self.connections.keys()
 
     async def broadcast(self, message, validate_fn=lambda a: True):
-        await self._do_broadcast(
-            validate_fn,
-            QDataStreamProtocol.send_message,
-            message
+        await self.broadcast_raw(
+            QDataStreamProtocol.encode_message(message),
+            validate_fn
         )
         self._logger.log(TRACE, "]]: %s", message)
 
     async def broadcast_raw(self, message, validate_fn=lambda a: True):
-        await self._do_broadcast(
-            validate_fn,
-            QDataStreamProtocol.send_raw,
-            message
-        )
-
-    async def _do_broadcast(self, validate_fn, send_fn, message):
         metrics.server_broadcasts.inc()
         tasks = []
         for conn, proto in self.connections.items():
             try:
                 if proto.is_connected() and validate_fn(conn):
                     tasks.append(
-                        self._broadcast_with_stall_handling(
-                            proto, send_fn, message
-                        )
+                        self._broadcast_raw_with_stall_handling(proto, message)
                     )
             except Exception:
                 self._logger.exception("Encountered error in broadcast")
 
         await gather_without_exceptions(tasks, DisconnectedError)
 
-    async def _broadcast_with_stall_handling(self, proto, send_fn, message):
+    async def _broadcast_raw_with_stall_handling(self, proto, message):
         try:
             await asyncio.wait_for(
-                send_fn(proto, message),
+                proto.send_raw(message),
                 timeout=CLIENT_STALL_TIME
             )
         except asyncio.TimeoutError:


### PR DESCRIPTION
Refactor `ServerContext.broadcast` so that it only performs json and QDataStream encoding once per message (as opposed to once per connection per message).