### PR TITLE
Issue/#602 search start confirmation

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -338,7 +338,7 @@ class LadderService(Service):
                 if not hosted:
                     raise TimeoutError("Host left lobby")
             finally:
-                # TODO: Once the client supports `game_launch_cancelled`, don't
+                # TODO: Once the client supports `match_cancelled`, don't
                 # send `launch_game` to the client if the host timed out. Until
                 # then, failing to send `launch_game` will cause the client to
                 # think it is searching for ladder, even though the server has
@@ -356,7 +356,7 @@ class LadderService(Service):
             self._logger.debug("Ladder game launched successfully")
         except Exception:
             self._logger.exception("Failed to start ladder game!")
-            msg = {"command": "game_launch_cancelled"}
+            msg = {"command": "match_cancelled"}
             with contextlib.suppress(DisconnectedError):
                 await asyncio.gather(
                     host.send_message(msg),

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -172,6 +172,11 @@ class LadderService(Service):
             if queue_name == "ladder1v1":
                 tasks.append(self.inform_player(player))
 
+            tasks.append(player.send_message({
+                "command": "search_started",
+                "queue": queue_name
+            }))
+
         try:
             await asyncio.gather(*tasks)
         except DisconnectedError:

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextlib
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import aiocron
 from sqlalchemy import and_, func, select, text
@@ -158,11 +158,16 @@ class LadderService(Service):
             ))
         return matchmaker_queues
 
-    async def start_search(self, initiator: Player, search: Search, queue_name: str):
+    async def start_search(
+        self,
+        initiator: Player,
+        search: Search,
+        queue_name: str
+    ):
         # TODO: Consider what happens if players disconnect while starting
         # search. Will need a message to inform other players in the search
         # that it has been cancelled.
-        self._cancel_existing_searches(initiator)
+        self._cancel_existing_searches(initiator, queue_name)
 
         tasks = []
         for player in search.players:
@@ -173,8 +178,9 @@ class LadderService(Service):
                 tasks.append(self.inform_player(player))
 
             tasks.append(player.send_message({
-                "command": "search_started",
-                "queue": queue_name
+                "command": "search_info",
+                "queue": queue_name,
+                "state": "start"
             }))
 
         try:
@@ -194,33 +200,52 @@ class LadderService(Service):
 
         asyncio.create_task(self.queues[queue_name].search(search))
 
-    async def cancel_search(self, initiator: Player):
-        searches = self._cancel_existing_searches(initiator)
+    async def cancel_search(
+        self,
+        initiator: Player,
+        queue_name: Optional[str] = None
+    ):
+        searches = self._cancel_existing_searches(initiator, queue_name)
 
         tasks = []
-        for search in searches:
+        for queue_name, search in searches:
             for player in search.players:
+                # FIXME: This is wrong for multiqueueing
                 if player.state == PlayerState.SEARCHING_LADDER:
                     player.state = PlayerState.IDLE
 
                 if player.lobby_connection is not None:
                     tasks.append(player.send_message({
-                        "command": "game_matchmaking",
+                        "command": "search_info",
+                        "queue": queue_name,
                         "state": "stop"
                     }))
             self._logger.info(
-                "%s stopped searching for ladder: %s", player, search
+                "%s stopped searching for %s: %s", initiator, queue_name, search
             )
 
         await gather_without_exceptions(tasks, DisconnectedError)
 
-    def _cancel_existing_searches(self, initiator: Player) -> List[Search]:
+    def _cancel_existing_searches(
+        self,
+        initiator: Player,
+        queue_name: Optional[str] = None
+    ) -> List[Tuple[str, Search]]:
+        """
+        Cancel search for a specific queue, or all searches if `queue_name` is
+        None.
+        """
+        if queue_name:
+            queue_names = [queue_name]
+        else:
+            queue_names = list(self.queues)
+
         searches = []
