### PR TITLE
issue/#649 Allow host to set rating range limitations to game

### DIFF
--- a/integration_tests/test_matchmaking.py
+++ b/integration_tests/test_matchmaking.py
@@ -55,5 +55,9 @@ async def test_ladder_1v1_match(test_client):
         "num_players": 0,
         "max_players": 2,
         "launched_at": None,
+        "rating_type": "ladder_1v1",
+        "rating_min": None,
+        "rating_max": None,
+        "enforce_rating_range": False,
         "teams": {}
     }

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -815,7 +815,7 @@ class Game:
         }.get(self.state, "closed")
         return {
             "command": "game_info",
-            "visibility": VisibilityState.to_string(self.visibility),
+            "visibility": self.visibility.value,
             "password_protected": self.password is not None,
             "uid": self.id,
             "title": self.name,

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -19,7 +19,7 @@ from server.games.game_results import (
     GameResultReports,
     resolve_game
 )
-from server.rating import RatingType
+from server.rating import InclusiveRange, RatingType
 
 from ..abc.base_game import GameConnectionState, InitMode
 from ..players import Player, PlayerState
@@ -60,6 +60,8 @@ class Game:
         map_: str = "SCMP_007",
         game_mode: str = FeaturedModType.FAF,
         rating_type: Optional[str] = None,
+        displayed_rating_range: Optional[InclusiveRange] = None,
+        enforce_rating_range: bool = False,
         max_players: int = 12
     ):
         self._db = database
@@ -89,6 +91,8 @@ class Game:
         self.validity = ValidityState.VALID
         self.game_mode = game_mode
         self.rating_type = rating_type or RatingType.GLOBAL
+        self.displayed_rating_range = displayed_rating_range or InclusiveRange()
+        self.enforce_rating_range = enforce_rating_range
         self.state = GameState.INITIALIZING
         self._connections = {}
         self.enforce_rating = False
@@ -782,6 +786,26 @@ class Game:
         self._army_stats_list = json.loads(stats_json)["stats"]
         self._process_pending_army_stats()
 
+    def is_visible_to_player(self, player: Player) -> bool:
+        if player == self.host:
+            return True
+
+        mean, dev = player.ratings[self.rating_type]
+        displayed_rating = mean - 3 * dev
+        if (
+            self.enforce_rating_range
+            and displayed_rating not in self.displayed_rating_range
+        ):
+            return False
+
+        if self.host is None:
+            return False
+
+        if self.visibility is VisibilityState.FRIENDS:
+            return player.id in self.host.friends
+        else:
+            return player.id not in self.host.foes
+
     def to_dict(self):
         client_state = {
             GameState.LOBBY: "open",
@@ -805,6 +829,10 @@ class Game:
             "num_players": len(self.players),
             "max_players": self.max_players,
             "launched_at": self.launched_at,
+            "rating_type": self.rating_type,
+            "rating_min": self.displayed_rating_range.lo,
+            "rating_max": self.displayed_rating_range.hi,
+            "enforce_rating_range": self.enforce_rating_range,
             "teams": {
                 team: [
                     player.login for player in self.players

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -787,7 +787,7 @@ class Game:
         self._process_pending_army_stats()
 
     def is_visible_to_player(self, player: Player) -> bool:
-        if player == self.host:
+        if player == self.host or player in self.players:
             return True
 
         mean, dev = player.ratings[self.rating_type]

--- a/server/games/typedefs.py
+++ b/server/games/typedefs.py
@@ -20,6 +20,7 @@ class Victory(Enum):
     ERADICATION = 2
     SANDBOX = 3
 
+
 @unique
 class GameType(Enum):
     COOP = 0
@@ -46,28 +47,11 @@ class GameType(Enum):
             GameType.MATCHMAKER: "matchmaker",
         }.get(self)
 
+
 @unique
 class VisibilityState(Enum):
-    PUBLIC = 0
-    FRIENDS = 1
-
-    @staticmethod
-    def from_string(value: str) -> Optional["VisibilityState"]:
-        """
-        :param value: The string to convert from
-
-        :return: VisibilityState or None if the string is not valid
-        """
-        return {
-            "public": VisibilityState.PUBLIC,
-            "friends": VisibilityState.FRIENDS,
-        }.get(value)
-
-    def to_string(self) -> Optional[str]:
-        return {
-            VisibilityState.PUBLIC: "public",
-            VisibilityState.FRIENDS: "friends",
-        }.get(self)
+    PUBLIC = "public"
+    FRIENDS = "friends"
 
 
 # Identifiers must be kept in sync with the contents of the invalid_game_reasons table.

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -40,6 +40,7 @@ from .ladder_service import LadderService
 from .player_service import PlayerService
 from .players import Player, PlayerState
 from .protocol import DisconnectedError, Protocol
+from .rating import InclusiveRange, RatingType
 from .types import Address, GameLaunchOptions
 
 
@@ -909,6 +910,13 @@ class LobbyConnection:
         mapname = message.get("mapname") or "scmp_007"
         password = message.get("password")
         game_mode = mod.lower()
+        rating_min = message.get("rating_min")
+        rating_max = message.get("rating_max")
+        enforce_rating_range = bool(message.get("enforce_rating_range", False))
+        if rating_min is not None:
+            rating_min = float(rating_min)
+        if rating_max is not None:
+            rating_max = float(rating_max)
 
         game = self.game_service.create_game(
             visibility=visibility,
@@ -916,7 +924,10 @@ class LobbyConnection:
             host=self.player,
             name=title,
             mapname=mapname,
-            password=password
+            password=password,
+            rating_type=RatingType.GLOBAL,
+            displayed_rating_range=InclusiveRange(rating_min, rating_max),
+            enforce_rating_range=enforce_rating_range
         )
         await self.launch_game(game, is_host=True)
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -272,8 +272,10 @@ class LobbyConnection:
     async def command_social_remove(self, message):
         if "friend" in message:
             subject_id = message["friend"]
+            player_attr = self.player.friends
         elif "foe" in message:
             subject_id = message["foe"]
+            player_attr = self.player.foes
         else:
             await self.abort("No-op social_remove.")
             return
@@ -284,13 +286,18 @@ class LobbyConnection:
                 friends_and_foes.c.subject_id == subject_id
             )))
 
