### PR TITLE
Only show players if they've managed to connect

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -205,14 +205,17 @@ class Game:
         :return: frozenset
         """
         if self.state is GameState.LOBBY:
-            return frozenset(self._connections.keys())
+            return frozenset(
+                player for player in self._connections.keys()
+                if player and player.id in self._player_options
+            )
         else:
-            return frozenset({
+            return frozenset(
                 player
                 for player in self._players
                 if self.get_player_option(player.id, 'Army') is not None
                 and self.get_player_option(player.id, 'Army') >= 0
-            })
+            )
 
     @property
     def connections(self):
@@ -391,16 +394,25 @@ class Game:
         """
         if game_connection not in self._connections.values():
             return
-        del self._connections[game_connection.player]
-        if game_connection.player:
-            del game_connection.player.game
+
+        player = game_connection.player
+        del self._connections[player]
+
+        if player:
+            del player.game
+
+            if (
+                self.state is GameState.LOBBY and
+                player.id in self._player_options
+            ):
+                del self._player_options[player.id]
+
         await self.check_sim_end()
 
         self._logger.info("Removed game connection %s", game_connection)
 
         def host_left_lobby() -> bool:
-            return (game_connection.player == self.host and
-                    self.state is not GameState.LIVE)
+            return player == self.host and self.state is not GameState.LIVE
 
         if self.state is not GameState.ENDED and (
             len(self._connections) == 0 or host_left_lobby()

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -207,7 +207,7 @@ class Game:
         if self.state is GameState.LOBBY:
             return frozenset(
                 player for player in self._connections.keys()
-                if player and player.id in self._player_options
+                if player.id in self._player_options
             )
         else:
             return frozenset(
@@ -397,25 +397,21 @@ class Game:
 
         player = game_connection.player
         del self._connections[player]
+        del player.game
 
-        if player:
-            del player.game
-
-            if (
-                self.state is GameState.LOBBY and
-                player.id in self._player_options
-            ):
-                del self._player_options[player.id]
+        if self.state is GameState.LOBBY and player.id in self._player_options:
+            del self._player_options[player.id]
 
         await self.check_sim_end()
 
         self._logger.info("Removed game connection %s", game_connection)
 
-        def host_left_lobby() -> bool:
-            return player == self.host and self.state is not GameState.LIVE
+        host_left_lobby = (
+            player == self.host and self.state is not GameState.LIVE
+        )
 
         if self.state is not GameState.ENDED and (
-            len(self._connections) == 0 or host_left_lobby()
+            len(self._connections) == 0 or host_left_lobby
         ):
             await self.on_game_end()
         else:

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -673,6 +673,8 @@ class LobbyConnection:
         await self.send_game_list()
 
     async def command_restore_game_session(self, message):
+        assert self.player is not None
+
         game_id = int(message.get('game_id'))
 
         # Restore the player's game connection, if the game still exists and is live
@@ -855,6 +857,7 @@ class LobbyConnection:
         is_host=False,
         options=GameLaunchOptions(),
     ):
+        assert self.player is not None
         # TODO: Fix setting up a ridiculous amount of cyclic pointers here
         if self.game_connection:
             await self.game_connection.abort("Player launched a new game")

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -46,8 +46,11 @@ def mock_game_connection():
     return make_mock_game_connection()
 
 
-def make_mock_game_connection(state=GameConnectionState.INITIALIZING, player=None):
-    gc = asynctest.create_autospec(spec=GameConnection)
+def make_mock_game_connection(
+    state=GameConnectionState.INITIALIZING,
+    player=mock.Mock()
+):
+    gc = asynctest.create_autospec(GameConnection)
     gc.state = state
     gc.player = player
     gc.finished_sim = False

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -224,6 +224,7 @@ async def test_add_game_connection(game: Game, players, mock_game_connection):
     # Players should not be considered as 'in lobby' until the host has sent
     # "PlayerOption" configuration for them
     assert game.to_dict()["num_players"] == 0
+    assert game.players == set()
     game.set_player_option(players.hosting.id, 'Team', 1)
     assert players.hosting in game.players
 
@@ -249,6 +250,7 @@ async def test_add_game_connection_twice(game: Game, players, mock_game_connecti
     # Player joins again
     game.add_game_connection(join_conn)
     assert game.to_dict()["num_players"] == 1
+    assert game.players == {players.hosting}
     game.set_player_option(players.joining.id, 'Team', 1)
     assert game.players == {players.hosting, players.joining}
     assert game.to_dict()["num_players"] == 2


### PR DESCRIPTION
Might fix #225.

When doing testing of the game result issue and struggling with getting the ICE adapter to connect two machines on the same network I noticed what might be causing the display of extra players in lobby. 

The server would count a player as "in-lobby" as soon as they sent `GameState: Lobby` meaning as soon as their game made it to the `connecting to host` screen. This means if someone was trying to join a lobby, but could not connect to the host, it would still falsely bump the `num_players` which might cause the lobby to appear full when it was actually one player short. 

It seems like the only way to detect if a player has successfully connected to the host is by the host sending `PlayerOption` commands for them. So we can use the presence of player options as an indicator for successful connection.

I'm not sure if this is the only reason why this bug occurs so I'll leave the issue open for now.