### PR TITLE
Issue/#636 Refactor game validity checks

### DIFF
--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -20,3 +20,17 @@ class CoopGame(Game):
             "Difficulty": 3,
             "Expansion": 1
         })
+
+    async def validate_game_mode_settings(self):
+        """
+        Checks which only apply to the coop mode
+        """
+
+        valid_options = {
+            "Victory": (Victory.SANDBOX, ValidityState.WRONG_VICTORY_CONDITION),
+            "TeamSpawn": ("fixed", ValidityState.SPAWN_NOT_FIXED),
+            "RevealedCivilians": ("No", ValidityState.CIVILIANS_REVEALED),
+            "Difficulty": (3, ValidityState.WRONG_DIFFICULTY),
+            "Expansion": (1, ValidityState.EXPANSION_DISABLED),
+        }
+        await self._validate_game_options(valid_options)


### PR DESCRIPTION
This commit closes #636. It restructures the validity checks that are performed on games. It starts taking advantage of the OOP setup of Game classes. Child classes of Game can redefine the `_validate_game_mode_settings` method to set custom game validity rules.

As discussed in #636 there is probably more tidyup to be done of these classes and how featured mods/game types work. I'm leaving that for later because I don't feel confident attempting it yet.