+        with contextlib.suppress(KeyError):
+            player_attr.remove(subject_id)
+
     async def command_social_add(self, message):
         if "friend" in message:
             status = "FRIEND"
             subject_id = message["friend"]
+            player_attr = self.player.friends
         elif "foe" in message:
             status = "FOE"
             subject_id = message["foe"]
+            player_attr = self.player.foes
         else:
             return
 
@@ -300,6 +307,8 @@ class LobbyConnection:
                 status=status,
                 subject_id=subject_id,
             ))
+
+        player_attr.add(subject_id)
 
     async def kick(self):
         await self.send({

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -897,12 +897,7 @@ class LobbyConnection:
 
         await self.abort_connection_if_banned()
 
-        visibility = VisibilityState.from_string(message.get("visibility"))
-        if not isinstance(visibility, VisibilityState):
-            # Protocol violation.
-            await self.abort("{} sent a nonsense visibility code: {}".format(self.player.login, message.get("visibility")))
-            return
-
+        visibility = VisibilityState(message["visibility"])
         title = message.get("title") or f"{self.player.login}'s game"
 
         try:

--- a/server/rating.py
+++ b/server/rating.py
@@ -1,4 +1,4 @@
-from typing import DefaultDict, Tuple, TypeVar, Union
+from typing import DefaultDict, Optional, Tuple, TypeVar, Union
 
 from trueskill import Rating
 
@@ -47,3 +47,33 @@ class PlayerRatings(RatingTypeMap[Tuple[float, float]]):
             return tmm_2v2_rating
         else:
             return super().__getitem__(key)
+
+
+class InclusiveRange():
+    """
+    A simple inclusive range.
+
+    # Examples
+    assert 10 in InclusiveRange()
+    assert 10 in InclusiveRange(0)
+    assert 10 in InclusiveRange(0, 10)
+    assert -1 not in InclusiveRange(0, 10)
+    assert 11 not in InclusiveRange(0, 10)
+    """
+    def __init__(self, lo: Optional[float] = None, hi: Optional[float] = None):
+        self.lo = lo
+        self.hi = hi
+
+    def __contains__(self, rating: float) -> bool:
+        if self.lo is not None and rating < self.lo:
+            return False
+        if self.hi is not None and rating > self.hi:
+            return False
+        return True
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, type(self))
+            and self.lo == other.lo
+            and self.hi == other.hi
+        )

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -22,17 +22,7 @@ async def host_game(proto: Protocol) -> int:
     msg = await read_until_command(proto, "game_launch")
     game_id = int(msg["uid"])
 
-    # Simulate FA opening
-    await proto.send_message({
-        "target": "game",
-        "command": "GameState",
-        "args": ["Idle"]
-    })
-    await proto.send_message({
-        "target": "game",
-        "command": "GameState",
-        "args": ["Lobby"]
-    })
+    await open_fa(proto)
 
     return game_id
 
@@ -43,8 +33,14 @@ async def join_game(proto: Protocol, uid: int):
         "uid": uid
     })
     await read_until_command(proto, "game_launch")
+    await open_fa(proto)
+    # HACK: Yield long enough for the server to process our message
+    await asyncio.sleep(0.5)
 
