### PR TITLE
Issue/#617 Add check for generated map

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -668,11 +668,12 @@ class Game:
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
             row = await result.fetchone()
+            is_generated = self.map_file_path.startswith("neroxis_map_generator")
 
             if row:
                 self.map_id = row['id']
 
-            if (not row or not row['ranked']) and self.validity is ValidityState.VALID:
+            if (not row or not row['ranked']) and self.validity is ValidityState.VALID and not is_generated:
                 await self.mark_invalid(ValidityState.BAD_MAP)
 
             modId = self.game_service.featured_mods[self.game_mode].id

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -668,14 +668,13 @@ class Game:
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
             row = await result.fetchone()
-            is_generated = False
-            if self.map_file_path:
-                is_generated = "neroxis_map_generator" in self.map_file_path
+            is_generated = (self.map_file_path and "neroxis_map_generator" in self.map_file_path)
 
             if row:
                 self.map_id = row['id']
 
-            if (not row or not row['ranked']) and self.validity is ValidityState.VALID and not is_generated:
+            if (self.validity is ValidityState.VALID and
+               ((row and not row.ranked) or (not row and not is_generated))):
                 await self.mark_invalid(ValidityState.BAD_MAP)
 
             modId = self.game_service.featured_mods[self.game_mode].id

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -667,23 +667,26 @@ class Game:
                 "SELECT id, ranked FROM map_version "
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
-            row = await result.fetchone()
-            is_generated = (self.map_file_path and "neroxis_map_generator" in self.map_file_path)
 
-            if row:
-                self.map_id = row['id']
+        row = await result.fetchone()
+        is_generated = (self.map_file_path and "neroxis_map_generator" in self.map_file_path)
 
-            if (self.validity is ValidityState.VALID and
-               ((row and not row.ranked) or (not row and not is_generated))):
-                await self.mark_invalid(ValidityState.BAD_MAP)
+        if row:
+            self.map_id = row['id']
 
-            modId = self.game_service.featured_mods[self.game_mode].id
+        if (self.validity is ValidityState.VALID and
+           ((row and not row.ranked) or (not row and not is_generated))):
+            await self.mark_invalid(ValidityState.BAD_MAP)
 
-            # Write out the game_stats record.
-            # In some cases, games can be invalidated while running: we check for those cases when
-            # the game ends and update this record as appropriate.
+        modId = self.game_service.featured_mods[self.game_mode].id
 
