### PR TITLE
Issue/#558 api authentication

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -30,8 +30,8 @@ DB_NAME = os.getenv("FAF_DB_NAME", "faf")
 
 API_CLIENT_ID = os.getenv("API_CLIENT_ID", "client_id")
 API_CLIENT_SECRET = os.getenv("API_CLIENT_SECRET", "banana")
-API_TOKEN_URI = os.getenv("API_TOKEN_URI", "http://api.test.faforever.com/oauth/token")
-API_BASE_URL = os.getenv("API_BASE_URL", "http://api.test.faforever.com/")
+API_TOKEN_URI = os.getenv("API_TOKEN_URI", "https://api.test.faforever.com/oauth/token")
+API_BASE_URL = os.getenv("API_BASE_URL", "https://api.test.faforever.com/")
 USE_API = os.getenv("USE_API", 'true').lower() == 'true'
 
 FAF_POLICY_SERVER_BASE_URL = os.getenv("FAF_POLICY_SERVER_BASE_URL", "http://faf-policy-server")

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -319,7 +319,7 @@ class GameConnection(GpgNetServerProtocol):
             )
 
     async def handle_json_stats(self, stats):
-        await self.game.report_army_stats(stats)
+        self.game.report_army_stats(stats)
 
     async def handle_enforce_rating(self):
         self.game.enforce_rating = True

--- a/server/stats/achievement_service.py
+++ b/server/stats/achievement_service.py
@@ -94,7 +94,7 @@ class AchievementService(Service):
 
         Else, it returns None
         """
-        self._logger.debug("Updating %d achievements", len(queue))
+        self._logger.info("Updating %d achievements for player %d", len(queue), player_id)
         try:
             response, content = await self.api_accessor.update_achievements(queue, player_id)
         except ConnectionError:

--- a/server/stats/event_service.py
+++ b/server/stats/event_service.py
@@ -58,7 +58,7 @@ class EventService(Service):
             }]
         Else, returns None
         """
-        self._logger.debug("Recording %d events", len(queue))
+        self._logger.info("Recording %d events for player %d", len(queue), player_id)
         try:
             response, content = await self.api_accessor.update_events(queue, player_id)
         except ConnectionError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import asynctest
 import pytest
 from asynctest import CoroutineMock
 from server.api.api_accessor import ApiAccessor
+from server.api.oauth_session import OAuth2Session
 from server.config import DB_LOGIN, DB_PASSWORD, DB_PORT, DB_SERVER, TRACE
 from server.db import FAFDatabase
 from server.game_service import GameService
@@ -241,13 +242,11 @@ def matchmaker_queue(game_service) -> MatchmakerQueue:
 
 @pytest.fixture()
 def api_accessor():
-    class FakeSession:
-        def __init__(self):
-            self.request = CoroutineMock(return_value=(200, 'test'))
-            self.fetch_token = CoroutineMock()
+    session = asynctest.create_autospec(OAuth2Session)
+    session.request.return_value = (200, 'test')
 
     api_accessor = ApiAccessor()
-    api_accessor.api_session.session = FakeSession()
+    api_accessor.api_session.session = session
     return api_accessor
 
 

--- a/tests/integration_tests/test_oauth_session.py
+++ b/tests/integration_tests/test_oauth_session.py
@@ -96,17 +96,6 @@ async def test_fetch_token_bad(oauth2_session):
     assert oauth2_session.refresh_token is None
 
 
-async def test_auto_refresh(oauth2_session):
-    await oauth2_session.fetch_token()
-
-    assert oauth2_session.token == 'the_token'
-
-    oauth2_session.token = 'something_else'
-    # Wait for the auto refresh
-    await asyncio.sleep(0.5)
-    assert oauth2_session.token == 'the_token'
-
-
 async def test_reqest(oauth2_session):
     await oauth2_session.fetch_token()
     resp = await oauth2_session.request('GET', 'http://localhost:8080/endpoint')