-    # Simulate FA opening
+
+async def open_fa(proto):
+    """Simulate FA opening"""
+
     await proto.send_message({
         "target": "game",
         "command": "GameState",
@@ -55,8 +51,6 @@ async def join_game(proto: Protocol, uid: int):
         "command": "GameState",
         "args": ["Lobby"]
     })
-    # HACK: Yield long enough for the server to process our message
-    await asyncio.sleep(0.5)
 
 
 async def get_player_ratings(proto, *names, rating_type="global"):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -577,7 +577,7 @@ async def test_to_dict(game, player_factory):
     data = game.to_dict()
     expected = {
         "command": "game_info",
-        "visibility": VisibilityState.to_string(game.visibility),
+        "visibility": game.visibility.value,
         "password_protected": game.password is not None,
         "uid": game.id,
         "title": game.sanitize_name(game.name),
@@ -869,17 +869,6 @@ async def test_game_outcomes_conflicting(game: Game, database, players):
     assert host_outcome is GameOutcome.CONFLICTING
     assert guest_outcome is GameOutcome.CONFLICTING
     # No guarantees on scores for conflicting results.
-
-
-async def test_visibility_states():
-    states = [("public", VisibilityState.PUBLIC),
-              ("friends", VisibilityState.FRIENDS)]
-
-    for string_value, enum_value in states:
-        assert (
-            VisibilityState.from_string(string_value) == enum_value
-            and VisibilityState.to_string(enum_value) == string_value
-        )
 
 
 async def test_is_even(game: Game, game_add_players):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -555,6 +555,10 @@ async def test_to_dict(game, player_factory):
         "num_players": len(game.players),
         "max_players": game.max_players,
         "launched_at": game.launched_at,
+        "rating_type": game.rating_type,
+        "rating_min": game.displayed_rating_range.lo,
+        "rating_max": game.displayed_rating_range.hi,
+        "enforce_rating_range": game.enforce_rating_range,
         "teams": {
             team: [
                 player.login for player in game.players

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -630,6 +630,7 @@ async def test_command_social_add_friend(lobbyconnection, database):
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == []
+    assert lobbyconnection.player.friends == set()
 
     await lobbyconnection.on_message_received({
         "command": "social_add",
@@ -638,6 +639,7 @@ async def test_command_social_add_friend(lobbyconnection, database):
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == [2]
+    assert lobbyconnection.player.friends == {2}
 
 
 async def test_command_social_remove_friend(lobbyconnection, database):
@@ -645,6 +647,7 @@ async def test_command_social_remove_friend(lobbyconnection, database):
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == [1]
+    lobbyconnection.player.friends = {1}
 
     await lobbyconnection.on_message_received({
         "command": "social_remove",
@@ -653,6 +656,17 @@ async def test_command_social_remove_friend(lobbyconnection, database):
 
     friends = await get_friends(lobbyconnection.player.id, database)
     assert friends == []
+    assert lobbyconnection.player.friends == set()
+
+    # Removing twice does nothing
+    await lobbyconnection.on_message_received({
+        'command': 'social_remove',
+        'friend': 1
+    })
+
+    friends = await get_friends(lobbyconnection.player.id, database)
+    assert friends == []
+    assert lobbyconnection.player.friends == set()
 
 
 async def test_command_ice_servers(

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.asyncio
 def test_game_info():
     return {
         "title": "Test game",
-        "visibility": VisibilityState.to_string(VisibilityState.PUBLIC),
+        "visibility": VisibilityState.PUBLIC.value,
         "mod": "faf",
         "mapname": "scmp_007",
         "password": None,
@@ -46,7 +46,7 @@ def test_game_info():
 def test_game_info_invalid():
     return {
         "title": "Title with non ASCI char \xc3",
-        "visibility": VisibilityState.to_string(VisibilityState.PUBLIC),
+        "visibility": VisibilityState.PUBLIC.value,
         "mod": "faf",
         "mapname": "scmp_007",
         "password": None,


### PR DESCRIPTION
Might need to refactor/rename some stuff (I'm a bit tired ATM) but I think it should work.

The host can now optionally send `rating_min` and `rating_max` fields as well as `enforce_rating_range` in the game host message. These fields are echoed back in the `game_info` message so that the client can display them. If `enforce_rating_range` is true, then the game will not be sent to players outside of the rating range. Note that the rating range can be unbounded, so for example to create a 1000+ game you would send `rating_min: 1000` and either omit `rating_max` or set it like `rating_min: null`. Also be aware that it will use the displayed rating (mean - 3*dev) for the game's rating type. For custom games this is currently always GLOBAL, but who knows what might be added in the future. Technically, these parameters are also valid for ladder games, although there is no way of setting them.

Closes #649


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#649: Support setting min and max rating](https://issuehunt.io/repos/25841126/issues/649)
---
</details>
<!-- /Issuehunt content-->