### PR TITLE
Issue/#610 refactor protocol interface

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -18,11 +18,7 @@ from .game_service import GameService
 from .games.game import Game, GameError, GameState, ValidityState, Victory
 from .player_service import PlayerService
 from .players import Player, PlayerState
-from .protocol import (
-    DisconnectedError,
-    GpgNetServerProtocol,
-    QDataStreamProtocol
-)
+from .protocol import DisconnectedError, GpgNetServerProtocol, Protocol
 
 
 @with_logger
@@ -36,7 +32,7 @@ class GameConnection(GpgNetServerProtocol):
         database: FAFDatabase,
         game: Game,
         player: Player,
-        protocol: QDataStreamProtocol,
+        protocol: Protocol,
         player_service: PlayerService,
         games: GameService,
         state: GameConnectionState = GameConnectionState.INITIALIZING

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -201,6 +201,13 @@ class LobbyConnection:
             result = await conn.execute(select([coop_map]))
 
             maps = []
+            campaigns = [
+                "FA Campaign",
+                "Aeon Vanilla Campaign",
+                "Cybran Vanilla Campaign",
+                "UEF Vanilla Campaign",
+                "Custom Missions"
+            ]
             async for row in result:
                 json_to_send = {
                     "command": "coop_info",
@@ -209,13 +216,6 @@ class LobbyConnection:
                     "filename": row["filename"],
                     "featured_mod": "coop"
                 }
-                campaigns = [
-                    "FA Campaign",
-                    "Aeon Vanilla Campaign",
-                    "Cybran Vanilla Campaign",
-                    "UEF Vanilla Campaign",
-                    "Custom Missions"
-                ]
                 if row["type"] < len(campaigns):
                     json_to_send["type"] = campaigns[row["type"]]
                 else:

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -1038,13 +1038,14 @@ class LobbyConnection:
             await self.abort(message)
 
     async def send(self, message):
-        """
+        """Send a message and wait for it to be sent."""
+        self.write(message)
+        await self.protocol.drain()
 
-        :param message:
-        :return:
-        """
+    def write(self, message):
+        """Write a message into the send buffer."""
         self._logger.log(TRACE, ">> %s: %s", self.get_user_identifier(), message)
-        await self.protocol.send_message(message)
+        self.protocol.write_message(message)
 
     async def on_connection_lost(self):
         async def nop(*args, **kwargs):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -39,10 +39,8 @@ from .ice_servers.nts import TwilioNTS
 from .ladder_service import LadderService
 from .player_service import PlayerService
 from .players import Player, PlayerState
-from .protocol import DisconnectedError, QDataStreamProtocol
+from .protocol import DisconnectedError, Protocol
 from .types import Address, GameLaunchOptions
-
-PONG_MSG = QDataStreamProtocol.pack_message("PONG")
 
 
 class ClientError(Exception):
@@ -88,7 +86,7 @@ class LobbyConnection:
         self.game_connection = None  # type: GameConnection
         self.peer_address = None  # type: Optional[Address]
         self.session = int(random.randrange(0, 4294967295))
-        self.protocol = None
+        self.protocol: Protocol = None
         self.user_agent = None
         self._version = None
 
@@ -108,7 +106,7 @@ class LobbyConnection:
         return str(self.session)
 
     @asyncio.coroutine
-    def on_connection_made(self, protocol: QDataStreamProtocol, peername: Address):
+    def on_connection_made(self, protocol: Protocol, peername: Address):
         self.protocol = protocol
         self.peer_address = peername
         metrics.server_connections.inc()
@@ -189,7 +187,7 @@ class LobbyConnection:
             await self.abort("Error processing command")
 
     async def command_ping(self, msg):
-        await self.protocol.send_raw(PONG_MSG)
+        await self.send({"command": "pong"})
 
     async def command_pong(self, msg):
         pass

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -70,7 +70,11 @@ server_connections = Counter(
     "Total number of connections to the lobby as per lobbyconnection.on_connection_made",
 )
 
