### PR TITLE
Refactor weakrefs in Player object

### DIFF
--- a/server/players.py
+++ b/server/players.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 from enum import Enum, unique
+from typing import Optional, Union
 
 from server.config import config
 from server.rating import PlayerRatings, RatingType, RatingTypeMap
@@ -11,11 +12,11 @@ from .weakattr import WeakAttribute
 
 @unique
 class PlayerState(Enum):
-    IDLE = 1,
-    PLAYING = 2,
-    HOSTING = 3,
-    JOINING = 4,
-    SEARCHING_LADDER = 5,
+    IDLE = 1
+    PLAYING = 2
+    HOSTING = 3
+    JOINING = 4
+    SEARCHING_LADDER = 5
 
 
 class Player:
@@ -38,8 +39,8 @@ class Player:
         ratings=None,
         clan=None,
         game_count=None,
-        lobby_connection: "LobbyConnection" = None
-    ):
+        lobby_connection: Optional["LobbyConnection"] = None
+    ) -> None:
         self._faction = Faction.uef
 
         self.id = player_id
@@ -74,11 +75,11 @@ class Player:
             self.lobby_connection = lobby_connection
 
     @property
-    def faction(self):
+    def faction(self) -> Faction:
         return self._faction
 
     @faction.setter
-    def faction(self, value):
+    def faction(self, value: Union[str, int, Faction]) -> None:
         if isinstance(value, str):
             self._faction = Faction.from_string(value)
         elif isinstance(value, int):
@@ -88,7 +89,7 @@ class Player:
         else:
             raise TypeError(f"Unsupported faction type {type(value)}!")
 
-    def power(self):
+    def power(self) -> int:
         """An artifact of the old permission system. The client still uses this
         number to determine if a player gets a special category in the user list
         such as "Moderator"
@@ -106,7 +107,7 @@ class Player:
     def is_moderator(self) -> bool:
         return "faf_moderators_global" in self.user_groups
 
-    async def send_message(self, message):
+    async def send_message(self, message) -> None:
         """
         Try to send a message to this player.
 
@@ -117,7 +118,7 @@ class Player:
 
         await self.lobby_connection.send(message)
 
-    def write_message(self, message):
+    def write_message(self, message) -> None:
         """
         Try to queue a message to be sent this player. Only call this from
         broadcasting functions. Does nothing if the player has disconnected.
@@ -161,19 +162,16 @@ class Player:
             )
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (f"Player({self.login}, {self.id}, "
                 f"{self.ratings[RatingType.GLOBAL]}, "
                 f"{self.ratings[RatingType.LADDER_1V1]})")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self.id
 
-    def __eq__(self, other):
-        if not isinstance(other, Player):
-            return False
-        else:
-            return self.id == other.id
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, type(self)) and self.id == other.id

--- a/server/players.py
+++ b/server/players.py
@@ -40,7 +40,7 @@ class Player:
         game_count=None,
         lobby_connection: "LobbyConnection" = None
     ):
-        self._faction = 0
+        self._faction = Faction.uef
 
         self.id = player_id
         self.login = login
@@ -69,8 +69,6 @@ class Player:
         self.user_groups = set()
 
         self.state = PlayerState.IDLE
-
-        self.faction = 1
 
         if lobby_connection is not None:
             self.lobby_connection = lobby_connection

--- a/server/players.py
+++ b/server/players.py
@@ -1,4 +1,3 @@
-import weakref
 from contextlib import suppress
 from enum import Enum, unique
 
@@ -7,6 +6,7 @@ from server.rating import PlayerRatings, RatingType, RatingTypeMap
 
 from .factions import Faction
 from .protocol import DisconnectedError
+from .weakattr import WeakAttribute
 
 
 @unique
@@ -25,6 +25,10 @@ class Player:
     In the context of a game, the Game object holds game-specific
     information about players.
     """
