### PR TITLE
Write GameOutcome to db in Game.persist_results.

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -475,21 +475,27 @@ class Game:
         scores = {}
         for player in self.players:
             army = self.get_player_option(player.id, 'Army')
+            outcome = self.get_army_result(player)
             score = self.get_army_score(army)
-            scores[player] = score
+            scores[player] = [score, outcome]
             self._logger.info(
-                'Result for army %s, player: %s: %s', army, player, score
+                'Result for army %s, player: %s: score %s, outcome %s',
+                army, player, score, outcome
             )
 
         async with self._db.acquire() as conn:
             rows = []
-            for player, score in scores.items():
-                self._logger.info("Score for player %s: %s", player, score)
-                rows.append((score, self.id, player.id))
+            for player, (score, outcome) in scores.items():
+                self._logger.info(
+                    "Score for player %s: score %s, outcome %s",
+                    player, score, outcome,
+                )
+                rows.append((score, outcome.name.upper(), self.id, player.id))
 
             await conn.execute(
                 "UPDATE game_player_stats "
-                "SET `score`=%s, `scoreTime`=NOW() "
+                "SET `score`=%s, `scoreTime`=NOW(), "
+                "`result`=%s "
                 "WHERE `gameId`=%s AND `playerId`=%s", rows
             )
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -475,7 +475,7 @@ class Game:
         scores = {}
         for player in self.players:
             army = self.get_player_option(player.id, 'Army')
