### PR TITLE
Bump faf-stack version to v20.4.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo /etc/init.d/mysql stop
   - git clone https://github.com/FAForever/faf-stack.git faf-stack
       && pushd faf-stack
-      && git checkout v20.2.7
+      && git checkout v20.4.18
       && export $(egrep -v '^#' .env.template | xargs)
       && cp -r config.template config
       && ./scripts/init-db.sh

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -323,13 +323,13 @@ insert into ban (player_id, author_id, reason, level, expires_at, revoke_time) v
 ;
 
 insert into game_stats (id, startTime, gameType, gameMod, host, mapId, gameName, validity) values
-    (41935, NOW(), '0', 6, 1, 0, 'MapRepetition', 0),
-    (41936, NOW() + interval 1 minute, '0', 6, 1, 1, 'MapRepetition', 0),
-    (41937, NOW() + interval 2 minute, '0', 6, 1, 2, 'MapRepetition', 0),
-    (41938, NOW() + interval 3 minute, '0', 6, 1, 3, 'MapRepetition', 0),
-    (41939, NOW() + interval 4 minute, '0', 6, 1, 4, 'MapRepetition', 0),
-    (41940, NOW() + interval 5 minute, '0', 6, 1, 5, 'MapRepetition', 0),
-    (41941, NOW() + interval 6 minute, '0', 6, 1, 6, 'MapRepetition', 0);
+    (41935, NOW(), '0', 6, 1, 1, 'MapRepetition', 0),
+    (41936, NOW() + interval 1 minute, '0', 6, 1, 2, 'MapRepetition', 0),
+    (41937, NOW() + interval 2 minute, '0', 6, 1, 3, 'MapRepetition', 0),
+    (41938, NOW() + interval 3 minute, '0', 6, 1, 4, 'MapRepetition', 0),
+    (41939, NOW() + interval 4 minute, '0', 6, 1, 5, 'MapRepetition', 0),
+    (41940, NOW() + interval 5 minute, '0', 6, 1, 6, 'MapRepetition', 0),
+    (41941, NOW() + interval 6 minute, '0', 6, 1, 7, 'MapRepetition', 0);
 
 insert into game_player_stats (gameId, playerId, AI, faction, color, team, place, mean, deviation, scoreTime) values
     (1, 1, 0, 0, 0, 2, 0, 1500, 500, NOW()),

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -323,13 +323,13 @@ insert into ban (player_id, author_id, reason, level, expires_at, revoke_time) v
 ;
 
 insert into game_stats (id, startTime, gameType, gameMod, host, mapId, gameName, validity) values
-    (41935, NOW(), '0', 6, 1, 1, 'MapRepetition', 0),
-    (41936, NOW() + interval 1 minute, '0', 6, 1, 2, 'MapRepetition', 0),
-    (41937, NOW() + interval 2 minute, '0', 6, 1, 3, 'MapRepetition', 0),
-    (41938, NOW() + interval 3 minute, '0', 6, 1, 4, 'MapRepetition', 0),
-    (41939, NOW() + interval 4 minute, '0', 6, 1, 5, 'MapRepetition', 0),
-    (41940, NOW() + interval 5 minute, '0', 6, 1, 6, 'MapRepetition', 0),
-    (41941, NOW() + interval 6 minute, '0', 6, 1, 7, 'MapRepetition', 0);
+    (41935, NOW(), '0', 6, 1, NULL, 'MapRepetition', 0),
+    (41936, NOW() + interval 1 minute, '0', 6, 1, 1, 'MapRepetition', 0),
+    (41937, NOW() + interval 2 minute, '0', 6, 1, 2, 'MapRepetition', 0),
+    (41938, NOW() + interval 3 minute, '0', 6, 1, 3, 'MapRepetition', 0),
+    (41939, NOW() + interval 4 minute, '0', 6, 1, 4, 'MapRepetition', 0),
+    (41940, NOW() + interval 5 minute, '0', 6, 1, 5, 'MapRepetition', 0),
+    (41941, NOW() + interval 6 minute, '0', 6, 1, 6, 'MapRepetition', 0);
 
 insert into game_player_stats (gameId, playerId, AI, faction, color, team, place, mean, deviation, scoreTime) values
     (1, 1, 0, 0, 0, 2, 0, 1500, 500, NOW()),

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -231,9 +231,9 @@ async def test_choose_map_raises_on_empty_map_pool(ladder_service: LadderService
 
 async def test_get_ladder_history(ladder_service: LadderService, players, database):
     history = await ladder_service.get_ladder_history(players.hosting, limit=1)
-    assert history == [7]
+    assert history == [6]
 
 
 async def test_get_ladder_history_many_maps(ladder_service: LadderService, players, database):
     history = await ladder_service.get_ladder_history(players.hosting, limit=4)
-    assert history == [7, 6, 5, 4]
+    assert history == [6, 5, 4, 3]

--- a/tests/unit_tests/test_ladder.py
+++ b/tests/unit_tests/test_ladder.py
@@ -231,9 +231,9 @@ async def test_choose_map_raises_on_empty_map_pool(ladder_service: LadderService
 
 async def test_get_ladder_history(ladder_service: LadderService, players, database):
     history = await ladder_service.get_ladder_history(players.hosting, limit=1)
-    assert history == [6]
+    assert history == [7]
 
 
 async def test_get_ladder_history_many_maps(ladder_service: LadderService, players, database):
     history = await ladder_service.get_ladder_history(players.hosting, limit=4)
-    assert history == [6, 5, 4, 3]
+    assert history == [7, 6, 5, 4]


### PR DESCRIPTION
Needed to use the new rating tables.

Required a few adaptations of the unit tests, since map id 0 was removed by a previous migration, which I wanted to keep out of from the rating service PR.