### PR TITLE
Update isort config and sort all imports

### DIFF
--- a/integration_tests/test_message_queue/test_message_queue_service.py
+++ b/integration_tests/test_message_queue/test_message_queue_service.py
@@ -1,9 +1,8 @@
 import asyncio
 
 import aio_pika
-import pytest
-
 import mock
+import pytest
 
 from server.config import config
 from server.decorators import with_logger

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -12,24 +12,24 @@ from typing import Optional
 from prometheus_client import start_http_server
 
 from server.db import FAFDatabase
-from .config import config
-from .games.game import GameState, VisibilityState
-from .stats.game_stats_service import GameStatsService
-from .gameconnection import GameConnection
-from .ice_servers.nts import TwilioNTS
-from .lobbyconnection import LobbyConnection
-from .protocol import QDataStreamProtocol
-from .servercontext import ServerContext
-from .configuration_service import ConfigurationService
-from .message_queue_service import MessageQueueService
-from .rating_service.rating_service import RatingService
-from .geoip_service import GeoIpService
-from .player_service import PlayerService
-from .game_service import GameService
-from .ladder_service import LadderService
-from .control import run_control_server
-from .timing import at_interval
 
+from .config import config
+from .configuration_service import ConfigurationService
+from .control import run_control_server
+from .game_service import GameService
+from .gameconnection import GameConnection
+from .games.game import GameState, VisibilityState
+from .geoip_service import GeoIpService
+from .ice_servers.nts import TwilioNTS
+from .ladder_service import LadderService
+from .lobbyconnection import LobbyConnection
+from .message_queue_service import MessageQueueService
+from .player_service import PlayerService
+from .protocol import QDataStreamProtocol
+from .rating_service.rating_service import RatingService
+from .servercontext import ServerContext
+from .stats.game_stats_service import GameStatsService
+from .timing import at_interval
 
 __author__ = 'Askaholic, Chris Kitching, Dragonfire, Gael Honorez, Jeroen De Dauw, Crotalus, Michael Søndergaard, Michel Jung'
 __contact__ = 'admin@faforever.com'

--- a/server/api/api_accessor.py
+++ b/server/api/api_accessor.py
@@ -2,8 +2,10 @@ from ssl import SSLError
 from typing import Optional
 
 from oauthlib.oauth2.rfc6749.errors import (
-    InsecureTransportError, MissingTokenError
+    InsecureTransportError,
+    MissingTokenError
 )
+
 from server.config import config
 from server.decorators import with_logger
 

--- a/server/api/oauth_session.py
+++ b/server/api/oauth_session.py
@@ -4,7 +4,8 @@ from typing import Dict
 
 import aiohttp
 from oauthlib.oauth2.rfc6749.errors import (
-    InsecureTransportError, MissingTokenError
+    InsecureTransportError,
+    MissingTokenError
 )
 
 

--- a/server/config.py
+++ b/server/config.py
@@ -3,9 +3,8 @@ import logging
 import os
 from typing import Callable, Dict
 
-import yaml
-
 import trueskill
+import yaml
 
 from .decorators import with_logger
 

--- a/server/core/__init__.py
+++ b/server/core/__init__.py
@@ -1,6 +1,5 @@
-from .service import Service, create_services
 from .dependency_injector import DependencyInjector
