### PR TITLE
Tweak automatch options

### DIFF
--- a/server/factions.py
+++ b/server/factions.py
@@ -10,5 +10,5 @@ class Faction(IntEnum):
     nomad = 5
 
     @staticmethod
-    def from_string(value):
-        return getattr(Faction, value)
+    def from_string(value: str) -> "Faction":
+        return Faction.__members__[value]

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -174,12 +174,12 @@ class LadderService:
 
             game.set_player_option(host.id, 'StartSpot', 1)
             game.set_player_option(guest.id, 'StartSpot', 2)
+            game.set_player_option(host.id, 'Army', 1)
+            game.set_player_option(guest.id, 'Army', 2)
             game.set_player_option(host.id, 'Faction', host.faction)
             game.set_player_option(guest.id, 'Faction', guest.faction)
             game.set_player_option(host.id, 'Color', 1)
             game.set_player_option(guest.id, 'Color', 2)
-            game.set_player_option(host.id, 'Army', 2)
-            game.set_player_option(guest.id, 'Army', 3)
 
             # Remembering that "Team 1" corresponds to "-": the non-team.
             game.set_player_option(host.id, 'Team', 1)

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -176,8 +176,8 @@ class LadderService:
             game.set_player_option(guest.id, 'StartSpot', 2)
             game.set_player_option(host.id, 'Army', 1)
             game.set_player_option(guest.id, 'Army', 2)
-            game.set_player_option(host.id, 'Faction', host.faction)
-            game.set_player_option(guest.id, 'Faction', guest.faction)
+            game.set_player_option(host.id, 'Faction', host.faction.value)
+            game.set_player_option(guest.id, 'Faction', guest.faction.value)
             game.set_player_option(host.id, 'Color', 1)
             game.set_player_option(guest.id, 'Color', 2)
 

--- a/server/players.py
+++ b/server/players.py
@@ -81,8 +81,12 @@ class Player:
     def faction(self, value):
         if isinstance(value, str):
             self._faction = Faction.from_string(value)
-        else:
+        elif isinstance(value, int):
+            self._faction = Faction(value)
+        elif isinstance(value, Faction):
             self._faction = value
+        else:
+            raise TypeError(f"Unsupported faction type {type(value)}!")
 
     @property
     def lobby_connection(self) -> "LobbyConnection":


### PR DESCRIPTION
StartSpot and Army are supposed to be the same (currently this is overwritten by the autolobby code anyways) and the Faction option needs to be an `int` otherwise the sql query will fail.