-            game_type = str(self.gameOptions.get("Victory").value)
+        # Write out the game_stats record.
+        # In some cases, games can be invalidated while running: we check for those cases when
+        # the game ends and update this record as appropriate.
+
+        game_type = str(self.gameOptions.get("Victory").value)
+
+        async with self._db.acquire() as conn:
             await conn.execute(
                 game_stats.insert().values(
                     id=self.id,

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -667,8 +667,8 @@ class Game:
                 "SELECT id, ranked FROM map_version "
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
+            row = await result.fetchone()
 
-        row = await result.fetchone()
         is_generated = (self.map_file_path and "neroxis_map_generator" in self.map_file_path)
 
         if row:

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -674,8 +674,10 @@ class Game:
         if row:
             self.map_id = row['id']
 
-        if (self.validity is ValidityState.VALID and
-           ((row and not row.ranked) or (not row and not is_generated))):
+        if (
+            self.validity is ValidityState.VALID
+            and ((row and not row.ranked) or (not row and not is_generated))
+        ):
             await self.mark_invalid(ValidityState.BAD_MAP)
 
         modId = self.game_service.featured_mods[self.game_mode].id

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -668,7 +668,8 @@ class Game:
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
             row = await result.fetchone()
-            is_generated = self.map_file_path.startswith("neroxis_map_generator")
+            if self.map_file_path:
+                is_generated = "neroxis_map_generator" in self.map_file_path
 
             if row:
                 self.map_id = row['id']

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -668,6 +668,7 @@ class Game:
                 "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
             )
             row = await result.fetchone()
+            is_generated = False
             if self.map_file_path:
                 is_generated = "neroxis_map_generator" in self.map_file_path
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -177,7 +177,8 @@ insert into map (id, display_name, map_type, battle_type, author) values
   (12, 'SCMP_012', 'FFA', 'skirmish', 3),
   (13, 'SCMP_013', 'FFA', 'skirmish', 3),
   (14, 'SCMP_014', 'FFA', 'skirmish', 3),
-  (15, 'SCMP_015', 'FFA', 'skirmish', 3);
+  (15, 'SCMP_015', 'FFA', 'skirmish', 3),
+  (16, 'neroxis_map_generator_sneaky_map', 'FFA', 'skirmish', 1);
 
 insert into map_version (id, description, max_players, width, height, version, filename, hidden, map_id) values
   (1, 'SCMP 001', 8, 1024, 1024, 1, 'maps/scmp_001.zip', 0, 1),
@@ -197,6 +198,9 @@ insert into map_version (id, description, max_players, width, height, version, f
   (15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 15),
   (16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 15),
   (17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 15);
+
+insert into map_version (id, description, max_players, width, height, version, filename, hidden, ranked, map_id) values
+  (18, 'Sneaky_Map', 8, 512, 512, 1, "maps/neroxis_map_generator_sneaky_map.zip", 0, 0, 16);
 
 insert into ladder_map (id, idmap) values
   (1,1),

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -180,26 +180,24 @@ insert into map (id, display_name, map_type, battle_type, author) values
   (15, 'SCMP_015', 'FFA', 'skirmish', 3),
   (16, 'neroxis_map_generator_sneaky_map', 'FFA', 'skirmish', 1);
 
-insert into map_version (id, description, max_players, width, height, version, filename, hidden, map_id) values
-  (1, 'SCMP 001', 8, 1024, 1024, 1, 'maps/scmp_001.zip', 0, 1),
-  (2, 'SCMP 002', 8, 1024, 1024, 1, 'maps/scmp_002.zip', 0, 2),
-  (3, 'SCMP 003', 8, 1024, 1024, 1, 'maps/scmp_003.zip', 0, 3),
-  (4, 'SCMP 004', 8, 1024, 1024, 1, 'maps/scmp_004.zip', 0, 4),
-  (5, 'SCMP 005', 8, 2048, 2048, 1, 'maps/scmp_005.zip', 0, 5),
-  (6, 'SCMP 006', 8, 1024, 1024, 1, 'maps/scmp_006.zip', 0, 6),
-  (7, 'SCMP 007', 8, 512, 512, 1, 'maps/scmp_007.zip', 0, 7),
-  (8, 'SCMP 008', 8, 1024, 1024, 1, 'maps/scmp_008.zip', 0, 8),
-  (9, 'SCMP 009', 8, 1024, 1024, 1, 'maps/scmp_009.zip', 0, 9),
-  (10, 'SCMP 010', 8, 1024, 1024, 1, 'maps/scmp_010.zip', 0, 10),
-  (11, 'SCMP 011', 8, 2048, 2048, 1, 'maps/scmp_011.zip', 0, 11),
-  (12, 'SCMP 012', 8, 256, 256, 1, 'maps/scmp_012.zip', 0, 12),
-  (13, 'SCMP 013', 8, 256, 256, 1, 'maps/scmp_013.zip', 0, 13),
-  (14, 'SCMP 014', 8, 1024, 1024, 1, 'maps/scmp_014.zip', 0, 14),
-  (15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 15),
-  (16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 15),
-  (17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 15);
-
 insert into map_version (id, description, max_players, width, height, version, filename, hidden, ranked, map_id) values
+  (1, 'SCMP 001', 8, 1024, 1024, 1, 'maps/scmp_001.zip', 0, 1, 1),
+  (2, 'SCMP 002', 8, 1024, 1024, 1, 'maps/scmp_002.zip', 0, 1, 2),
+  (3, 'SCMP 003', 8, 1024, 1024, 1, 'maps/scmp_003.zip', 0, 1, 3),
+  (4, 'SCMP 004', 8, 1024, 1024, 1, 'maps/scmp_004.zip', 0, 1, 4),
+  (5, 'SCMP 005', 8, 2048, 2048, 1, 'maps/scmp_005.zip', 0, 1, 5),
+  (6, 'SCMP 006', 8, 1024, 1024, 1, 'maps/scmp_006.zip', 0, 1, 6),
+  (7, 'SCMP 007', 8, 512, 512, 1, 'maps/scmp_007.zip', 0, 1, 7),
+  (8, 'SCMP 008', 8, 1024, 1024, 1, 'maps/scmp_008.zip', 0, 1, 8),
+  (9, 'SCMP 009', 8, 1024, 1024, 1, 'maps/scmp_009.zip', 0, 1, 9),
+  (10, 'SCMP 010', 8, 1024, 1024, 1, 'maps/scmp_010.zip', 0, 1, 10),
+  (11, 'SCMP 011', 8, 2048, 2048, 1, 'maps/scmp_011.zip', 0, 1, 11),
+  (12, 'SCMP 012', 8, 256, 256, 1, 'maps/scmp_012.zip', 0, 1, 12),
+  (13, 'SCMP 013', 8, 256, 256, 1, 'maps/scmp_013.zip', 0, 1, 13),
+  (14, 'SCMP 014', 8, 1024, 1024, 1, 'maps/scmp_014.zip', 0, 1, 14),
+  (15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 1, 15),
+  (16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 1, 15),
+  (17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 1, 15),
   (18, 'Sneaky_Map', 8, 512, 512, 1, "maps/neroxis_map_generator_sneaky_map.zip", 0, 0, 16);
 
 insert into ladder_map (id, idmap) values

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -395,6 +395,7 @@ async def test_gamestate_ended_clears_references(
         test_proto,
         lambda msg: msg["command"] == "game_info" and msg["state"] == "closed"
     )
+    await asyncio.sleep(0.1)
     assert test.game_connection is None
     assert len(game.connections) == 0
     assert len(game._results) == 1

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -150,6 +150,22 @@ async def test_ffa_not_rated(game, game_add_players):
     assert game.validity == ValidityState.FFA_NOT_RANKED
 
 
+async def test_generated_map_is_rated(game, game_add_players):
+    game.state = GameState.LOBBY
+    game.map_file_path = 'maps/neroxis_map_generator_1.0.0_1234.zip'
+    game_add_players(game, 2, team=1)
+    await game.launch()
+    assert game.validity == ValidityState.VALID
+
+
+async def test_unranked_generated_map_not_rated(game, game_add_players):
+    game.state = GameState.LOBBY
+    game.map_file_path = 'maps/neroxis_map_generator_sneaky_map.zip'
+    game_add_players(game, 2, team=1)
+    await game.launch()
+    assert game.validity == ValidityState.BAD_MAP
+
+
 async def test_two_player_ffa_is_rated(game, game_add_players):
     game.state = GameState.LOBBY
     game_add_players(game, 2, team=1)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -155,6 +155,9 @@ async def test_generated_map_is_rated(game, game_add_players):
     game.map_file_path = 'maps/neroxis_map_generator_1.0.0_1234.zip'
     game_add_players(game, 2, team=1)
     await game.launch()
+    await game.add_result(0, 1, 'victory', 5)
+    game.launched_at = time.time() - 60 * 20  # seconds
+    await game.on_game_end()
     assert game.validity == ValidityState.VALID
 
 
@@ -163,6 +166,9 @@ async def test_unranked_generated_map_not_rated(game, game_add_players):
     game.map_file_path = 'maps/neroxis_map_generator_sneaky_map.zip'
     game_add_players(game, 2, team=1)
     await game.launch()
+    await game.add_result(0, 1, 'victory', 5)
+    game.launched_at = time.time() - 60 * 20  # seconds
+    await game.on_game_end()
     assert game.validity == ValidityState.BAD_MAP
 
 


### PR DESCRIPTION
Adds in a check for if the map is a generated map by checking whether the start of the map name matches the map generator template name. If the map is marked as generated it will not be given a BAD_MAP Validity State.

Closes #617