-sent_messages = Counter("server_messages_total", "Total number of Messages sent")
+sent_messages = Counter(
+    "server_messages_total",
+    "Total number of Messages sent",
+    ["protocol"]
+)
 
 unauth_messages = Counter(
     "server_messages_unauthenticated_total",

--- a/server/players.py
+++ b/server/players.py
@@ -161,6 +161,16 @@ class Player:
 
         await self.lobby_connection.send(message)
 
+    def write_message(self, message):
+        """
+        Try to queue a message to be sent this player. Only call this from
+        broadcasting functions. Does nothing if the player has disconnected.
+        """
+        if self.lobby_connection is None:
+            return
+
+        self.lobby_connection.write(message)
+
     def to_dict(self):
         """
         Return a dictionary representing this player object

--- a/server/protocol/__init__.py
+++ b/server/protocol/__init__.py
@@ -1,11 +1,11 @@
 from .gpgnet import GpgNetClientProtocol, GpgNetServerProtocol
-from .protocol import Protocol
-from .qdatastreamprotocol import DisconnectedError, QDataStreamProtocol
+from .protocol import DisconnectedError, Protocol
+from .qdatastream import QDataStreamProtocol
 
 __all__ = (
-    'DisconnectedError',
-    'QDataStreamProtocol',
-    'Protocol',
-    'GpgNetClientProtocol',
-    'GpgNetServerProtocol'
+    "DisconnectedError",
+    "GpgNetClientProtocol",
+    "GpgNetServerProtocol",
+    "Protocol",
+    "QDataStreamProtocol",
 )

--- a/server/protocol/protocol.py
+++ b/server/protocol/protocol.py
@@ -1,10 +1,43 @@
+import asyncio
+import contextlib
 from abc import ABCMeta, abstractmethod
+from asyncio import StreamReader, StreamWriter
 from typing import List
+
+import server.metrics as metrics
+
+
+class DisconnectedError(ConnectionError):
+    """For signaling that a protocol has lost connection to the remote."""
 
 
 class Protocol(metaclass=ABCMeta):
+    def __init__(self, reader: StreamReader, writer: StreamWriter):
+        self.reader = reader
+        self.writer = writer
+        # Force calls to drain() to only return once the data has been sent
+        self.writer.transport.set_write_buffer_limits(high=0)
+
+        # drain() cannot be called concurrently by multiple coroutines:
+        # http://bugs.python.org/issue29930.
+        self._drain_lock = asyncio.Lock()
+
+    @staticmethod
     @abstractmethod
-    async def read_message(self: 'Protocol') -> dict:
+    def encode_message(message: dict) -> bytes:
+        """
+        Encode a message as raw bytes. Can be used along with `*_raw` methods.
+        """
+        pass  # pragma: no cover
+
+    def is_connected(self) -> bool:
+        """
+        Return whether or not the connection is still alive
+        """
+        return not self.writer.is_closing()
+
+    @abstractmethod
+    async def read_message(self) -> dict:
         """
         Asynchronously read a message from the stream
 
@@ -13,16 +46,15 @@ class Protocol(metaclass=ABCMeta):
         """
         pass  # pragma: no cover
 
-    @abstractmethod
     async def send_message(self, message: dict) -> None:
         """
         Send a single message in the form of a dictionary
 
         :param message: Message to send
+        :raises: DisconnectedError
         """
-        pass  # pragma: no cover
+        await self.send_raw(self.encode_message(message))
 
-    @abstractmethod
     async def send_messages(self, messages: List[dict]) -> None:
         """
         Send multiple messages in the form of a list of dictionaries.
@@ -30,14 +62,78 @@ class Protocol(metaclass=ABCMeta):
         May be more optimal than sending a single message.
 
         :param messages:
+        :raises: DisconnectedError
         """
-        pass  # pragma: no cover
+        self.write_messages(messages)
+        await self.drain()
 
-    @abstractmethod
     async def send_raw(self, data: bytes) -> None:
         """
         Send raw bytes. Should generally not be used.
 
         :param data: bytes to send
+        :raises: DisconnectedError
         """
-        pass  # pragma: no cover
+        self.write_raw(data)
+        await self.drain()
+
+    def write_message(self, message: dict) -> None:
+        """
+        Write a single message into the message buffer. Should be used when
+        sending broadcasts or when sending messages that are triggered by
+        incoming messages from other players.
+
+        :param message: Message to send
+        """
+        if not self.is_connected():
+            raise DisconnectedError("Protocol is not connected!")
+
+        self.write_raw(self.encode_message(message))
+
+    def write_messages(self, messages: List[dict]) -> None:
+        """
+        Write multiple message into the message buffer.
+
+        :param messages: List of messages to write
+        """
+        metrics.sent_messages.labels(self.__class__.__name__).inc()
+        if not self.is_connected():
+            raise DisconnectedError("Protocol is not connected!")
+
+        self.writer.writelines([self.encode_message(msg) for msg in messages])
+
+    def write_raw(self, data: bytes) -> None:
+        """
+        Write raw bytes into the message buffer. Should generally not be used.
+
+        :param data: bytes to send
+        """
+        metrics.sent_messages.labels(self.__class__.__name__).inc()
+        if not self.is_connected():
+            raise DisconnectedError("Protocol is not connected!")
+
+        self.writer.write(data)
+
+    async def close(self) -> None:
+        """
+        Close the underlying writer as soon as the buffer has emptied.
+        :return:
+        """
+        self.writer.close()
+        with contextlib.suppress(Exception):
+            await self.writer.wait_closed()
+
+    async def drain(self) -> None:
+        """
+        Await the write buffer to empty.
+        See StreamWriter.drain()
+
+        :raises: DisconnectedError if the client disconnects while waiting for
+        the write buffer to empty.
+        """
+        async with self._drain_lock:
+            try:
+                await self.writer.drain()
+            except Exception as e:
+                await self.close()
+                raise DisconnectedError("Protocol connection lost!") from e

--- a/server/protocol/qdatastream.py
+++ b/server/protocol/qdatastream.py
@@ -1,12 +1,8 @@
-import asyncio
 import base64
-import contextlib
 import json
 import struct
-from asyncio import StreamReader, StreamWriter
 from typing import Tuple
 
-import server.metrics as metrics
 from server.decorators import with_logger
 
 from .protocol import Protocol
@@ -14,32 +10,11 @@ from .protocol import Protocol
 json_encoder = json.JSONEncoder(separators=(',', ':'))
 
 
-class DisconnectedError(ConnectionError):
-    """For signaling that a protocol has lost connection to the remote."""
-
-
 @with_logger
 class QDataStreamProtocol(Protocol):
     """
     Implements the legacy QDataStream-based encoding scheme
     """
-    def __init__(self, reader: StreamReader, writer: StreamWriter):
-        """
-        Initialize the protocol
-
-        :param StreamReader reader: asyncio stream to read from
-        """
-        self.reader = reader
-        self.writer = writer
-        # Force calls to drain() to only return once the data has been sent
-        self.writer.transport.set_write_buffer_limits(high=0)
-
-        # drain() cannot be called concurrently by multiple coroutines:
-        # http://bugs.python.org/issue29930.
-        self._drain_lock = asyncio.Lock()
-
-    def is_connected(self) -> bool:
-        return not self.writer.is_closing()
 
     @staticmethod
     def read_qstring(buffer: bytes, pos: int = 0) -> Tuple[int, str]:
@@ -94,10 +69,16 @@ class QDataStreamProtocol(Protocol):
         return QDataStreamProtocol.pack_block(msg)
 
     @staticmethod
-    def encode_message(message) -> bytes:
+    def encode_message(message: dict) -> bytes:
         """
-        Encodes a python object as raw bytes
+        Encodes a python object as a block of QStrings
         """
+        command = message.get("command")
+        if command == "ping":
+            return PING_MSG
+        elif command == "pong":
+            return PONG_MSG
+
         return QDataStreamProtocol.pack_message(json_encoder.encode(message))
 
     async def read_message(self):
@@ -131,57 +112,6 @@ class QDataStreamProtocol(Protocol):
                 pass
             return message
 
-    async def close(self):
-        """
-        Close writer stream as soon as the buffer has emptied.
-        :return:
-        """
-        self.writer.close()
-        with contextlib.suppress(Exception):
-            await self.writer.wait_closed()
 
-    async def drain(self):
-        """
-        Await the write buffer to empty.
-        See StreamWriter.drain()
-
-        :raises: DisconnectedError if the client disconnects while waiting for
-        the write buffer to empty.
-        """
-        # NOTE: This sleep is needed in python versions <= 3.6
-        # https://github.com/aio-libs/aioftp/issues/7
-        await asyncio.sleep(0)
-        async with self._drain_lock:
-            try:
-                await self.writer.drain()
-            except Exception as e:
-                await self.close()
-                raise DisconnectedError("Protocol connection lost!") from e
-
-    async def send_message(self, message: dict):
-        await self.send_raw(self.encode_message(message))
-
-    async def send_messages(self, messages):
-        metrics.sent_messages.inc()
-        if not self.is_connected():
-            raise DisconnectedError("Protocol is not connected!")
-
-        payload = [self.encode_message(msg) for msg in messages]
-        self.writer.writelines(payload)
-        await self.drain()
-
-    async def send_raw(self, data):
-        metrics.sent_messages.inc()
-        if not self.is_connected():
-            raise DisconnectedError("Protocol is not connected!")
-
-        self.writer.write(data)
-        # NOTE: This try/except is for debugging purposes only. In the log we
-        # are seeing "Task exception was never retrieved" errors for
-        # `send_message` and `send_raw` but the stack trace does not tell us
-        # enough to determine which tasks are generating them. We include the
-        # message contents here to help determine the cause.
-        try:
-            await self.drain()
-        except DisconnectedError as e:
-            raise DisconnectedError(data) from e
+PING_MSG = QDataStreamProtocol.pack_message("PING")
+PONG_MSG = QDataStreamProtocol.pack_message("PONG")

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -13,7 +13,7 @@ from asynctest import exhaust_callbacks
 from server import GameService, run_control_server, run_lobby_server
 from server.db.models import login
 from server.ladder_service import LadderService
-from server.protocol import QDataStreamProtocol
+from server.protocol import Protocol, QDataStreamProtocol
 from server.rating_service.rating_service import RatingService
 
 
@@ -146,7 +146,7 @@ async def connect_client(server) -> QDataStreamProtocol:
 
 
 async def perform_login(
-    proto: QDataStreamProtocol, credentials: Tuple[str, str]
+    proto: Protocol, credentials: Tuple[str, str]
 ) -> None:
     login, pw = credentials
     pw_hash = hashlib.sha256(pw.encode('utf-8'))
@@ -161,7 +161,7 @@ async def perform_login(
 
 
 async def read_until(
-    proto: QDataStreamProtocol, pred: Callable[[Dict[str, Any]], bool]
+    proto: Protocol, pred: Callable[[Dict[str, Any]], bool]
 ) -> Dict[str, Any]:
     while True:
         msg = await proto.read_message()
@@ -174,7 +174,7 @@ async def read_until(
 
 
 async def read_until_command(
-    proto: QDataStreamProtocol,
+    proto: Protocol,
     command: str,
     timeout: float = 60
 ) -> Dict[str, Any]:

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from server.protocol import QDataStreamProtocol
+from server.protocol import Protocol
 from tests.utils import fast_forward
 
 from .conftest import connect_and_sign_in, read_until, read_until_command
@@ -12,7 +12,7 @@ from .test_matchmaker import queue_players_for_matchmaking
 pytestmark = pytest.mark.asyncio
 
 
-async def host_game(proto: QDataStreamProtocol) -> int:
+async def host_game(proto: Protocol) -> int:
     await proto.send_message({
         "command": "game_host",
         "mod": "faf",
@@ -36,7 +36,7 @@ async def host_game(proto: QDataStreamProtocol) -> int:
     return game_id
 
 
-async def join_game(proto: QDataStreamProtocol, uid: int):
+async def join_game(proto: Protocol, uid: int):
     await proto.send_message({
         "command": "game_join",
         "uid": uid

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 
 import pytest
 
@@ -361,6 +362,7 @@ async def test_gamestate_ended_clears_references(
         "command": "GameState",
         "args": ["Launching"]
     })
+    await asyncio.sleep(0.1)
 
     game = game_service[game_id]
 
@@ -381,6 +383,7 @@ async def test_gamestate_ended_clears_references(
         "args": [1, "victory 10"]
     })
     await asyncio.sleep(0.1)
+    gc.collect()
     assert rhiza.game_connection is None
     assert len(game.connections) == 1
     assert len(game._results) == 0
@@ -402,6 +405,7 @@ async def test_gamestate_ended_clears_references(
         lambda msg: msg["command"] == "game_info" and msg["state"] == "closed"
     )
     await asyncio.sleep(0.1)
+    gc.collect()
     assert test.game_connection is None
     assert len(game.connections) == 0
     assert len(game._results) == 1

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -90,7 +90,7 @@ async def test_connection_broken_external(context, mock_server):
 
     # Might raise DisconnectedError depending on OS
     with contextlib.suppress(DisconnectedError):
-        await proto.send_message(["Some long message" * 4096])
+        await proto.send_message({"command": "Some long message" * 4096})
 
     await asyncio.sleep(0.1)
     assert len(ctx.connections) == 0


### PR DESCRIPTION
There were only a few places that were relying on methods from `QDataStreamProtocol`. Now it should be possible to simply plug a different `Protocol` implementation into `ServerContext` and everything should work correctly.

Also added `write_message` to player (extracted from other PRs).

Closes #610 