### PR TITLE
Automatic service instantiation

### DIFF
--- a/server/core/__init__.py
+++ b/server/core/__init__.py
@@ -1,6 +1,9 @@
-from .service import Service
+from .service import Service, create_services
+from .dependency_injector import DependencyInjector
 
 
 __all__ = (
+    "DependencyInjector",
     "Service",
+    "create_services"
 )

--- a/server/core/dependency_injector.py
+++ b/server/core/dependency_injector.py
@@ -1,0 +1,137 @@
+import inspect
+from collections import ChainMap, defaultdict
+from typing import Dict, List
+
+DependencyGraph = Dict[str, List[str]]
+
+
+class DependencyInjector(object):
+    """
+    Does dependency injection.
+
+    Dependencies are resolved by parameter name. So if a class has init method
+    ```
+    def __init__(self, hello, world):
+        pass
+    ```
+    the injector will look for two dependencies, called `hello` and `world`.
+    These could either be an object registered with `add_injectables`, or an
+    instance of another class passed to `build_classes`.
+
+    Injected arguments are only ever constructed once. So if two classes both
+    depend on an object called `hello`, then they will both receive the same
+    instance of the object called `hello` (whether that is an injectable, or
+    another class in the class list).
+
+    # Example
+    ```
+    class SomeClass(object):
+        def __init__(self, external):
+            self.external = external
+
+    class SomeOtherClass(object):
+        def __init__(self, some_class):
+            self.some_class = some_class
+
+    injector = DependencyInjector()
+    injector.add_injectables(external=object())
+    classes = injector.build_classes({
+        "some_class": SomeClass,
+        "other": SomeOtherClass
+    })
+
+    assert isinstance(classes["some_class"], SomeClass)
+    assert isinstance(classes["other"], SomeOtherClass)
+    assert classes["other"].some_class is classes["some_class"]
+    ```
+
+    """
+
+    def __init__(self) -> None:
+        # Objects which are available to the constructors of injected objects
+        self.injectables: Dict[str, object] = {}
+
+    def add_injectables(self, **kwargs: object) -> None:
+        """
+        Register additional objects that can be requested by injected classes.
+        """
+        self.injectables.update(kwargs)
+
+    def build_classes(self, classes: Dict[str, type]) -> Dict[str, object]:
+        """
+        Resolve dependencies by name and instantiate each class.
+        """
+        dep = self._make_dependency_graph(classes)
+        # Can get away with a shallow copy because dep values are not modified
+        # in-place.
+        param_map = dep.copy()
+
+        return self._build_classes_from_dependencies(dep, classes, param_map)
+
+    def _make_dependency_graph(self, classes: Dict[str, type]) -> DependencyGraph:
+        """Build dependency graph"""
+        graph: DependencyGraph = defaultdict(list)
+        for name in self.injectables:
+            graph[name] = []
+
+        for obj_name, klass in classes.items():
+            signature = inspect.signature(klass.__init__)
+            # Strip off the `self` parameter
+            params = list(signature.parameters.values())[1:]
+            graph[obj_name] = [param.name for param in params]
+
+        return graph
+
+    def _build_classes_from_dependencies(
+        self,
+        dep: DependencyGraph,
+        classes: Dict[str, type],
+        param_map: Dict[str, List[str]]
+    ) -> Dict[str, object]:
+        """
+        Tries to build all classes in the dependency graph. Raises RuntimeError
+        if some dependencies are not available or there was a cyclic dependency.
+        """
+        instances: Dict[str, object] = {}
+        resolved = ChainMap(instances, self.injectables)
+
+        while True:
+            # Find all services with no dependencies (leaves of our graph)
+            leaves = [
+                name for name, dependencies in dep.items() if not dependencies
+            ]
+            if not leaves:
+                if not dep:
+                    return instances
+
+                # Find which dependencies are missing
+                missing = {
+                    d for dependencies in dep.values()
+                    for d in dependencies if d not in dep
+                }
+                if missing:
+                    raise RuntimeError(
+                        f"Some dependencies could not be resolved: {missing}"
+                    )
+                else:
+                    cycle = tuple(dep.keys())
+                    raise RuntimeError(
+                        f"Could not resolve cyclic dependency: {cycle}"
+                    )
+
+            # Build all objects with no dependencies
+            for obj_name in leaves:
+                if obj_name not in resolved:
+                    klass = classes[obj_name]
+                    param_names = param_map[obj_name]
+
+                    # Build instances using the objects we've resolved so far
+                    instances[obj_name] = klass(**{
+                        param: resolved[param]
+                        for param in param_names
+                    })
+                del dep[obj_name]
+
+            # Remove leaves from the dependency graph
+            for name, dependencies in dep.items():
+                dep[name] = [d for d in dependencies if d not in leaves]

