### PR TITLE
Allow only ascii characters in game names

### DIFF
--- a/server/db/models.py
+++ b/server/db/models.py
@@ -142,7 +142,7 @@ game_stats = Table(
     Column("gameMod",   Integer,        ForeignKey("game_featuredMods.id"), nullable=False),
     Column("host",      Integer,        nullable=False),
     Column("mapId",     Integer),
-    Column("gameName",  String,         nullable=False),
+    Column("gameName",  String(128),    nullable=False),
     Column("validity",  Integer,        nullable=False),
 )
 

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -235,7 +235,8 @@ class GameConnection(GpgNetServerProtocol):
                 self.game.map_scenario_path.split("/")[2].lower()
             )
         elif key == "Title":
-            self.game.name = self.game.sanitize_name(value)
+            with contextlib.suppress(ValueError):
+                self.game.name = value
 
         self._mark_dirty()
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -883,16 +883,8 @@ class LobbyConnection:
 
         visibility = VisibilityState(message["visibility"])
         title = message.get("title") or f"{self.player.login}'s game"
-
-        try:
-            title.encode("ascii")
-        except UnicodeEncodeError:
-            await self.send({
-                "command": "notice",
-                "style": "error",
-                "text": "Non-ascii characters in game name detected."
-            })
-            return
+        if not title.isascii():
+            raise ClientError("Title must contain only ascii characters.")
 
         mod = message.get("mod") or FeaturedModType.FAF
         mapname = message.get("mapname") or "scmp_007"

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -358,7 +358,7 @@ async def test_handle_action_GameOption(game: Game, game_connection: GameConnect
     await game_connection.handle_action("GameOption", ["ScenarioFile", "C:\\Maps\\Some_Map"])
     assert game.map_file_path == "maps/some_map.zip"
     await game_connection.handle_action("GameOption", ["Title", "All welcome"])
-    assert game.name == game.sanitize_name("All welcome")
+    assert game.name == "All welcome"
     await game_connection.handle_action("GameOption", ["ArbitraryKey", "ArbitraryValue"])
     assert game.gameOptions["ArbitraryKey"] == "ArbitraryValue"
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -471,7 +471,7 @@ async def test_command_game_host_calls_host_game_invalid_title(
     })
     assert mock_games.create_game.mock_calls == []
     lobbyconnection.send.assert_called_once_with(
-        dict(command="notice", style="error", text="Non-ascii characters in game name detected."))
+        dict(command="notice", style="error", text="Title must contain only ascii characters."))
 
 
 async def test_abort(mocker, lobbyconnection):


### PR DESCRIPTION
Previously it was possible to put non-ascii characters into the game name by changing the name through the in-game lobby. These changes prevent the game name from being set to non-ascii characters from everywhere.