### PR TITLE
[WIP] Issue/#609 Add metrics for certain data structure sizes

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import aiocron
 from sqlalchemy import and_, func, select, text, true
 
+import server.metrics as metrics
 from .abc.base_game import InitMode
 from .config import config
 from .core import Service
@@ -133,6 +134,8 @@ class LadderService(Service):
             if queue_name not in db_queues:
                 self.queues[queue_name].shutdown()
                 del self.queues[queue_name]
+
+        metrics.ladder_service_searches_dict_length.set(len(self._searches))
 
     async def fetch_map_pools(self, conn) -> Dict[int, Tuple[str, List[Map]]]:
         result = await conn.execute(

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -102,6 +102,8 @@ class MatchmakerQueue:
 
             number_of_matches = len(self._matches)
             metrics.matches.labels(self.name).set(number_of_matches)
+            number_of_searches_in_queue = len(self.queue)
+            metrics.matchmaker_queue_length.labels(self.name).set(number_of_searches_in_queue)
 
             # TODO: Move this into algorithm, then don't need to recalculate quality_with?
             # Probably not a major bottleneck though.

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -37,6 +37,12 @@ matchmaker_queue_pop = Gauge(
     ["queue"],
 )
 
+matchmaker_queue_length = Gauge(
+    "server_matchmaker_queue_length",
+    "Number of items in queue",
+    ["queue"],
+)
+
 # =====
 # Users
 # =====
@@ -109,4 +115,13 @@ active_games = Gauge(
 # ==============
 rating_service_backlog = Gauge(
     "server_rating_service_backlog", "Number of games remaining to be rated",
+)
+
+
+# ==============
+# Ladder Service
+# ==============
+ladder_service_searches_dict_length = Gauge(
+    "ladder_service_searches_dict_length",
+    "Number of items in LadderService._searches",
 )


### PR DESCRIPTION
This PR closes #609. It adds Prometheus metrics to track the number of items in various datastructures. This will be useful to check that they are not growing unboundedly.

The metrics are updated re-using whatever periodic update functions already existed, rather than adding new schedules and functions to do it.