### PR TITLE
Support multiple servercontexts

### DIFF
--- a/server.py
+++ b/server.py
@@ -23,6 +23,7 @@ from server.game_service import GameService
 from server.ice_servers.nts import TwilioNTS
 from server.player_service import PlayerService
 from server.profiler import Profiler
+from server.protocol import SimpleJsonProtocol
 
 
 async def main():
@@ -92,6 +93,7 @@ async def main():
     config.register_callback("CONTROL_SERVER_PORT", restart_control_server)
 
     await instance.listen(("", 8001))
+    await instance.listen(("", 8002), SimpleJsonProtocol)
 
     server.metrics.info.info({
         "version": os.environ.get("VERSION") or "dev",

--- a/server/players.py
+++ b/server/players.py
@@ -1,4 +1,5 @@
 import weakref
+from contextlib import suppress
 from enum import Enum, unique
 
 from server.config import config
@@ -169,7 +170,8 @@ class Player:
         if self.lobby_connection is None:
             return
 
-        self.lobby_connection.write(message)
+        with suppress(DisconnectedError):
+            self.lobby_connection.write(message)
 
     def to_dict(self):
         """

--- a/server/protocol/__init__.py
+++ b/server/protocol/__init__.py
@@ -1,6 +1,7 @@
 from .gpgnet import GpgNetClientProtocol, GpgNetServerProtocol
 from .protocol import DisconnectedError, Protocol
 from .qdatastream import QDataStreamProtocol
+from .simple_json import SimpleJsonProtocol
 
 __all__ = (
     "DisconnectedError",
@@ -8,4 +9,5 @@ __all__ = (
     "GpgNetServerProtocol",
     "Protocol",
     "QDataStreamProtocol",
+    "SimpleJsonProtocol"
 )

--- a/server/protocol/protocol.py
+++ b/server/protocol/protocol.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 from abc import ABCMeta, abstractmethod
 from asyncio import StreamReader, StreamWriter
 from typing import List
@@ -6,6 +7,8 @@ from typing import List
 import server.metrics as metrics
 
 from ..asyncio_extensions import synchronizedmethod
+
+json_encoder = json.JSONEncoder(separators=(',', ':'))
 
 
 class DisconnectedError(ConnectionError):

--- a/server/protocol/qdatastream.py
+++ b/server/protocol/qdatastream.py
@@ -94,23 +94,23 @@ class QDataStreamProtocol(Protocol):
         # FIXME: New protocol will remove the need for this
 
         pos, action = self.read_qstring(block)
-        if action in ['PING', 'PONG']:
+        if action in ('PING', 'PONG'):
             return {'command': action.lower()}
-        else:
-            message = json.loads(action)
-            try:
-                for part in self.read_block(block):
-                    try:
-                        message_part = json.loads(part)
-                        if part != action:
-                            message.update(message_part)
-                    except (ValueError, TypeError):
-                        if 'legacy' not in message:
-                            message['legacy'] = []
-                        message['legacy'].append(part)
-            except (KeyError, ValueError):
-                pass
-            return message
+
+        message = json.loads(action)
+        try:
+            for part in self.read_block(block):
+                try:
+                    message_part = json.loads(part)
+                    if part != action:
+                        message.update(message_part)
+                except (ValueError, TypeError):
+                    if 'legacy' not in message:
+                        message['legacy'] = []
+                    message['legacy'].append(part)
+        except (KeyError, ValueError):
+            pass
+        return message
 
 
 PING_MSG = QDataStreamProtocol.pack_message("PING")

--- a/server/protocol/qdatastream.py
+++ b/server/protocol/qdatastream.py
@@ -5,9 +5,7 @@ from typing import Tuple
 
 from server.decorators import with_logger
 
-from .protocol import Protocol
-
-json_encoder = json.JSONEncoder(separators=(',', ':'))
+from .protocol import Protocol, json_encoder
 
 
 @with_logger

--- a/server/protocol/simple_json.py
+++ b/server/protocol/simple_json.py
@@ -1,0 +1,13 @@
+import json
+
+from .protocol import Protocol, json_encoder
+
+
+class SimpleJsonProtocol(Protocol):
+    @staticmethod
+    def encode_message(message: dict) -> bytes:
+        return (json_encoder.encode(message) + "\n").encode()
+
+    async def read_message(self) -> dict:
+        line = await self.reader.readline()
+        return json.loads(line.strip())

--- a/tests/integration_tests/test_server_instance.py
+++ b/tests/integration_tests/test_server_instance.py
@@ -1,12 +1,11 @@
 import asyncio
-import json
 
 import pytest
 from asynctest import exhaust_callbacks
 
 from server import ServerInstance
 from server.config import config
-from server.protocol import Protocol, QDataStreamProtocol
+from server.protocol import QDataStreamProtocol, SimpleJsonProtocol
 
 from .conftest import connect_and_sign_in, read_until
 from .test_game import host_game
@@ -35,15 +34,6 @@ async def test_multiple_contexts(
     event_loop
 ):
     config.USE_POLICY_SERVER = False
-
-    class SimpleJsonProtocol(Protocol):
-        @staticmethod
-        def encode_message(message) -> bytes:
-            return (json.dumps(message) + "\n").encode()
-
-        async def read_message(self) -> dict:
-            line = await self.reader.readline()
-            return json.loads(line.strip())
 
     instance = ServerInstance(
         "TestMultiContext",

--- a/tests/integration_tests/test_server_instance.py
+++ b/tests/integration_tests/test_server_instance.py
@@ -1,0 +1,100 @@
+import asyncio
+import json
+
+import pytest
+from asynctest import exhaust_callbacks
+
+from server import ServerInstance
+from server.config import config
+from server.protocol import Protocol, QDataStreamProtocol
+
+from .conftest import connect_and_sign_in, read_until
+from .test_game import host_game
+
+
+def has_player(msg, name):
+    if msg["command"] != "player_info":
+        return False
+
+    for player in msg["players"]:
+        if player["login"] == name:
+            return True
+
+    return False
+
+
+@pytest.mark.asyncio
+async def test_multiple_contexts(
+    database,
+    game_service,
+    player_service,
+    geoip_service,
+    ladder_service,
+    tmp_user,
+    policy_server,
+    event_loop
+):
+    config.USE_POLICY_SERVER = False
+
+    class SimpleJsonProtocol(Protocol):
+        @staticmethod
+        def encode_message(message) -> bytes:
+            return (json.dumps(message) + "\n").encode()
+
+        async def read_message(self) -> dict:
+            line = await self.reader.readline()
+            return json.loads(line.strip())
+
+    instance = ServerInstance(
+        "TestMultiContext",
+        database,
+        api_accessor=None,
+        twilio_nts=None,
+        loop=event_loop,
+        _override_services={
+            "game_service": game_service,
+            "player_service": player_service,
+            "geo_ip_service": geoip_service,
+            "ladder_service": ladder_service,
+        }
+    )
+    await instance.listen(("127.0.0.1", 8111), QDataStreamProtocol)
+    await instance.listen(("127.0.0.1", 8112), SimpleJsonProtocol)
+
+    ctx_1, ctx_2 = tuple(instance.contexts)
+    if ctx_1.protocol_class is SimpleJsonProtocol:
+        ctx_1, ctx_2 = ctx_2, ctx_1
+
+    # Connect one client to each context
+    _, _, proto1 = await connect_and_sign_in(
+        await tmp_user("QDataStreamUser"),
+        ctx_1,
+        QDataStreamProtocol
+    )
+
+    _, _, proto2 = await connect_and_sign_in(
+        await tmp_user("SimpleJsonUser"),
+        ctx_2,
+        SimpleJsonProtocol
+    )
+
+    # Verify that the users can see each other
+    await asyncio.wait_for(
+        read_until(proto1, lambda m: has_player(m, "SimpleJsonUser1")),
+        timeout=5
+    )
+    await asyncio.wait_for(
+        read_until(proto2, lambda m: has_player(m, "QDataStreamUser1")),
+        timeout=5
+    )
+
+    # Host a game
+    game_id = await host_game(proto1)
+    msg = await read_until(
+        proto2,
+        lambda msg: msg["command"] == "game_info" and "games" not in msg
+    )
+    assert msg["uid"] == game_id
+
+    await instance.shutdown()
+    await exhaust_callbacks(event_loop)

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -104,3 +104,19 @@ async def test_send_message():
     assert p.lobby_connection is None
     with pytest.raises(DisconnectedError):
         await p.send_message({})
+
+
+def test_write_message():
+    p = Player(login='Test')
+
+    assert p.lobby_connection is None
+    # Should not raise
+    p.write_message({})
+
+
+def test_write_message_while_disconnecting(player_factory):
+    p = player_factory("Test", with_lobby_connection=True)
+    p.lobby_connection.write.side_effect = DisconnectedError()
+
+    # Should not raise
+    p.write_message({})

--- a/tests/unit_tests/test_server_instance.py
+++ b/tests/unit_tests/test_server_instance.py
@@ -1,0 +1,9 @@
+from server import GameService, PlayerService, ServerInstance
+
+
+def test_auto_create_services():
+    instance = ServerInstance("TestCreateServices", None, None, None, None)
+
+    assert instance.services != {}
+    assert isinstance(instance.services["player_service"], PlayerService)
+    assert isinstance(instance.services["game_service"], GameService)


### PR DESCRIPTION
Refactors the server broadcasting code so that multiple ServerContext's can be run correctly at the same time. This will allow us to start working on a v2 version of the protocol which can concurrently with the legacy protocol. As a sample I've added a `SimpleJsonProtocol` class that sends each message as a json object followed by a newline.

I think we should try to transition to the new protocol incrementally. As a first step, we can swap out the "transport" or "wire" layer from `QDataStream` to `Json`, and keep everything else the same. We could implement this in the client and start using it immediately, which would cut the amount of network traffic in half (due to the legacy protocol using utf-16 encoding instead of utf-8). There isn't really a down side to doing this, as we can keep adding new incremental protocol versions on new ports. Hopefully with these refactors it will even be possible to implement a websocket protocol, but I haven't looked into the details of that yet. I just know that there is a websockets library in python that uses asyncio.