### PR TITLE
Issue/#637 mq service initialization race condition

### DIFF
--- a/integration_tests/test_message_queue/test_message_queue_service.py
+++ b/integration_tests/test_message_queue/test_message_queue_service.py
@@ -100,6 +100,7 @@ async def test_reconnect(mq_service):
     assert mq_service._exchange_types["test_topic"] == aio_pika.ExchangeType.TOPIC
     assert "test_direct" in mq_service._exchanges
     assert mq_service._exchange_types["test_direct"] == aio_pika.ExchangeType.DIRECT
+    assert mq_service._is_ready
 
 
 async def test_incorrect_credentials(mocker, caplog):
@@ -109,6 +110,7 @@ async def test_incorrect_credentials(mocker, caplog):
     await service.initialize()
     expected_warning = "Unable to connect to RabbitMQ. Incorrect credentials?"
     assert expected_warning in [rec.message for rec in caplog.records]
+    assert service._is_ready is False
     caplog.clear()
 
     await service.declare_exchange("test_exchange")

--- a/integration_tests/test_message_queue/test_message_queue_service.py
+++ b/integration_tests/test_message_queue/test_message_queue_service.py
@@ -159,3 +159,17 @@ async def test_initialize_declare_exchange_race_condition():
             i += 1
 
     await asyncio.gather(keep_declaring_exchanges(), service.initialize())
+
+
+async def test_declaring_exchange_without_initialization():
+    service = MessageQueueService()
+    exchange_name = "test_exchange"
+
+    assert service._is_ready is False
+    assert service._connection is None
+
+    await service.declare_exchange(exchange_name)
+
+    assert service._is_ready
+    assert service._connection is not None
+    assert service._exchanges.get(exchange_name) is not None

--- a/server/message_queue_service.py
+++ b/server/message_queue_service.py
@@ -83,12 +83,18 @@ class MessageQueueService(Service):
     async def declare_exchange(
         self, exchange_name: str, exchange_type: ExchangeType = ExchangeType.TOPIC
     ) -> None:
+        await self.initialize()
         if not self._is_ready:
             self._logger.warning(
                 "Not connected to RabbitMQ, unable to declare exchange."
             )
             return
 
+        await self._declare_exchange(exchange_name, exchange_type)
+
+    async def _declare_exchange(
+        self, exchange_name: str, exchange_type: ExchangeType
+    ) -> None:
         new_exchange = await self._channel.declare_exchange(
             exchange_name, exchange_type
         )
@@ -148,7 +154,7 @@ class MessageQueueService(Service):
             return
 
         for exchange_name in list(self._exchanges.keys()):
-            await self.declare_exchange(
+            await self._declare_exchange(
                 exchange_name, self._exchange_types[exchange_name]
             )
         self._is_ready = True

--- a/server/message_queue_service.py
+++ b/server/message_queue_service.py
@@ -37,7 +37,7 @@ class MessageQueueService(Service):
             if self._connection is not None:
                 return
 
-            self._is_ready =  await self._connect()
+            self._is_ready = await self._connect()
 
     async def _connect(self) -> bool:
         """ Returns True on success. """
@@ -53,19 +53,20 @@ class MessageQueueService(Service):
                 loop=asyncio.get_running_loop(),
             )
         except ConnectionError:
-            self._logger.warning("Unable to connect to RabbitMQ. Is it running?", exc_info=True)
+            self._logger.warning(
+                "Unable to connect to RabbitMQ. Is it running?", exc_info=True
+            )
             return False
         except ProbableAuthenticationError:
             self._logger.warning(
-                "Unable to connect to RabbitMQ. Incorrect credentials?",
-                exc_info=True
+                "Unable to connect to RabbitMQ. Incorrect credentials?", exc_info=True
             )
             return False
         except Exception as e:
             self._logger.warning(
                 "Unable to connect to RabbitMQ due to unhandled excpetion %s. Incorrect vhost?",
                 e,
-                exc_info=True
+                exc_info=True,
             )
             return False
 


### PR DESCRIPTION
Adds `_is_ready` to `MessageQueueService` keeping track of whether a connection is fully established (i.e. connection *and* channel). Methods that touch ths are `initialize()`, `shutdown()`, and `reconnect()`.
Since spamming e.g. reconnect could potentially leave things in a bad state, I also added an `_initialization_lock` and `_is_ready` is only modified by methods holding the lock.

Closes #637 