### PR TITLE
Rework ladder search internals/interface

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -63,7 +63,7 @@ class LadderService(Service):
             )
         }
 
-        self.searches: Dict[str, Dict[Player, Search]] = defaultdict(dict)
+        self._searches: Dict[Player, Dict[str, Search]] = defaultdict(dict)
 
     async def initialize(self) -> None:
         # TODO: Starting hardcoded queues here
@@ -194,14 +194,17 @@ class LadderService(Service):
             ))
         return matchmaker_queues
 
-    def start_search(self, initiator: Player, queue_name: str):
-        self._cancel_existing_searches(initiator, queue_name)
+    def start_search(self, players: List[Player], queue_name: str):
+        # Cancel any existing searches that players have for this queue
+        for player in players:
+            if queue_name in self._searches[player]:
+                self._cancel_search(player, queue_name)
+
         queue = self.queues[queue_name]
-        search = Search([initiator], rating_type=queue.rating_type)
+        search = Search(players, rating_type=queue.rating_type)
 
-        for player in search.players:
+        for player in players:
             player.state = PlayerState.SEARCHING_LADDER
-
             # FIXME: For now, inform_player is only designed for ladder1v1
             if queue_name == "ladder1v1":
                 self.inform_player(player)
@@ -212,10 +215,10 @@ class LadderService(Service):
                 "state": "start"
             })
 
-        self.searches[queue_name][initiator] = search
+            self._searches[player][queue_name] = search
 
         self._logger.info(
-            "%s is searching for '%s': %s", initiator, queue_name, search
+            "%s are searching for '%s': %s", players, queue_name, search
         )
 
         asyncio.create_task(queue.search(search))
@@ -224,46 +227,37 @@ class LadderService(Service):
         self,
         initiator: Player,
         queue_name: Optional[str] = None
-    ):
-        searches = self._cancel_existing_searches(initiator, queue_name)
-
-        for queue_name, search in searches:
-            for player in search.players:
-                # FIXME: This is wrong for multiqueueing
-                if player.state == PlayerState.SEARCHING_LADDER:
-                    player.state = PlayerState.IDLE
-
-                player.write_message({
-                    "command": "search_info",
-                    "queue_name": queue_name,
-                    "state": "stop"
-                })
-            self._logger.info(
-                "%s stopped searching for %s: %s", initiator, queue_name, search
-            )
-
-    def _cancel_existing_searches(
-        self,
-        initiator: Player,
-        queue_name: Optional[str] = None
-    ) -> List[Tuple[str, Search]]:
-        """
-        Cancel search for a specific queue, or all searches if `queue_name` is
-        None.
-        """
-        if queue_name:
-            queue_names = [queue_name]
+    ) -> None:
+        if queue_name is None:
+            queue_names = list(self._searches[initiator].keys())
         else:
-            queue_names = list(self.queues)
+            queue_names = [queue_name]
 
-        searches = []
         for queue_name in queue_names:
-            search = self.searches[queue_name].get(initiator)
-            if search:
-                search.cancel()
-                searches.append((queue_name, search))
-                del self.searches[queue_name][initiator]
-        return searches
+            self._cancel_search(initiator, queue_name)
+
+    def _cancel_search(self, initiator: Player, queue_name: str) -> None:
+        """
+        Cancel search for a specific player/queue.
+        """
+        cancelled_search = self._searches[initiator][queue_name]
+        cancelled_search.cancel()
+
+        for player in cancelled_search.players:
+            del self._searches[player][queue_name]
+            player.write_message({
+                "command": "search_info",
+                "queue_name": queue_name,
+                "state": "stop"
+            })
+            if (
+                not self._searches[player]
+                and player.state == PlayerState.SEARCHING_LADDER
+            ):
+                player.state = PlayerState.IDLE
+        self._logger.info(
+            "%s stopped searching for %s", cancelled_search, queue_name
+        )
 
     def inform_player(self, player: Player):
         if player not in self._informed_players:
@@ -455,6 +449,7 @@ class LadderService(Service):
 
     async def on_connection_lost(self, player):
         self.cancel_search(player)
+        del self._searches[player]
         if player in self._informed_players:
             self._informed_players.remove(player)
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -847,7 +847,7 @@ class LobbyConnection:
 
             # TODO: Put player parties here
             self.ladder_service.start_search(
-                self.player,
+                [self.player],
                 queue_name=queue_name
             )
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -837,7 +837,7 @@ class LobbyConnection:
             raise ClientError("Cannot host game. Please update your client to the newest version.")
 
         if state == "stop":
-            await self.ladder_service.cancel_search(self.player, queue_name)
+            self.ladder_service.cancel_search(self.player, queue_name)
             return
 
         if state == "start":
@@ -846,7 +846,7 @@ class LobbyConnection:
             self.player.faction = message['faction']
 
             # TODO: Put player parties here
-            await self.ladder_service.start_search(
+            self.ladder_service.start_search(
                 self.player,
                 queue_name=queue_name
             )

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -281,7 +281,7 @@ async def test_start_and_cancel_search(
     search = ladder_service.searches["ladder1v1"][p1]
 
     assert p1.state == PlayerState.SEARCHING_LADDER
-    assert ladder_service.queues['ladder1v1'].queue[search]
+    assert search in ladder_service.queues['ladder1v1']._queue
     assert not search.is_cancelled
 
     await ladder_service.cancel_search(p1)
@@ -308,7 +308,7 @@ async def test_start_search_cancels_previous_search(
     search1 = ladder_service.searches["ladder1v1"][p1]
 
     assert p1.state == PlayerState.SEARCHING_LADDER
-    assert ladder_service.queues['ladder1v1'].queue[search1]
+    assert search1 in ladder_service.queues['ladder1v1']._queue
 
     await ladder_service.start_search(p1, 'ladder1v1')
     await exhaust_callbacks(event_loop)
@@ -316,8 +316,8 @@ async def test_start_search_cancels_previous_search(
 
     assert p1.state == PlayerState.SEARCHING_LADDER
     assert search1.is_cancelled
-    assert not ladder_service.queues['ladder1v1'].queue.get(search1)
-    assert ladder_service.queues['ladder1v1'].queue[search2]
+    assert search1 not in ladder_service.queues['ladder1v1']._queue
+    assert search2 in ladder_service.queues['ladder1v1']._queue
 
 
 async def test_cancel_all_searches(ladder_service: LadderService,
@@ -329,7 +329,7 @@ async def test_cancel_all_searches(ladder_service: LadderService,
     search = ladder_service.searches["ladder1v1"][p1]
 
     assert p1.state == PlayerState.SEARCHING_LADDER
-    assert ladder_service.queues['ladder1v1'].queue[search]
+    assert search in ladder_service.queues['ladder1v1']._queue
     assert not search.is_cancelled
 
     await ladder_service.cancel_search(p1)

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -376,7 +376,7 @@ async def test_queue_race(matchmaker_queue, player_factory):
     except (TimeoutError, CancelledError):
         pass
 
-    assert len(matchmaker_queue.queue) == 0
+    assert len(matchmaker_queue._queue) == 0
 
 
 @pytest.mark.asyncio
@@ -420,4 +420,4 @@ async def test_queue_mid_cancel(matchmaker_queue, matchmaker_players_all_match):
     assert not s1.is_matched
     assert s2.is_matched
     assert s3.is_matched
-    assert len(matchmaker_queue.queue) == 0
+    assert len(matchmaker_queue._queue) == 0


### PR DESCRIPTION
The interface for searching/cancelling is now asymmetric. 
- Searches are started on a list of players and one queue name
- Searches are cancelled for one player and one queue name (or all queues)

This should allow pretty trivial integration with the party system. 
- When a player starts a search, call `start_search` with the players entire party
- When a player cancels a search, call `cancel_search` with just the requesting player

Permissions still need to be handled by the caller of `LadderService` (which is always `LobbyConnection`)