-
+from .service import Service, create_services
 
 __all__ = (
     "DependencyInjector",

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -1,10 +1,21 @@
 from sqlalchemy import (
-    TIME, TIMESTAMP, Boolean, Column, DateTime, Enum, Float, ForeignKey,
-    Integer, MetaData, String, Table, Text
+    TIME,
+    TIMESTAMP,
+    Boolean,
+    Column,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text
 )
 
-from ..games.typedefs import Victory
 from ..games.game_results import GameOutcome
+from ..games.typedefs import Victory
 
 metadata = MetaData()
 

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -8,7 +8,11 @@ from .core import Service
 from .db import FAFDatabase
 from .decorators import with_logger
 from .games import (
-    CoopGame, CustomGame, FeaturedMod, FeaturedModType, LadderGame
+    CoopGame,
+    CustomGame,
+    FeaturedMod,
+    FeaturedModType,
+    LadderGame
 )
 from .games.game import Game, GameState, VisibilityState
 from .games.typedefs import EndedGameInfo, ValidityState

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -1,13 +1,18 @@
 import asyncio
 import contextlib
 
-from server.db import FAFDatabase
 from sqlalchemy import or_, select, text
+
+from server.db import FAFDatabase
 
 from .abc.base_game import GameConnectionState
 from .config import TRACE
 from .db.models import (
-    coop_leaderboard, coop_map, login, moderation_report, reported_user,
+    coop_leaderboard,
+    coop_map,
+    login,
+    moderation_report,
+    reported_user,
     teamkills
 )
 from .decorators import with_logger
@@ -16,7 +21,9 @@ from .games.game import Game, GameError, GameState, ValidityState, Victory
 from .player_service import PlayerService
 from .players import Player, PlayerState
 from .protocol import (
-    DisconnectedError, GpgNetServerProtocol, QDataStreamProtocol
+    DisconnectedError,
+    GpgNetServerProtocol,
+    QDataStreamProtocol
 )
 
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -13,7 +13,10 @@ from sqlalchemy.sql.functions import now as sql_now
 from server.config import FFA_TEAM
 from server.db.models import game_player_stats, game_stats
 from server.games.game_results import (
-    GameOutcome, GameResolutionError, GameResultReport, GameResultReports,
+    GameOutcome,
+    GameResolutionError,
+    GameResultReport,
+    GameResultReports,
     resolve_game
 )
 from server.rating import RatingType
@@ -21,8 +24,13 @@ from server.rating import RatingType
 from ..abc.base_game import GameConnectionState, InitMode
 from ..players import Player, PlayerState
 from .typedefs import (
-    BasicGameInfo, EndedGameInfo, FeaturedModType, GameState, ValidityState,
-    Victory, VisibilityState
+    BasicGameInfo,
+    EndedGameInfo,
+    FeaturedModType,
+    GameState,
+    ValidityState,
+    Victory,
+    VisibilityState
 )
 
 

--- a/server/ice_servers/nts.py
+++ b/server/ice_servers/nts.py
@@ -6,8 +6,9 @@ import asyncio
 from functools import partial
 from typing import Dict, List
 
-from server.config import config
 from twilio.rest import Client as TwilioRestClient
+
+from server.config import config
 
 
 class TwilioNTS:

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -14,11 +14,17 @@ from .config import config
 from .core import Service
 from .db import FAFDatabase
 from .db.models import (
-    game_featuredMods, game_player_stats, game_stats, leaderboard
+    game_featuredMods,
+    game_player_stats,
+    game_stats,
+    leaderboard
 )
 from .db.models import map as t_map
 from .db.models import (
-    map_pool, map_pool_map_version, map_version, matchmaker_queue,
+    map_pool,
+    map_pool_map_version,
+    map_version,
+    matchmaker_queue,
     matchmaker_queue_map_pool
 )
 from .decorators import with_logger

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -22,7 +22,12 @@ from .abc.base_game import GameConnectionState, InitMode
 from .async_functions import gather_without_exceptions
 from .config import TRACE, config
 from .db.models import (
-    avatars, avatars_list, ban, coop_map, friends_and_foes, lobby_ban
+    avatars,
+    avatars_list,
+    ban,
+    coop_map,
+    friends_and_foes,
+    lobby_ban
 )
 from .db.models import login as t_login
 from .decorators import timed, with_logger

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -4,7 +4,14 @@ import random
 import statistics as stats
 from collections import OrderedDict
 from typing import (
-    Dict, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar
 )
 
 from ..decorators import with_logger

--- a/server/message_queue_service.py
+++ b/server/message_queue_service.py
@@ -6,7 +6,7 @@ import aio_pika
 from aio_pika import DeliveryMode, ExchangeType
 from aio_pika.exceptions import ProbableAuthenticationError
 
-from .config import config, TRACE
+from .config import TRACE, config
 from .core import Service
 from .decorators import with_logger
 

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -13,9 +13,19 @@ from server.rating import RatingType
 
 from .core import Service
 from .db.models import (
-    avatars, avatars_list, clan, clan_membership, global_rating,
-    group_permission, group_permission_assignment, ladder1v1_rating,
-    leaderboard, leaderboard_rating, login, user_group, user_group_assignment
+    avatars,
+    avatars_list,
+    clan,
+    clan_membership,
+    global_rating,
+    group_permission,
+    group_permission_assignment,
+    ladder1v1_rating,
+    leaderboard,
+    leaderboard_rating,
+    login,
+    user_group,
+    user_group_assignment
 )
 
 

--- a/server/protocol/__init__.py
+++ b/server/protocol/__init__.py
@@ -1,7 +1,6 @@
-from .qdatastreamprotocol import QDataStreamProtocol, DisconnectedError
-from .protocol import Protocol
 from .gpgnet import GpgNetClientProtocol, GpgNetServerProtocol
-
+from .protocol import Protocol
+from .qdatastreamprotocol import DisconnectedError, QDataStreamProtocol
 
 __all__ = (
     'DisconnectedError',

--- a/server/rating_service/game_rater.py
+++ b/server/rating_service/game_rater.py
@@ -1,8 +1,9 @@
 from typing import Dict, List
 
 import trueskill
-from server.games.game_results import GameOutcome
 from trueskill import Rating
+
+from server.games.game_results import GameOutcome
 
 from ..decorators import with_logger
 from .typedefs import GameRatingData, PlayerID

--- a/server/rating_service/rating_service.py
+++ b/server/rating_service/rating_service.py
@@ -9,8 +9,12 @@ from server.config import config
 from server.core import Service
 from server.db import FAFDatabase
 from server.db.models import (
-    game_player_stats, global_rating, ladder1v1_rating, leaderboard,
-    leaderboard_rating, leaderboard_rating_journal
+    game_player_stats,
+    global_rating,
+    ladder1v1_rating,
+    leaderboard,
+    leaderboard_rating,
+    leaderboard_rating_journal
 )
 from server.decorators import with_logger
 from server.games.game_results import GameOutcome
@@ -20,7 +24,10 @@ from server.rating import RatingType, RatingTypeMap
 
 from .game_rater import GameRater, GameRatingError
 from .typedefs import (
-    GameRatingData, GameRatingSummary, PlayerID, ServiceNotReadyError,
+    GameRatingData,
+    GameRatingSummary,
+    PlayerID,
+    ServiceNotReadyError,
     TeamRatingData
 )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,4 @@
 [isort]
-multi_line_output = 5
-virtual_env = .venv
-
-[yapf]
-based_on_style = pep8
-spaces_before_comment = 4
-split_before_dot = true
-coalesce_brackets = true
-dedent_closing_brackets = true
-spaces_around_default_or_named_assign = false
+multi_line_output=3
+known_first_party=server,tests,integration_tests
+default_section=THIRDPARTY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,8 @@ import logging
 from typing import Iterable
 from unittest import mock
 
-import pytest
-
 import asynctest
+import pytest
 from asynctest import CoroutineMock
 
 from server.api.api_accessor import ApiAccessor

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -9,6 +9,7 @@ import asynctest
 import pytest
 from aiohttp import web
 from asynctest import exhaust_callbacks
+
 from server import GameService, run_control_server, run_lobby_server
 from server.db.models import login
 from server.ladder_service import LadderService

--- a/tests/integration_tests/test_load.py
+++ b/tests/integration_tests/test_load.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 import pytest
+
 from tests.utils import fast_forward
 
 from .conftest import connect_and_sign_in, read_until_command

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -1,7 +1,10 @@
 import pytest
 
 from .conftest import (
-    connect_and_sign_in, connect_client, perform_login, read_until_command
+    connect_and_sign_in,
+    connect_client,
+    perform_login,
+    read_until_command
 )
 
 # All test coroutines will be treated as marked.

--- a/tests/integration_tests/test_oauth_session.py
+++ b/tests/integration_tests/test_oauth_session.py
@@ -5,6 +5,7 @@ import pytest
 from aiohttp import web
 from aiohttp.client_exceptions import ClientResponseError
 from oauthlib.oauth2.rfc6749.errors import MissingTokenError
+
 from server.api.oauth_session import OAuth2Session
 
 pytestmark = pytest.mark.asyncio

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -2,12 +2,16 @@ import asyncio
 import contextlib
 
 import pytest
-from server.db.models import avatars, avatars_list, ban
 from sqlalchemy import and_, select
+
+from server.db.models import avatars, avatars_list, ban
 from tests.utils import fast_forward
 
 from .conftest import (
-    connect_and_sign_in, connect_client, perform_login, read_until,
+    connect_and_sign_in,
+    connect_client,
+    perform_login,
+    read_until,
     read_until_command
 )
 

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from asynctest import CoroutineMock, exhaust_callbacks
+
 from server import ServerContext
 from server.lobbyconnection import LobbyConnection
 from server.protocol import DisconnectedError, QDataStreamProtocol

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -2,10 +2,10 @@ from contextlib import AbstractContextManager
 from time import perf_counter
 from unittest import mock
 
-import pytest
-
 import asynctest
+import pytest
 from asynctest import CoroutineMock
+
 from server import GameStatsService
 from server.game_service import GameService
 from server.gameconnection import GameConnection, GameConnectionState

--- a/tests/unit_tests/test_achievement_service.py
+++ b/tests/unit_tests/test_achievement_service.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock, Mock
 
 import pytest
-
 from asynctest import CoroutineMock
+
 from server.api.api_accessor import ApiAccessor, SessionManager
 from server.stats.achievement_service import AchievementService
 

--- a/tests/unit_tests/test_api_accessor.py
+++ b/tests/unit_tests/test_api_accessor.py
@@ -1,7 +1,7 @@
 import pytest
-
 from asynctest import CoroutineMock
 from mock import Mock
+
 from server.api.api_accessor import SessionManager
 from server.config import config
 

--- a/tests/unit_tests/test_async_functions.py
+++ b/tests/unit_tests/test_async_functions.py
@@ -1,6 +1,6 @@
 import pytest
-
 from asynctest import CoroutineMock
+
 from server.async_functions import gather_without_exceptions
 
 pytestmark = pytest.mark.asyncio

--- a/tests/unit_tests/test_configuration_refresh.py
+++ b/tests/unit_tests/test_configuration_refresh.py
@@ -3,8 +3,8 @@ from unittest import mock
 
 import pytest
 import yaml
-
 from asynctest import CoroutineMock
+
 from server import config
 from server.configuration_service import ConfigurationService
 from tests.utils import fast_forward

--- a/tests/unit_tests/test_coop_game.py
+++ b/tests/unit_tests/test_coop_game.py
@@ -1,6 +1,6 @@
+import mock
 import pytest
 
-import mock
 from server.games import CoopGame
 
 pytestmark = pytest.mark.asyncio

--- a/tests/unit_tests/test_event_service.py
+++ b/tests/unit_tests/test_event_service.py
@@ -1,8 +1,8 @@
 from unittest.mock import Mock
 
 import pytest
-
 from asynctest import CoroutineMock
+
 from server.api.api_accessor import ApiAccessor
 from server.stats.event_service import EventService
 

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -11,12 +11,19 @@ from trueskill import Rating
 from server.gameconnection import GameConnection, GameConnectionState
 from server.games import CoopGame, CustomGame
 from server.games.game import (
-    Game, GameError, GameState, ValidityState, Victory, VisibilityState
+    Game,
+    GameError,
+    GameState,
+    ValidityState,
+    Victory,
+    VisibilityState
 )
 from server.games.game_results import GameOutcome
 from server.rating import RatingType
 from tests.unit_tests.conftest import (
-    add_connected_player, add_connected_players, make_mock_game_connection
+    add_connected_player,
+    add_connected_players,
+    make_mock_game_connection
 )
 from tests.utils import fast_forward
 

--- a/tests/unit_tests/test_game_rater.py
+++ b/tests/unit_tests/test_game_rater.py
@@ -1,10 +1,10 @@
 import pytest
+from trueskill import Rating
 
 from server.games.game_results import GameOutcome
 from server.rating import RatingType
 from server.rating_service.game_rater import GameRater
 from server.rating_service.typedefs import TeamRatingData
-from trueskill import Rating
 
 
 class MockPlayer:

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -1,7 +1,9 @@
 import pytest
 
 from server.games.game_results import (
-    GameOutcome, GameResolutionError, resolve_game
+    GameOutcome,
+    GameResolutionError,
+    resolve_game
 )
 
 

--- a/tests/unit_tests/test_game_stats_service.py
+++ b/tests/unit_tests/test_game_stats_service.py
@@ -1,14 +1,16 @@
 import json
 from unittest.mock import Mock
 
-import pytest
-
 import asynctest
+import pytest
 from asynctest import CoroutineMock
+
 from server.factions import Faction
 from server.games import Game
 from server.games.game_results import (
-    GameOutcome, GameResultReport, GameResultReports
+    GameOutcome,
+    GameResultReport,
+    GameResultReports
 )
 from server.lobbyconnection import LobbyConnection
 from server.stats import achievement_service as ach

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -1,10 +1,10 @@
 import asyncio
 from unittest import mock
 
-import pytest
-
 import asynctest
+import pytest
 from asynctest import CoroutineMock, exhaust_callbacks
+
 from server import GameConnection
 from server.abc.base_game import GameConnectionState
 from server.games import Game

--- a/tests/unit_tests/test_geoip_service.py
+++ b/tests/unit_tests/test_geoip_service.py
@@ -10,9 +10,9 @@ from time import time
 from unittest.mock import Mock
 
 import pytest
+from aiohttp import web
 
 import server.config
-from aiohttp import web
 from server.geoip_service import GeoIpService
 
 pytestmark = pytest.mark.asyncio

--- a/tests/unit_tests/test_ice.py
+++ b/tests/unit_tests/test_ice.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 import pytest
+from twilio.rest import Client as TwilioRestClient
 
 from server.ice_servers.coturn import CoturnHMAC
 from server.ice_servers.nts import TwilioNTS
-from twilio.rest import Client as TwilioRestClient
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_laddergame.py
+++ b/tests/unit_tests/test_laddergame.py
@@ -1,12 +1,12 @@
 import time
 
 import pytest
+from sqlalchemy import and_, select
 
 from server.db.models import leaderboard_rating
 from server.games import LadderGame
 from server.games.game import GameState, ValidityState
 from server.rating import RatingType
-from sqlalchemy import and_, select
 from tests.unit_tests.test_game import add_connected_players
 
 pytestmark = pytest.mark.asyncio

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -1,9 +1,9 @@
 import random
 
 import pytest
-
 from hypothesis import given
 from hypothesis import strategies as st
+
 from server.matchmaker import MapPool
 from server.types import Map
 

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -5,10 +5,10 @@ from collections import deque
 from concurrent.futures import CancelledError, TimeoutError
 
 import pytest
-
-import server.config as config
 from hypothesis import given
 from hypothesis import strategies as st
+
+import server.config as config
 from server.matchmaker import CombinedSearch, MapPool, PopTimer, Search
 from server.rating import RatingType
 from tests.utils import fast_forward

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -3,7 +3,6 @@ import math
 import random
 
 import pytest
-
 from hypothesis import given, settings
 from hypothesis import strategies as st
 

--- a/tests/unit_tests/test_oauth_session.py
+++ b/tests/unit_tests/test_oauth_session.py
@@ -1,10 +1,11 @@
 import time
 
 import pytest
-
 from oauthlib.oauth2.rfc6749.errors import (
-    InsecureTransportError, MissingTokenError
+    InsecureTransportError,
+    MissingTokenError
 )
+
 from server.api.oauth_session import OAuth2Session
 
 

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -1,8 +1,7 @@
 from enum import Enum
 
-import pytest
-
 import asynctest
+import pytest
 from mock import Mock
 
 from server.lobbyconnection import LobbyConnection

--- a/tests/unit_tests/test_profiler.py
+++ b/tests/unit_tests/test_profiler.py
@@ -2,8 +2,8 @@ import asyncio
 from unittest import mock
 
 import pytest
-
 from asynctest import CoroutineMock
+
 from server.config import config
 from server.profiler import Profiler
 from tests.utils import fast_forward

--- a/tests/unit_tests/test_rating_service.py
+++ b/tests/unit_tests/test_rating_service.py
@@ -7,15 +7,20 @@ from trueskill import Rating
 
 from server.db import FAFDatabase
 from server.db.models import (
-    game_player_stats, leaderboard_rating, leaderboard_rating_journal
+    game_player_stats,
+    leaderboard_rating,
+    leaderboard_rating_journal
 )
 from server.games.game_results import GameOutcome
 from server.games.typedefs import (
-    EndedGameInfo, TeamRatingSummary, ValidityState
+    EndedGameInfo,
+    TeamRatingSummary,
+    ValidityState
 )
 from server.rating import RatingType
 from server.rating_service.rating_service import (
-    RatingService, ServiceNotReadyError
+    RatingService,
+    ServiceNotReadyError
 )
 from server.rating_service.typedefs import GameRatingSummary, TeamRatingData
 


### PR DESCRIPTION
Decided to remove the `virtual_env` setting since by default pipenv does not use the `.venv` folder and instead make the config work without a virtual environment by setting the default section to "third party".

I also changed the multiline sorting style to put one import on each line to try and make the git diffs nicer (and easier to auto merge). For some imports it seems a bit excessive (type imports for example) but I think overall this should play nicer with git, and it doesn't really matter if the imports take up a bit more space.