### PR TITLE
Unset lobby_connection reference to game_connection on abort

### DIFF
--- a/integration_tests/fafclient.py
+++ b/integration_tests/fafclient.py
@@ -153,3 +153,10 @@ class FAFClient(object):
                 for player_info in msg["players"]
             })
         return ratings
+
+    async def send_gpg_command(self, command, *args):
+        await self.send_message({
+            "target": "game",
+            "command": command,
+            "args": args
+        })

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -572,6 +572,8 @@ class GameConnection(GpgNetServerProtocol):
             await self.game.remove_game_connection(self)
             self._mark_dirty()
             self.player.state = PlayerState.IDLE
+            if self.player.lobby_connection:
+                self.player.lobby_connection.game_connection = None
             del self.player.game
             del self.player.game_connection
         except Exception as ex:  # pragma: no cover

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -124,7 +124,6 @@ class LobbyConnection:
             )
         if self.game_connection:
             await self.game_connection.abort()
-            self.game_connection = None
 
         await self.protocol.close()
 


### PR DESCRIPTION
Should be able to solve #580 with this small change and another really small change in the FA code (sending `GameState: Ended` when `SafeQuit` is triggered). I think this is a better solution (because its so much simpler) than what I described in #587.

When investigating the `SafeQuit` issue, I noticed that `GameConnection` objects would not be deleted after games ended because `lobby_connection` would still hold a reference to them. This reference would only be removed once a new game was started or the player disconnected from the server. Since `GameConnection` holds a strong reference to `Game` this also means that `Game` objects would not be deleted for a possibly very long time.

Another possible solution would be to make `LobbyConnection` only hold a weak reference to `GameConnection`.