-        for queue_name in self.queues:
+        for queue_name in queue_names:
             search = self.searches[queue_name].get(initiator)
             if search:
                 search.cancel()
-                searches.append(search)
+                searches.append((queue_name, search))
                 del self.searches[queue_name][initiator]
         return searches
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -834,7 +834,7 @@ class LobbyConnection:
             raise ClientError("Cannot host game. Please update your client to the newest version.")
 
         if state == "stop":
-            await self.ladder_service.cancel_search(self.player)
+            await self.ladder_service.cancel_search(self.player, mod)
             return
 
         if state == "start":

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -145,11 +145,11 @@ async def test_game_matchmaking_timeout(lobby_server):
     msg2 = await read_until_command(proto2, 'game_launch')
     # LEGACY BEHAVIOUR: The host does not respond with the appropriate GameState
     # so the match is cancelled. However, the client does not know how to
-    # handle `game_launch_cancelled` messages so we still send `game_launch` to
+    # handle `match_cancelled` messages so we still send `game_launch` to
     # prevent the client from showing that it is searching when it really isn't.
     msg1 = await read_until_command(proto1, 'game_launch')
-    await read_until_command(proto2, 'game_launch_cancelled')
-    await read_until_command(proto1, 'game_launch_cancelled')
+    await read_until_command(proto2, 'match_cancelled')
+    await read_until_command(proto1, 'match_cancelled')
 
     assert msg1['uid'] == msg2['uid']
     assert msg1['mod'] == 'ladder1v1'
@@ -182,9 +182,9 @@ async def test_game_matchmaking_disconnect(lobby_server):
     # One player disconnects before the game has launched
     await proto1.close()
 
-    msg = await read_until_command(proto2, 'game_launch_cancelled')
+    msg = await read_until_command(proto2, 'match_cancelled')
 
-    assert msg == {'command': 'game_launch_cancelled'}
+    assert msg == {'command': 'match_cancelled'}
 
 
 @fast_forward(100)

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -18,6 +18,7 @@ async def queue_player_for_matchmaking(user, lobby_server):
         'state': 'start',
         'faction': 'uef'
     })
+    await read_until_command(proto, 'search_started')
 
     return proto
 
@@ -39,6 +40,7 @@ async def queue_players_for_matchmaking(lobby_server):
         'state': 'start',
         'faction': 1  # Python client sends factions as numbers
     })
+    await read_until_command(proto2, 'search_started')
 
     # If the players did not match, this will fail due to a timeout error
     await read_until_command(proto1, 'match_found')

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -49,10 +49,10 @@ async def test_start_game_timeout(ladder_service: LadderService, player_factory)
 
     await ladder_service.start_game(p1, p2)
 
-    p1.lobby_connection.send.assert_called_once_with({"command": "game_launch_cancelled"})
-    p2.lobby_connection.send.assert_called_once_with({"command": "game_launch_cancelled"})
+    p1.lobby_connection.send.assert_called_once_with({"command": "match_cancelled"})
+    p2.lobby_connection.send.assert_called_once_with({"command": "match_cancelled"})
     assert p1.lobby_connection.launch_game.called
-    # TODO: Once client supports `game_launch_cancelled` change this to `assert not ...`
+    # TODO: Once client supports `match_cancelled` change this to `assert not ...`
     assert p2.lobby_connection.launch_game.called
 
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -824,7 +824,10 @@ async def test_command_game_matchmaking(lobbyconnection):
         'state': 'stop'
     })
 
-    lobbyconnection.ladder_service.cancel_search.assert_called_with(lobbyconnection.player)
+    lobbyconnection.ladder_service.cancel_search.assert_called_with(
+        lobbyconnection.player,
+        "ladder1v1"
+    )
 
 
 async def test_command_matchmaker_info(lobbyconnection, ladder_service, queue_factory):


### PR DESCRIPTION
Add server message to tell clients when they have been entered into a queue.

Rename `game_launch_cancelled` to `match_cancelled`.

Closes #602