--- a/tests/unit_tests/test_api_accessor.py
+++ b/tests/unit_tests/test_api_accessor.py
@@ -40,8 +40,7 @@ async def test_api_patch(api_accessor):
         "PATCH",
         API_BASE_URL+'test',
         headers={'Content-type': 'application/json'},
-        json=data,
-        raise_for_status=True
+        json=data
     )
 
     assert result == (200, 'test')

--- a/tests/unit_tests/test_api_accessor.py
+++ b/tests/unit_tests/test_api_accessor.py
@@ -10,6 +10,10 @@ pytestmark = pytest.mark.asyncio
 async def test_session_manager(mocker):
     class MockSession(Mock):
         fetch_token = CoroutineMock()
+        refresh_tokens = CoroutineMock()
+
+        is_expired = Mock(return_value=True)
+        has_refresh_token = Mock(return_value=False)
 
     manager = SessionManager()
     mocker.patch('server.api.api_accessor.OAuth2Session', MockSession)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -987,7 +987,7 @@ async def test_report_army_stats_sends_stats_for_defeated_player(
     with open("tests/data/game_stats_simple_win.json", "r") as stats_file:
         stats = stats_file.read()
 
-    await game.report_army_stats(stats)
+    game.report_army_stats(stats)
 
     game._game_stats_service.process_game_stats.assert_called_once_with(
         players[1], game, stats
@@ -1012,7 +1012,7 @@ async def test_partial_stats_not_affecting_rating_persistence(
     game.launched_at = time.time() - 60 * 60
     await game.add_result(0, 0, 'victory', 10)
     await game.add_result(0, 1, 'defeat', -10)
-    await game.report_army_stats({'stats': {'Player 1': {}}})
+    game.report_army_stats("{'stats': {'Player 1': {}}}")
     await game.on_game_end()
 
     assert game.validity is ValidityState.VALID

--- a/tests/unit_tests/test_oauth_session.py
+++ b/tests/unit_tests/test_oauth_session.py
@@ -1,18 +1,49 @@
+import time
+
 import pytest
-from oauthlib.oauth2.rfc6749.errors import (InsecureTransportError,
-                                            MissingTokenError)
+from oauthlib.oauth2.rfc6749.errors import (
+    InsecureTransportError, MissingTokenError
+)
 from server.api.oauth_session import OAuth2Session
 
 
-@pytest.mark.asyncio
-async def test_error_conditions():
-    oauth_session = OAuth2Session(
+@pytest.fixture
+def oauth_session():
+    return OAuth2Session(
         client_id="client_id",
         client_secret="client_secret",
         token_url='http://some_url'
     )
+
+
+@pytest.mark.asyncio
+async def test_error_conditions(oauth_session):
     with pytest.raises(InsecureTransportError):
         await oauth_session.fetch_token()
 
+    oauth_session.refresh_token = "asdf"
+    with pytest.raises(InsecureTransportError):
+        await oauth_session.refresh_tokens()
+
     with pytest.raises(MissingTokenError):
         await oauth_session.request('GET', 'http://some_other_url')
+
+
+def test_is_expired(oauth_session):
+    assert oauth_session.is_expired()
+    assert oauth_session.has_refresh_token() is False
+
+
+def test_is_expired_2(oauth_session):
+    oauth_session.update_tokens({
+        "access_token": "access_token",
+        "expires_in": 120
+    })
+
+    assert not oauth_session.is_expired()
+
+    oauth_session.update_tokens({
+        "access_token": "access_token",
+        "expires_in": 0
+    })
+    assert oauth_session.is_expired()


### PR DESCRIPTION
Seems like the API was not returning refresh tokens in the way that was expected by the code, so after 1 hour when the first token expired, achievements would stop working. Now token expiration is checked on request, and if the token has expired it will either use a refresh token if one is available or just fetch a new token using the client id and secret.

Also adds more logging to the achievement/event stuff.

Fixes #558 

