### PR TITLE
Hopefix for infinite login

### DIFF
--- a/integration_tests/fafclient.py
+++ b/integration_tests/fafclient.py
@@ -57,7 +57,6 @@ class FAFClient(object):
         return await self.read_until(
             lambda msg: (
                 msg.get("command") == "game_info" and
-                msg["host"] == "test" and
                 msg["launched_at"] is not None
                 and msg["uid"] == uid
             )

--- a/server/rating_service/rating_service.py
+++ b/server/rating_service/rating_service.py
@@ -100,9 +100,12 @@ class RatingService(Service):
 
                 self._queue.task_done()
                 rating_service_backlog.set(self._queue.qsize())
+        except asyncio.CancelledError:
+            pass
         except Exception:
             self._logger.critical(
-                "Unexpected exception while handling rating queue."
+                "Unexpected exception while handling rating queue.",
+                exc_info=True
             )
 
         self._logger.debug("RatingService stopped.")

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -699,7 +699,7 @@ async def test_broadcast(lobbyconnection: LobbyConnection, player_factory):
         tuna.id: tuna
     }
     lobbyconnection.player_service.__iter__.side_effect = data.values().__iter__
-    lobbyconnection.send_warning = CoroutineMock()
+    lobbyconnection.write_warning = Mock()
 
     await lobbyconnection.on_message_received({
         "command": "admin",
@@ -707,8 +707,8 @@ async def test_broadcast(lobbyconnection: LobbyConnection, player_factory):
         "message": "This is a test message"
     })
 
-    player.lobby_connection.send_warning.assert_called_with("This is a test message")
-    tuna.lobby_connection.send_warning.assert_called_with("This is a test message")
+    player.lobby_connection.write_warning.assert_called_with("This is a test message")
+    tuna.lobby_connection.write_warning.assert_called_with("This is a test message")
 
 
 async def test_broadcast_during_disconnect(lobbyconnection: LobbyConnection, player_factory):
@@ -724,7 +724,7 @@ async def test_broadcast_during_disconnect(lobbyconnection: LobbyConnection, pla
         tuna.id: tuna
     }
     lobbyconnection.player_service.__iter__.side_effect = data.values().__iter__
-    lobbyconnection.send_warning = CoroutineMock()
+    lobbyconnection.write_warning = Mock()
 
     # This should not leak any exceptions
     await lobbyconnection.on_message_received({
@@ -733,7 +733,7 @@ async def test_broadcast_during_disconnect(lobbyconnection: LobbyConnection, pla
         "message": "This is a test message"
     })
 
-    player.lobby_connection.send_warning.assert_called_with("This is a test message")
+    player.lobby_connection.write_warning.assert_called_with("This is a test message")
 
 
 async def test_broadcast_connection_error(lobbyconnection: LobbyConnection, player_factory):
@@ -741,13 +741,13 @@ async def test_broadcast_connection_error(lobbyconnection: LobbyConnection, play
     player.lobby_connection = lobbyconnection
     player.id = 1
     tuna = player_factory("Tuna", player_id=55, with_lobby_connection=True)
-    tuna.lobby_connection.send_warning.side_effect = ConnectionError("Some error")
+    tuna.lobby_connection.write_warning.side_effect = DisconnectedError("Some error")
     data = {
         player.id: player,
         tuna.id: tuna
     }
     lobbyconnection.player_service.__iter__.side_effect = data.values().__iter__
-    lobbyconnection.send_warning = CoroutineMock()
+    lobbyconnection.write_warning = Mock()
 
     # This should not leak any exceptions
     await lobbyconnection.on_message_received({
@@ -756,7 +756,7 @@ async def test_broadcast_connection_error(lobbyconnection: LobbyConnection, play
         "message": "This is a test message"
     })
 
-    player.lobby_connection.send_warning.assert_called_with("This is a test message")
+    player.lobby_connection.write_warning.assert_called_with("This is a test message")
 
 
 async def test_game_connection_not_restored_if_no_such_game_exists(lobbyconnection: LobbyConnection, mocker):

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -204,7 +204,7 @@ async def test_double_login(lobbyconnection, mock_players, player_factory):
         "unique_id": "blah"
     })
 
-    old_player.lobby_connection.send_warning.assert_called_with(
+    old_player.lobby_connection.write_warning.assert_called_with(
         "You have been signed out because you signed in elsewhere.",
         fatal=True
     )


### PR DESCRIPTION
We were not able to reproduce the issue yet, but in theory it might be possible that the await statement on sending the warning to old player connections could prevent the welcome message from being delivered to the new connection.

Uses the `write` variant (instead of `send`) when notifying the old connection of the new login.