--- a/server/core/dependency_injector.py
+++ b/server/core/dependency_injector.py
@@ -66,10 +66,16 @@ class DependencyInjector(object):
         # in-place.
         param_map = dep.copy()
 
-        return self._build_classes_from_dependencies(dep, classes, param_map)
+        instances = self._build_classes_from_dependencies(
+            dep, classes, param_map
+        )
+        self.add_injectables(**instances)
+        return instances
 
     def _make_dependency_graph(self, classes: Dict[str, type]) -> DependencyGraph:
-        """Build dependency graph"""
+        """
+        Build dependency graph
+        """
         graph: DependencyGraph = defaultdict(list)
         for name in self.injectables:
             graph[name] = []
@@ -98,6 +104,7 @@ class DependencyInjector(object):
         while True:
             if not dep:
                 return instances
+
             # Find all services with no dependencies (leaves of our graph)
             leaves = [
                 name for name, dependencies in dep.items() if not dependencies
@@ -129,6 +136,9 @@ class DependencyInjector(object):
                         param: resolved[param]
                         for param in param_names
                     })
+                else:
+                    instances[obj_name] = resolved[obj_name]
+
                 del dep[obj_name]
 
             # Remove leaves from the dependency graph

--- a/server/core/dependency_injector.py
+++ b/server/core/dependency_injector.py
@@ -51,16 +51,25 @@ class DependencyInjector(object):
         # Objects which are available to the constructors of injected objects
         self.injectables: Dict[str, object] = {}
 
-    def add_injectables(self, **kwargs: object) -> None:
+    def add_injectables(
+        self, injectables: Dict[str, object] = {}, **kwargs: object
+    ) -> None:
         """
         Register additional objects that can be requested by injected classes.
         """
+        self.injectables.update(injectables)
         self.injectables.update(kwargs)
 
-    def build_classes(self, classes: Dict[str, type]) -> Dict[str, object]:
+    def build_classes(
+        self, classes: Dict[str, type] = {}, **kwargs: type
+    ) -> Dict[str, object]:
         """
         Resolve dependencies by name and instantiate each class.
         """
+        # kwargs is temporary so we won't be messing with the caller's data
+        kwargs.update(classes)
+        classes = kwargs
+
         dep = self._make_dependency_graph(classes)
         # Can get away with a shallow copy because dep values are not modified
         # in-place.

--- a/server/core/dependency_injector.py
+++ b/server/core/dependency_injector.py
@@ -96,15 +96,14 @@ class DependencyInjector(object):
         resolved = ChainMap(instances, self.injectables)
 
         while True:
+            if not dep:
+                return instances
             # Find all services with no dependencies (leaves of our graph)
             leaves = [
                 name for name, dependencies in dep.items() if not dependencies
             ]
             if not leaves:
