### PR TITLE
Check init mode in command `game_join`

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -17,7 +17,7 @@ import server.metrics as metrics
 from server.db import FAFDatabase
 from sqlalchemy import and_, func, select, text
 
-from .abc.base_game import GameConnectionState
+from .abc.base_game import GameConnectionState, InitMode
 from .async_functions import gather_without_exceptions
 from .config import TRACE, config
 from .db.models import (
@@ -828,7 +828,7 @@ class LobbyConnection:
             await self.send({
                 "command": "notice",
                 "style": "info",
-                "text": "The host has left the game"
+                "text": "The host has left the game."
             })
             return
 
@@ -841,11 +841,14 @@ class LobbyConnection:
             })
             return
 
+        if game.init_mode != InitMode.NORMAL_LOBBY:
+            raise ClientError("The game cannot be joined in this way.")
+
         if game.password != password:
             await self.send({
                 "command": "notice",
                 "style": "info",
-                "text": "Bad password (it's case sensitive)"
+                "text": "Bad password (it's case sensitive)."
             })
             return
 

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -5,6 +5,7 @@ from server.protocol import QDataStreamProtocol
 from tests.utils import fast_forward
 
 from .conftest import connect_and_sign_in, read_until, read_until_command
+from .test_matchmaker import queue_players_for_matchmaking
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -168,8 +169,10 @@ async def test_game_ended_rates_game(lobby_server):
 
 @fast_forward(60)
 async def test_partial_game_ended_rates_game(lobby_server, tmp_user):
-    """Test that game is rated as soon as all players have either disconnected
-    or sent `GameEnded`"""
+    """
+    Test that game is rated as soon as all players have either disconnected
+    or sent `GameEnded`
+    """
     host_id, _, host_proto = await connect_and_sign_in(
         ("test", "test_password"), lobby_server
     )
@@ -272,3 +275,41 @@ async def test_partial_game_ended_rates_game(lobby_server, tmp_user):
     # The game should only be rated once
     with pytest.raises(asyncio.TimeoutError):
         await read_until_command(host_proto, "player_info", timeout=10)
+
+
+@fast_forward(15)
+async def test_ladder_game_not_joinable(lobby_server):
+    """
+    We should not be able to join AUTO_LOBBY games using the `game_join` command.
+    """
+    _, _, test_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    proto1, proto2 = await queue_players_for_matchmaking(lobby_server)
+    await read_until_command(test_proto, "game_info")
+
+    msg = await read_until_command(proto1, "game_launch")
+    await proto1.send_message({
+        'command': 'GameState',
+        'target': 'game',
+        'args': ['Idle']
+    })
+    await proto1.send_message({
+        'command': 'GameState',
+        'target': 'game',
+        'args': ['Lobby']
+    })
+
+    game_uid = msg["uid"]
+
+    await test_proto.send_message({
+        "command": "game_join",
+        "uid": game_uid
+    })
+
+    msg = await read_until_command(test_proto, "notice", timeout=5)
+    assert msg == {
+        "command": "notice",
+        "style": "error",
+        "text": "The game cannot be joined in this way."
+    }


### PR DESCRIPTION
One of the things we noticed during TMM testing was that the games would show up in the custom games tab and could be joined through the normal method. However the game was pretty broken after that point, with the player who joined in this way showing up as playing the nomads faction, but also being set as observer. 

As it turns out, the server hasn't been checking whether player initiated game joins are actually valid with respect to init mode. It is possible that some of the rare ladder errors involving players having the nomads faction were caused by some client bugs / inconsistent state allowing them to join ladder games through the custom games tab.