### PR TITLE
Add outcome override for ladder 1v1 games

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -83,6 +83,7 @@ class ConfigurationStore:
         self.GEO_IP_LICENSE_KEY = ""
         self.GEO_IP_DATABASE_MAX_AGE_DAYS = 22
 
+        self.LADDER_1V1_OUTCOME_OVERRIDE = True
         self.LADDER_ANTI_REPETITION_LIMIT = 3
         self.LADDER_SEARCH_EXPANSION_MAX = 0.25
         self.LADDER_SEARCH_EXPANSION_STEP = 0.05

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -423,7 +423,11 @@ class Game:
                     {self.get_player_outcome(player) for player in team}
                     for team in basic_info.teams
                 ]
-                team_outcomes = resolve_game(team_player_partial_outcomes)
+                #TODO Remove override once game result messages are reliable
+                team_outcomes = (
+                    self._outcome_override_hook()
+                    or resolve_game(team_player_partial_outcomes)
+                )
             except GameResolutionError:
                 await self.mark_invalid(ValidityState.UNKNOWN_RESULT)
 
@@ -438,6 +442,9 @@ class Game:
         return EndedGameInfo.from_basic(
             basic_info, self.validity, team_outcomes, commander_kills
         )
+
+    def _outcome_override_hook(self) -> Optional[List[GameOutcome]]:
+        return None
 
     async def load_results(self):
         """


### PR DESCRIPTION
Gives the possibility to decide the outcome of 1v1 ladder games by score instead of by reported result, as it was a year ago.
I added a config variable, so that this can be turned on and off dynamically (e.g. for testing new game patches on the test server).

I hope that the game still reports scores as it did and that that didn't change with recent patches?

Could make this override for all 1v1 games, but I thought I'd rather have as little scope as possible.

Addresses issue #580 but should be regarded a temporary fix.