-            outcome = self.get_army_result(player)
+            outcome = self.get_player_outcome(player)
             score = self.get_army_score(army)
             scores[player] = [score, outcome]
             self._logger.info(
@@ -542,7 +542,7 @@ class Game:
         table = f'{rating.value}_rating'
 
         if rating is RatingType.LADDER_1V1:
-            is_victory = self.get_army_result(player) is GameOutcome.VICTORY
+            is_victory = self.get_player_outcome(player) is GameOutcome.VICTORY
             await conn.execute(
                 "UPDATE ladder1v1_rating "
                 "SET mean = %s, is_active=1, deviation = %s, numGames = numGames + 1, winGames = winGames + %s "
@@ -819,7 +819,7 @@ class Game:
     def get_army_score(self, army):
         return self._results.score(army)
 
-    def get_army_result(self, player):
+    def get_player_outcome(self, player):
         army = self.get_player_option(player.id, 'Army')
         if army is None:
             return GameOutcome.UNKNOWN
@@ -844,7 +844,7 @@ class Game:
             )
 
         outcome_by_player = {
-            player: self.get_army_result(player)
+            player: self.get_player_outcome(player)
             for player in self.players
         }
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -477,7 +477,7 @@ class Game:
             army = self.get_player_option(player.id, 'Army')
             outcome = self.get_player_outcome(player)
             score = self.get_army_score(army)
-            scores[player] = [score, outcome]
+            scores[player] = (score, outcome)
             self._logger.info(
                 'Result for army %s, player: %s: score %s, outcome %s',
                 army, player, score, outcome
@@ -494,8 +494,7 @@ class Game:
 
             await conn.execute(
                 "UPDATE game_player_stats "
-                "SET `score`=%s, `scoreTime`=NOW(), "
-                "`result`=%s "
+                "SET `score`=%s, `scoreTime`=NOW(), `result`=%s "
                 "WHERE `gameId`=%s AND `playerId`=%s", rows
             )
 

--- a/server/games/game_rater.py
+++ b/server/games/game_rater.py
@@ -73,6 +73,11 @@ class GameRater(object):
     def _get_team_outcome(self, team: Iterable[Player]) -> GameOutcome:
         outcomes = set(self._outcome_by_player[player] for player in team)
         outcomes.discard(GameOutcome.UNKNOWN)
+
+        # Treat conflicting reports as unknown
+        # to make it harder to unrank games by faking reports
+        outcomes.discard(GameOutcome.CONFLICTING)
+
         if not outcomes:
             return GameOutcome.UNKNOWN
         if GameOutcome.VICTORY in outcomes:

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -91,8 +91,8 @@ class GameResults(Mapping):
             return outcomes.pop()
         elif len(outcomes) > 1:
             self._logger.info(
-                "Multiple outcomes for game %s army %s: %s", self._game_id,
-                army, list(outcomes)
+                "Multiple outcomes for game %s army %s: %s",
+                self._game_id, army, list(outcomes)
             )
             return GameOutcome.CONFLICTING
 
@@ -143,11 +143,6 @@ class GameResults(Mapping):
             async for row in rows:
                 startspot, score = row[0], row[1]
                 # FIXME: Assertion about startspot == army
-                # FIXME: Reporter not retained in database
-                # TODO: I don't understand the comment above
-                # there is no unique reporter for a score,
-                # only a consolidated score is saved in the database
-                # Is this asking us to save _all_ reports in the DB?
                 outcome = GameOutcome[row[2]]
                 result = GameResult(0, startspot, outcome, score)
                 results.add(result)

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -12,6 +12,7 @@ class GameOutcome(Enum):
     DRAW = 'draw'
     MUTUAL_DRAW = 'mutual_draw'
     UNKNOWN = 'unknown'
+    CONFLICTING = 'conflicting'
 
     @classmethod
     def from_message(cls, msg: str):
@@ -88,13 +89,14 @@ class GameResults(Mapping):
 
         if len(outcomes) == 1:
             return outcomes.pop()
-        else:
-            if len(outcomes) > 1:
-                self._logger.info(
-                    "Multiple outcomes for game %s army %s: %s", self._game_id,
-                    army, list(outcomes)
-                )
-            return GameOutcome.UNKNOWN
+        elif len(outcomes) > 1:
+            self._logger.info(
+                "Multiple outcomes for game %s army %s: %s", self._game_id,
+                army, list(outcomes)
+            )
+            return GameOutcome.CONFLICTING
+
+        return GameOutcome.UNKNOWN
 
     def score(self, army: int):
         """
@@ -133,7 +135,7 @@ class GameResults(Mapping):
         results = cls(game_id)
         async with database.acquire() as conn:
             rows = await conn.execute(
-                "SELECT `place`, `score` "
+                "SELECT `place`, `score`, `result` "
                 "FROM `game_player_stats` "
                 "WHERE `gameId`=%s", (game_id, )
             )
@@ -142,6 +144,11 @@ class GameResults(Mapping):
                 startspot, score = row[0], row[1]
                 # FIXME: Assertion about startspot == army
                 # FIXME: Reporter not retained in database
-                result = GameResult(0, startspot, GameOutcome.UNKNOWN, score)
+                # TODO: I don't understand the comment above
+                # there is no unique reporter for a score,
+                # only a consolidated score is saved in the database
+                # Is this asking us to save _all_ reports in the DB?
+                outcome = GameOutcome[row[2]]
+                result = GameResult(0, startspot, outcome, score)
                 results.add(result)
         return results

--- a/server/games/ladder_game.py
+++ b/server/games/ladder_game.py
@@ -24,7 +24,7 @@ class LadderGame(Game):
             await self.persist_rating_change_stats(new_ratings, RatingType.LADDER_1V1)
 
     def is_winner(self, player: Player):
-        return self.get_army_result(player) is GameOutcome.VICTORY
+        return self.get_player_outcome(player) is GameOutcome.VICTORY
 
     def get_army_score(self, army: int) -> int:
         """

--- a/server/stats/game_stats_service.py
+++ b/server/stats/game_stats_service.py
@@ -46,7 +46,7 @@ class GameStatsService:
             self._logger.warning("Player %s reported stats of a game he was not part of", player.login)
             return
 
-        army_result = game.get_army_result(player)
+        army_result = game.get_player_outcome(player)
         if army_result is GameOutcome.UNKNOWN:
             self._logger.warning("No army result available for player %s", player.login)
             return

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -706,17 +706,18 @@ async def test_compute_rating_works_with_partially_unknown_results(
             assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
 
 
-async def test_game_get_player_outcome_ignores_unknown_results(game,
-                                                            game_add_players):
+async def test_game_get_player_outcome_ignores_unknown_results(
+    game, game_add_players
+):
     game.state = GameState.LOBBY
     players = game_add_players(game, 2)
 
     await game.add_result(0, 0, 'defeat', 0)
     await game.add_result(0, 0, 'score', 0)
-    assert game.get_player_outcome(players[0]) == GameOutcome.DEFEAT
+    assert game.get_player_outcome(players[0]) is GameOutcome.DEFEAT
 
     await game.add_result(0, 1, 'score', 0)
-    assert game.get_player_outcome(players[1]) == GameOutcome.UNKNOWN
+    assert game.get_player_outcome(players[1]) is GameOutcome.UNKNOWN
 
 
 async def test_on_game_end_does_not_call_rate_game_for_single_player(game):
@@ -857,7 +858,6 @@ async def test_persist_results_called_with_two_players(game, game_add_players):
             assert game.get_player_outcome(player) is GameOutcome.VICTORY
         else:
             assert game.get_player_outcome(player) is GameOutcome.UNKNOWN
-
 
 
 async def test_persist_results_called_for_unranked(game, game_add_players):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -706,17 +706,17 @@ async def test_compute_rating_works_with_partially_unknown_results(
             assert new_rating != Rating(*player.ratings[RatingType.GLOBAL])
 
 
-async def test_game_get_army_result_ignores_unknown_results(game,
+async def test_game_get_player_outcome_ignores_unknown_results(game,
                                                             game_add_players):
     game.state = GameState.LOBBY
     players = game_add_players(game, 2)
 
     await game.add_result(0, 0, 'defeat', 0)
     await game.add_result(0, 0, 'score', 0)
-    assert game.get_army_result(players[0]) == GameOutcome.DEFEAT
+    assert game.get_player_outcome(players[0]) == GameOutcome.DEFEAT
 
     await game.add_result(0, 1, 'score', 0)
-    assert game.get_army_result(players[1]) == GameOutcome.UNKNOWN
+    assert game.get_player_outcome(players[1]) == GameOutcome.UNKNOWN
 
 
 async def test_on_game_end_does_not_call_rate_game_for_single_player(game):
@@ -854,9 +854,9 @@ async def test_persist_results_called_with_two_players(game, game_add_players):
     assert game.get_army_score(1) == 5
     for player in game.players:
         if game.get_player_option(player.id, 'Army') == 1:
-            assert game.get_army_result(player) is GameOutcome.VICTORY
+            assert game.get_player_outcome(player) is GameOutcome.VICTORY
         else:
-            assert game.get_army_result(player) is GameOutcome.UNKNOWN
+            assert game.get_player_outcome(player) is GameOutcome.UNKNOWN
 
 
 
@@ -873,17 +873,17 @@ async def test_persist_results_called_for_unranked(game, game_add_players):
     assert len(game.players) == 2
     for player in game.players:
         if game.get_player_option(player.id, 'Army') == 1:
-            assert game.get_army_result(player) is GameOutcome.VICTORY
+            assert game.get_player_outcome(player) is GameOutcome.VICTORY
         else:
-            assert game.get_army_result(player) is GameOutcome.UNKNOWN
+            assert game.get_player_outcome(player) is GameOutcome.UNKNOWN
 
     await game.load_results()
     assert game.get_army_score(1) == 5
     for player in game.players:
         if game.get_player_option(player.id, 'Army') == 1:
-            assert game.get_army_result(player) is GameOutcome.VICTORY
+            assert game.get_player_outcome(player) is GameOutcome.VICTORY
         else:
-            assert game.get_army_result(player) is GameOutcome.UNKNOWN
+            assert game.get_player_outcome(player) is GameOutcome.UNKNOWN
 
 
 async def test_get_army_score_conflicting_results_clear_winner(
@@ -1014,8 +1014,8 @@ async def test_game_outcomes(game: Game, database, players):
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
 
-    host_outcome = game.get_army_result(players.hosting)
-    guest_outcome = game.get_army_result(players.joining)
+    host_outcome = game.get_player_outcome(players.hosting)
+    guest_outcome = game.get_player_outcome(players.joining)
     assert host_outcome is GameOutcome.VICTORY
     assert guest_outcome is GameOutcome.DEFEAT
 
@@ -1036,8 +1036,8 @@ async def test_game_outcomes_no_results(game: Game, database, players):
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
 
-    host_outcome = game.get_army_result(players.hosting)
-    guest_outcome = game.get_army_result(players.joining)
+    host_outcome = game.get_player_outcome(players.hosting)
+    guest_outcome = game.get_player_outcome(players.joining)
     assert host_outcome is GameOutcome.UNKNOWN
     assert guest_outcome is GameOutcome.UNKNOWN
 
@@ -1059,8 +1059,8 @@ async def test_game_outcomes_conflicting(game: Game, database, players):
     game.set_player_option(players.hosting.id, 'Team', 1)
     game.set_player_option(players.joining.id, 'Team', 1)
 
-    host_outcome = game.get_army_result(players.hosting)
-    guest_outcome = game.get_army_result(players.joining)
+    host_outcome = game.get_player_outcome(players.hosting)
+    guest_outcome = game.get_player_outcome(players.joining)
     assert host_outcome is GameOutcome.CONFLICTING
     assert guest_outcome is GameOutcome.CONFLICTING
     # No guarantees on scores for conflicting results.

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -852,6 +852,12 @@ async def test_persist_results_called_with_two_players(game, game_add_players):
 
     await game.load_results()
     assert game.get_army_score(1) == 5
+    for player in game.players:
+        if game.get_player_option(player.id, 'Army') == 1:
+            assert game.get_army_result(player) is GameOutcome.VICTORY
+        else:
+            assert game.get_army_result(player) is GameOutcome.UNKNOWN
+
 
 
 async def test_persist_results_called_for_unranked(game, game_add_players):
@@ -865,9 +871,19 @@ async def test_persist_results_called_for_unranked(game, game_add_players):
 
     assert game.get_army_score(1) == 5
     assert len(game.players) == 2
+    for player in game.players:
+        if game.get_player_option(player.id, 'Army') == 1:
+            assert game.get_army_result(player) is GameOutcome.VICTORY
+        else:
+            assert game.get_army_result(player) is GameOutcome.UNKNOWN
 
     await game.load_results()
     assert game.get_army_score(1) == 5
+    for player in game.players:
+        if game.get_player_option(player.id, 'Army') == 1:
+            assert game.get_army_result(player) is GameOutcome.VICTORY
+        else:
+            assert game.get_army_result(player) is GameOutcome.UNKNOWN
 
 
 async def test_get_army_score_conflicting_results_clear_winner(
@@ -1045,8 +1061,8 @@ async def test_game_outcomes_conflicting(game: Game, database, players):
 
     host_outcome = game.get_army_result(players.hosting)
     guest_outcome = game.get_army_result(players.joining)
-    assert host_outcome is GameOutcome.UNKNOWN
-    assert guest_outcome is GameOutcome.UNKNOWN
+    assert host_outcome is GameOutcome.CONFLICTING
+    assert guest_outcome is GameOutcome.CONFLICTING
     # No guarantees on scores for conflicting results.
 
 


### PR DESCRIPTION
Now `Game.persist_results` writes the `GameOutcome` for every single player to the new `result` column of `game_player_stats`, according to `Game.outcome` at the time of the call.

Also introduces new `GameOutcome.CONFLICTING`, which is treated as `UNKNOWN` for rating purposes, so this shouldn't change any rating decisions.