### PR TITLE
Issue/#282 Game titles seem to be quoted needlessly

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import hashlib
-import html
 import json
 import random
 import urllib.parse
@@ -868,7 +867,7 @@ class LobbyConnection:
             await self.abort("{} sent a nonsense visibility code: {}".format(self.player.login, message.get('visibility')))
             return
 
-        title = html.escape(message.get('title') or f"{self.player.login}'s game")
+        title = message.get('title') or f"{self.player.login}'s game"
 
         try:
             title.encode('ascii')

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -187,7 +187,7 @@ async def test_host_missing_fields(event_loop, lobby_server, player_service):
 
     msg = await read_until_command(proto, 'game_info')
 
-    assert msg['title'] == 'test&#x27;s game'
+    assert msg['title'] == 'test\'s game'
     assert msg['mapname'] == 'scmp_007'
     assert msg['map_file_path'] == 'maps/scmp_007.zip'
     assert msg['featured_mod'] == 'faf'


### PR DESCRIPTION
Hej, i created a bunch of games using some silly tool i made and made sure they were correct in the client. All seems ok. I could not find any places where the &amp; i mean \&amp; would pop up though. Nice to see that html injection works in this box.

Checked the client (a little bit) for any unescape code, but java isn't really my cup of tea.

Fixes #282 