+
+    lobby_connection = WeakAttribute["LobbyConnection"]()
+    game = WeakAttribute["Game"]()
+    game_connection = WeakAttribute["GameConnection"]()
 
     def __init__(
         self,
@@ -68,12 +72,8 @@ class Player:
 
         self.faction = 1
 
-        self._lobby_connection = lambda: None
         if lobby_connection is not None:
             self.lobby_connection = lobby_connection
-
-        self._game = lambda: None
-        self._game_connection = lambda: None
 
     @property
     def faction(self):
@@ -89,49 +89,6 @@ class Player:
             self._faction = value
         else:
             raise TypeError(f"Unsupported faction type {type(value)}!")
-
-    @property
-    def lobby_connection(self) -> "LobbyConnection":
-        """
-        Weak reference to the LobbyConnection of this player
-        """
-        return self._lobby_connection()
-
-    @lobby_connection.setter
-    def lobby_connection(self, value: "LobbyConnection"):
-        self._lobby_connection = weakref.ref(value)
-
-    @property
-    def game(self):
-        """
-        Weak reference to the Game object that this player wants to join or is
-        currently in
-        """
-        return self._game()
-
-    @game.setter
-    def game(self, value):
-        self._game = weakref.ref(value)
-
-    @game.deleter
-    def game(self):
-        self._game = lambda: None
-
-    @property
-    def game_connection(self):
-        """
-        Weak reference to the GameConnection object for this player
-        :return:
-        """
-        return self._game_connection()
-
-    @game_connection.setter
-    def game_connection(self, value):
-        self._game_connection = weakref.ref(value)
-
-    @game_connection.deleter
-    def game_connection(self):
-        self._game_connection = lambda: None
 
     def power(self):
         """An artifact of the old permission system. The client still uses this

--- a/server/weakattr.py
+++ b/server/weakattr.py
@@ -1,0 +1,29 @@
+import contextlib
+import weakref
+from typing import Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+# Adapted from https://www.python.org/dev/peps/pep-0487/
+class WeakAttribute(Generic[T]):
+    """
+    Transparently allow an object attribute to reference another object via a
+    weak reference.
+    """
+
+    def __set_name__(self, _: object, name: str) -> None:
+        self.name = name
+
+    def __get__(self, obj: object, objclass: type) -> Optional[T]:
+        ref = obj.__dict__.get(self.name)
+        if ref:
+            return ref()
+        return None
+
+    def __set__(self, obj: object, value: T) -> None:
+        obj.__dict__[self.name] = weakref.ref(value)
+
+    def __delete__(self, obj: object) -> None:
+        with contextlib.suppress(KeyError):
+            del obj.__dict__[self.name]

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -45,7 +45,7 @@ def test_equality_by_id():
 
 def test_weak_references():
     p = Player(login="Test")
-    weak_properties = ["lobby_connection", "game"]
+    weak_properties = ["lobby_connection", "game", "game_connection"]
     referent = mock.Mock()
     for prop in weak_properties:
         setattr(p, prop, referent)

--- a/tests/unit_tests/test_weakattr.py
+++ b/tests/unit_tests/test_weakattr.py
@@ -1,0 +1,41 @@
+import mock
+import pytest
+
+from server.weakattr import WeakAttribute
+
+
+@pytest.fixture(params=("typed", "untyped"))
+def obj(request):
+    """An object with a WeakAttribute"""
+    if request.param == "untyped":
+        class Foo(object):
+            attr = WeakAttribute()
+    else:
+        class Foo(object):
+            attr = WeakAttribute[mock.Mock]()
+
+    return Foo()
+
+
+def test_basic(obj):
+    ref_obj = mock.Mock()
+
+    assert obj.attr is None
+
+    obj.attr = ref_obj
+    assert obj.attr is ref_obj
+
+    del obj.attr
+    assert obj.attr is None
+
+    obj.attr = ref_obj
+    assert obj.attr is ref_obj
+
+    del ref_obj
+    assert obj.attr is None
+
+
+def test_delete_before_set(obj):
+    assert obj.attr is None
+    del obj.attr
+    assert obj.attr is None


### PR DESCRIPTION
I stumbled across this `WeakAttribute` implementation while looking up something unrelated and realized that we actually have a use case for it. This will also make it easier to add weak references on other objects too, not just Player. I also refactored a few other things in Player while I was at it.