### PR TITLE
Issue/#639 Show ban duration to user with higher resolution

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,7 +21,7 @@ aiocron = "*"
 oauthlib = "*"
 sqlalchemy = "*"
 twilio = "*"
-humanize = "*"
+humanize = ">=2.6.0"
 aiomysql = {editable = true, git = "https://github.com/aio-libs/aiomysql"}
 pyyaml = "*"
 aio_pika = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -114,11 +114,11 @@
         },
         "humanize": {
             "hashes": [
-                "sha256:07dd1293bac6c77daa5ccdc22c0b41b2315bee0e339a9f035ba86a9f1a272002",
-                "sha256:42ae7d54b398c01bd100847f6cb0fc9e381c21be8ad3f8e2929135e48dbff026"
+                "sha256:8ee358ea6c23de896b9d1925ebe6a8504bb2ba7e98d5ccf4d07ab7f3b28f3819",
+                "sha256:fd5b32945687443d5b8bc1e02fad027da1d293a9e963b3450122ad98ef534f21"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.6.0"
         },
         "idna": {
             "hashes": [

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -1087,8 +1087,8 @@ class LobbyConnection:
             raise_ban_error(ban_expiry - now, data[ban.c.reason])
 
 def raise_ban_error(ban_duration, ban_reason):
-    raise ClientError((f"You are banned from FAF {ban_duration_text(ban_duration)}.\n "
-                       f"Reason :\n "
+    raise ClientError((f"You are banned from FAF {ban_duration_text(ban_duration)}. <br>"
+                       f"Reason : <br>"
                        f"{ban_reason}"), recoverable=False)
 
 def ban_duration_text(ban_duration):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -56,6 +56,26 @@ class ClientError(Exception):
         self.recoverable = recoverable
 
 
+class BanError(Exception):
+    def __init__(self, ban_expiry, ban_reason, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ban_expiry = ban_expiry
+        self.ban_reason = ban_reason
+
+    def message(self):
+        return (f"You are banned from FAF {self._ban_duration_text()}. <br>"
+                f"Reason : <br>"
+                f"{self.ban_reason}")
+
+    def _ban_duration_text(self):
+        ban_duration = self.ban_expiry - datetime.now()
+        if ban_duration.days > 365 * 100:
+            return "forever"
+        humanized_ban_duration = humanize.precisedelta(ban_duration, minimum_unit="hours")
+        return f"for {humanized_ban_duration}"
+
+
+
 class AuthenticationError(Exception):
     def __init__(self, message, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -166,6 +186,13 @@ class LobbyConnection:
                 'command': 'authentication_failed',
                 'text': ex.message
             })
+        except BanError as ex:
+            await self.send({
+                "command": "notice",
+                "style": "error",
+                "text": ex.message()
+            })
+            await self.abort(ex.message())
         except ClientError as ex:
             self._logger.warning("Client error: %s", ex.message)
             await self.send({
@@ -390,8 +417,7 @@ class LobbyConnection:
         if ban_reason is not None and now < ban_expiry:
             self._logger.debug('Rejected login from banned user: %s, %s, %s',
                                player_id, username, self.session)
-
-            raise_ban_error(ban_expiry - now, ban_reason)
+            raise BanError(ban_expiry, ban_reason)
 
         # New accounts are prevented from playing if they didn't link to steam
 
@@ -1079,20 +1105,8 @@ class LobbyConnection:
                 return
 
             ban_expiry = data[ban.c.expires_at]
-            if now >= ban_expiry:
-                return
-
-            self._logger.debug("Aborting connection of banned user: %s, %s, %s",
-                               self.player.id, self.player.login, self.session)
-            raise_ban_error(ban_expiry - now, data[ban.c.reason])
-
-def raise_ban_error(ban_duration, ban_reason):
-    raise ClientError((f"You are banned from FAF {ban_duration_text(ban_duration)}. <br>"
-                       f"Reason : <br>"
-                       f"{ban_reason}"), recoverable=False)
-
-def ban_duration_text(ban_duration):
-    if ban_duration.days > 365 * 100:
-        return "forever"
-    humanized_ban_duration = humanize.precisedelta(ban_duration, minimum_unit='hours')
-    return f"for {humanized_ban_duration}"
+            ban_reason = data[ban.c.reason]
+            if now < ban_expiry:
+                self._logger.debug("Aborting connection of banned user: %s, %s, %s",
+                                   self.player.id, self.player.login, self.session)
+                raise BanError(ban_expiry, ban_reason)

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -78,6 +78,7 @@ insert into login (id, login, email, password, steamid, create_time) values
   (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
   (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
   (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
+  (204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null, '2000-01-01 00:00:00'),
   (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
 ;
 -- New accounts for testing account age check
@@ -323,7 +324,8 @@ insert into ban (player_id, author_id, reason, level, expires_at, revoke_reason,
 insert into ban (player_id, author_id, reason, level, expires_at, revoke_time) values
   (201, 201, 'Test revoked ban', 'GLOBAL', NULL, now() - interval 1 day),
   (202, 202, 'Test expired ban', 'GLOBAL', now() - interval 1 day, NULL),
-  (203, 203, 'Test permanent ban', 'GLOBAL', now() + interval 1000 year, NULL)
+  (203, 203, 'Test permanent ban', 'GLOBAL', now() + interval 1000 year, NULL),
+  (204, 204, 'Test ongoing ban with 46 hours left', 'GLOBAL', now() + interval 46 hour, NULL)
 ;
 
 -- sample clans

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -37,9 +37,10 @@ async def test_server_ban(lobby_server, user):
     await perform_login(proto, user)
     msg = await proto.read_message()
     assert msg == {
-        'command': 'notice',
-        'style': 'error',
-        'text': 'You are banned from FAF forever. <br>Reason : <br>Test permanent ban'}
+        "command": "notice",
+        "style": "error",
+        "text": "You are banned from FAF forever. <br>Reason : <br>Test permanent ban"
+    }
 
 
 @pytest.mark.parametrize('user', ['ban_revoked', 'ban_expired'])

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -39,7 +39,7 @@ async def test_server_ban(lobby_server, user):
     assert msg == {
         'command': 'notice',
         'style': 'error',
-        'text': 'You are banned from FAF forever.\n Reason :\n Test permanent ban'}
+        'text': 'You are banned from FAF forever. <br>Reason : <br>Test permanent ban'}
 
 
 @pytest.mark.parametrize('user', ['ban_revoked', 'ban_expired'])

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -245,9 +245,9 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
 
     msg = await proto.read_message()
     assert msg == {
-        'command': 'notice',
-        'style': 'error',
-        'text': 'You are banned from FAF forever. <br>Reason : <br>Test live ban'
+        "command": "notice",
+        "style": "error",
+        "text": "You are banned from FAF forever. <br>Reason : <br>Test live ban"
     }
 
 

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -247,7 +247,7 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
     assert msg == {
         'command': 'notice',
         'style': 'error',
-        'text': 'You are banned from FAF forever.\n Reason :\n Test live ban'
+        'text': 'You are banned from FAF forever. <br>Reason : <br>Test live ban'
     }
 
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import asynctest
 import pytest
+import re
 from aiohttp import web
 from asynctest import CoroutineMock
 from sqlalchemy import and_, select
@@ -949,3 +950,29 @@ async def test_check_policy_conformity_fatal(lobbyconnection, policy_server):
         honest = await lobbyconnection.check_policy_conformity(1, result, session=100)
         assert honest is False
         lobbyconnection.abort.assert_called_once()
+
+
+async def test_abort_connection_if_banned(
+    lobbyconnection: LobbyConnection,
+    mock_nts_client
+):
+    lobbyconnection.player.id = 1 # test user that has never been banned
+    await lobbyconnection.abort_connection_if_banned()
+
+    lobbyconnection.player.id = 201 # test user whose ban has been revoked
+    await lobbyconnection.abort_connection_if_banned()
+
+    lobbyconnection.player.id = 202 # test user whose ban has expired
+    await lobbyconnection.abort_connection_if_banned()
+
+    lobbyconnection.player.id = 203 # test user who is permabanned
+    with pytest.raises(ClientError) as banned_error:
+        await lobbyconnection.abort_connection_if_banned()
+    assert banned_error.value.message == "You are banned from FAF forever. <br>Reason : <br>Test permanent ban"
+    assert banned_error.value.recoverable is False
+
+    lobbyconnection.player.id = 204 # test user who is banned for another 46 hours
+    with pytest.raises(ClientError) as banned_error:
+        await lobbyconnection.abort_connection_if_banned()
+    assert re.match(r"You are banned from FAF for 1 day and 2[0-3]\.[0-9]+ hours. <br>Reason : <br>Test ongoing ban with 46 hours left", banned_error.value.message)
+    assert banned_error.value.recoverable is False

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -18,7 +18,7 @@ from server.games import CustomGame, Game
 from server.geoip_service import GeoIpService
 from server.ice_servers.nts import TwilioNTS
 from server.ladder_service import LadderService
-from server.lobbyconnection import ClientError, LobbyConnection
+from server.lobbyconnection import BanError, ClientError, LobbyConnection
 from server.matchmaker import Search
 from server.player_service import PlayerService
 from server.players import PlayerState
@@ -966,13 +966,11 @@ async def test_abort_connection_if_banned(
     await lobbyconnection.abort_connection_if_banned()
 
     lobbyconnection.player.id = 203 # test user who is permabanned
-    with pytest.raises(ClientError) as banned_error:
+    with pytest.raises(BanError) as banned_error:
         await lobbyconnection.abort_connection_if_banned()
-    assert banned_error.value.message == "You are banned from FAF forever. <br>Reason : <br>Test permanent ban"
-    assert banned_error.value.recoverable is False
+    assert banned_error.value.message() == "You are banned from FAF forever. <br>Reason : <br>Test permanent ban"
 
     lobbyconnection.player.id = 204 # test user who is banned for another 46 hours
-    with pytest.raises(ClientError) as banned_error:
+    with pytest.raises(BanError) as banned_error:
         await lobbyconnection.abort_connection_if_banned()
-    assert re.match(r"You are banned from FAF for 1 day and 2[0-3]\.[0-9]+ hours. <br>Reason : <br>Test ongoing ban with 46 hours left", banned_error.value.message)
-    assert banned_error.value.recoverable is False
+    assert re.match(r"You are banned from FAF for 1 day and 2[0-3]\.[0-9]+ hours. <br>Reason : <br>Test ongoing ban with 46 hours left", banned_error.value.message())


### PR DESCRIPTION
Hi. This is my first PR to FAF.

This PR addresses #639: "Show ban duration to user with higher resolution." I think it would be better to implement #640 in the long term, but I don't know how to do that yet and this PR still gives an improvement.

The tests outline the new behaviour, and test more of what was already there. A temporarily banned user will now see a message saying:

```
You are banned from FAF for 1 day and 8.5 hours.
Reason :
[ban reason here]
```

I haven't actually been banned myself 😇 but this seemed like a good first contribution.

Closes #639.