-                if not dep:
-                    return instances
-
-                # Find which dependencies are missing
+                # Find which dependencies could not be resolved
                 missing = {
                     d for dependencies in dep.values()
                     for d in dependencies if d not in dep

--- a/server/core/service.py
+++ b/server/core/service.py
@@ -1,4 +1,29 @@
-class Service(object):
+import re
+from typing import Dict, List
+
+from .dependency_injector import DependencyInjector
+
+CASE_PATTERN = re.compile(r'(?<!^)(?=[A-Z])')
+DependencyGraph = Dict[str, List[str]]
+
+
+class ServiceMeta(type):
+    """
+    For tracking which Services have been defined.
+    """
+
+    # Mapping from parameter name to class
+    services: Dict[str, type] = {}
+
+    def __new__(cls, name, bases, attrs):
+        klass = type.__new__(cls, name, bases, attrs)
+        if name != "Service":
+            arg_name = snake_case(name)
+            cls.services[arg_name] = klass
+        return klass
+
+
+class Service(metaclass=ServiceMeta):
     """
     All services should inherit from this class.
 
@@ -16,3 +41,22 @@ class Service(object):
         Called once after the server received the shutdown signal.
         """
         pass  # pragma: no cover
+
+
+def create_services(injectables: Dict[str, object] = {}) -> Dict[str, Service]:
+    """
+    Resolve service dependencies and instantiate each service. This should only
+    be called once.
+    """
+    injector = DependencyInjector()
+    injector.add_injectables(**injectables)
+
+    return injector.build_classes(ServiceMeta.services)
+
+
+def snake_case(string: str) -> str:
+    """
+    Copied from:
+    https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
+    """
+    return CASE_PATTERN.sub('_', string).lower()

--- a/tests/unit_tests/core/test_dependency_injector.py
+++ b/tests/unit_tests/core/test_dependency_injector.py
@@ -1,0 +1,73 @@
+import pytest
+from server.core import DependencyInjector
+
+
+@pytest.fixture
+def injector():
+    return DependencyInjector()
+
+
+def test_dependency_injector_builds_classes(injector):
+    class A:
+        def __init__(self) -> None:
+            pass
+
+    class B:
+        def __init__(self) -> None:
+            pass
+
+    classes = injector.build_classes({"a": A, "b": B})
+
+    assert isinstance(classes["a"], A)
+    assert isinstance(classes["b"], B)
+
+
+def test_dependency_injector_resolves_dependencies(injector):
+    class A:
+        def __init__(self, injected: object) -> None:
+            self.injected = injected
+
+    some_object = object()
+    injector.add_injectables(injected=some_object)
+    classes = injector.build_classes({"a": A})
+
+    assert classes["a"].injected is some_object
+    assert "some_object" not in classes
+
+
+def test_dependency_injector_resolves_class_dependencies(injector):
+    class A:
+        def __init__(self) -> None:
+            pass
+
+    class B:
+        def __init__(self, a: A) -> None:
+            self.a = a
+
+    classes = injector.build_classes({"a": A, "b": B})
+
+    assert isinstance(classes["a"], A)
+    assert isinstance(classes["b"], B)
+    assert classes["b"].a is classes["a"]
+
+
+def test_dependency_injector_finds_missing(injector):
+    class A:
+        def __init__(self, b: object) -> None:
+            pass
+
+    with pytest.raises(RuntimeError):
+        injector.build_classes({"a": A})
+
+
+def test_dependency_injector_finds_cycle(injector):
+    class A:
+        def __init__(self, b: "B") -> None:
+            pass
+
+    class B:
+        def __init__(self, a: A) -> None:
+            self.a = a
+
+    with pytest.raises(RuntimeError):
+        injector.build_classes({"a": A, "b": B})

--- a/tests/unit_tests/core/test_dependency_injector.py
+++ b/tests/unit_tests/core/test_dependency_injector.py
@@ -22,6 +22,17 @@ def test_dependency_injector_builds_classes(injector):
     assert isinstance(classes["b"], B)
 
 
+def test_dependency_injector_only_builds_once(injector):
+    class A:
+        def __init__(self) -> None:
+            pass
+
+    classes = injector.build_classes({"a": A})
+    classes2 = injector.build_classes({"a": A})
+
+    assert classes["a"] is classes2["a"]
+
+
 def test_dependency_injector_resolves_dependencies(injector):
     class A:
         def __init__(self, injected: object) -> None:
@@ -49,6 +60,22 @@ def test_dependency_injector_resolves_class_dependencies(injector):
     assert isinstance(classes["a"], A)
     assert isinstance(classes["b"], B)
     assert classes["b"].a is classes["a"]
+
+
+def test_dependency_injector_saves_instances(injector):
+    class A:
+        def __init__(self) -> None:
+            pass
+
+    class B:
+        def __init__(self, a: A) -> None:
+            self.a = a
+
+    classes = injector.build_classes({"a": A})
+    classes2 = injector.build_classes({"b": B})
+
+    assert classes["a"] is classes2["a"]
+    assert classes2["b"].a is classes2["a"]
 
 
 def test_dependency_injector_finds_missing(injector):


### PR DESCRIPTION
Makes it easier for us to add new services and to change the parameters to service constructors. 

Any class inheriting from `Service` will be instantiated as a singleton object automatically. The class can take other `Service`'s as arguments so long as there is no cyclic dependency between services. 

Any class inheriting from `Service` is provided two server lifecycle hooks: `initialize` and `shutdown` which can be used to perform setup and cleanup actions for the service.