### PR TITLE
Issue/#621 Detect when some players don't join a matchmaker game

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -125,7 +125,9 @@ class Game:
         tm = 30 if self.game_mode != FeaturedModType.COOP else 60
         await asyncio.sleep(tm)
         if self.state is GameState.INITIALIZING:
-            self._is_hosted.set_exception(TimeoutError("Game setup timed out"))
+            self._is_hosted.set_exception(
+                asyncio.TimeoutError("Game setup timed out")
+            )
             self._logger.debug("Game setup timed out.. Cancelling game")
             await self.on_game_end()
 
@@ -233,12 +235,12 @@ class Game:
 
         return list(teams.values()) + ffa_players
 
-    async def wait_hosted(self):
-        return await asyncio.wait_for(self._is_hosted, None)
+    async def wait_hosted(self, timeout: float):
+        return await asyncio.wait_for(self._is_hosted, timeout=timeout)
 
-    def set_hosted(self, value: bool = True):
+    def set_hosted(self):
         if not self._is_hosted.done():
-            self._is_hosted.set_result(value)
+            self._is_hosted.set_result(None)
 
     async def wait_launched(self, timeout: float):
         return await asyncio.wait_for(self._launch_fut, timeout=timeout)
@@ -409,8 +411,6 @@ class Game:
         except Exception:    # pragma: no cover
             self._logger.exception("Error during game end")
         finally:
-            self.set_hosted(value=False)
-
             self.state = GameState.ENDED
 
             self.game_service.mark_dirty(self)

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -367,9 +367,7 @@ class LadderService(Service):
                 game, is_host=True, options=game_options(host)
             )
             try:
-                hosted = await game.wait_hosted()
-                if not hosted:
-                    raise TimeoutError("Host left lobby")
+                await game.wait_hosted(30)
             finally:
                 # TODO: Once the client supports `match_cancelled`, don't
                 # send `launch_game` to the client if the host timed out. Until

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -295,6 +295,7 @@ class LadderService(Service):
         self._logger.debug(
             "Starting %s game between %s and %s", queue.name, team1, team2
         )
+        game = None
         try:
             host = team1[0]
             all_players = team1 + team2
@@ -366,7 +367,7 @@ class LadderService(Service):
                 game, is_host=True, options=game_options(host)
             )
             try:
-                hosted = await game.await_hosted()
+                hosted = await game.wait_hosted()
                 if not hosted:
                     raise TimeoutError("Host left lobby")
             finally:
@@ -383,9 +384,11 @@ class LadderService(Service):
                     )
                     for guest in all_guests
                 ])
-                # TODO: Wait for players to join here
+            await game.wait_launched(30)
             self._logger.debug("Ladder game launched successfully")
         except Exception:
+            if game:
+                await game.on_game_end()
             self._logger.exception("Failed to start ladder game!")
             msg = {"command": "match_cancelled"}
             with contextlib.suppress(DisconnectedError):

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -5,7 +5,7 @@ import pytest
 from tests.utils import fast_forward
 
 from .conftest import connect_and_sign_in, read_until, read_until_command
-from .test_game import get_player_ratings, send_player_options
+from .test_game import client_response, get_player_ratings, send_player_options
 
 pytestmark = pytest.mark.asyncio
 
@@ -41,23 +41,6 @@ async def queue_players_for_matchmaking(lobby_server):
     ])
 
     return protos, ids
-
-
-async def client_response(proto):
-    msg = await read_until_command(proto, "game_launch")
-    # Ensures that the game enters the `LOBBY` state
-    await proto.send_message({
-        "command": "GameState",
-        "target": "game",
-        "args": ["Idle"]
-    })
-    # Ensures that the game is considered hosted
-    await proto.send_message({
-        "command": "GameState",
-        "target": "game",
-        "args": ["Lobby"]
-    })
-    return msg
 
 
 @fast_forward(10)

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -97,7 +97,7 @@ async def test_start_game_1v1(
     p1 = player_factory("Dostya", player_id=1, with_lobby_connection=True)
     p2 = player_factory("Rhiza", player_id=2, with_lobby_connection=True)
 
-    with mock.patch("server.games.game.Game.await_hosted", CoroutineMock()):
+    with mock.patch("server.games.game.Game.wait_hosted", CoroutineMock()):
         await ladder_service.start_game([p1], [p2], queue)
 
     game = game_service[game_service.game_id_counter]
@@ -140,7 +140,7 @@ async def test_start_game_with_teams(
 
     game_service.ladder_maps = [(1, "scmp_007", "maps/scmp_007.zip")]
 
-    with mock.patch("server.games.game.Game.await_hosted", CoroutineMock()):
+    with mock.patch("server.games.game.Game.wait_hosted", CoroutineMock()):
         await ladder_service.start_game([p1, p3], [p2, p4], queue)
 
     game = game_service[game_service.game_id_counter]


### PR DESCRIPTION
Adds logic for sending `match_cancelled` messages if the matchmaker game doesn't start within about a minute. This should fix point 4 mentioned here https://github.com/FAForever/downlords-faf-client/pull/1778#issuecomment-660403082. 

Seems like some of the mocking code in the tests was not working correctly, and they were waiting for 30 seconds for the game timeout to trigger before passing. Now that's been fixed and the tests run about 30 seconds faster.

Closes #621