### PR TITLE
Enhancement/#676 remove python version check

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -453,6 +453,16 @@ class LobbyConnection:
             metrics.user_agent_version.labels(str(version)).inc()
         self._version = version
 
+    async def _check_user_agent(self):
+        if not self.user_agent or "downlords-faf-client" not in self.user_agent:
+            await self.send_warning(
+                "You are using an unofficial client version! "
+                "Some features might not work as expected. "
+                "If you experience any problems please download the latest "
+                "version of the official client from "
+                f'<a href="{config.WWW_URL}">{config.WWW_URL}</a>'
+            )
+
     async def check_policy_conformity(self, player_id, uid_hash, session, ignore_result=False):
         if not config.USE_POLICY_SERVER:
             return True
@@ -698,6 +708,7 @@ class LobbyConnection:
         user_agent = message.get("user_agent")
         version = message.get("version")
         self._set_user_agent_and_version(user_agent, version)
+        await self._check_user_agent()
         await self.send({"command": "session", "session": self.session})
 
     async def command_avatar(self, message):

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -37,7 +37,6 @@ class PlayerService(Service):
 
         # Static-ish data fields.
         self.uniqueid_exempt = {}
-        self.client_version_info = ("0.0.0", None)
         self._dirty_players = set()
 
     async def initialize(self) -> None:
@@ -255,14 +254,6 @@ class PlayerService(Service):
             )
             rows = await result.fetchall()
             self.uniqueid_exempt = frozenset(map(lambda x: x[0], rows))
-
-            # Client version number
-            result = await conn.execute(
-                "SELECT version, file FROM version_lobby ORDER BY id DESC LIMIT 1"
-            )
-            row = await result.fetchone()
-            if row is not None:
-                self.client_version_info = (row[0], row[1])
 
     async def shutdown(self):
         tasks = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,9 +45,6 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
     )
-    config.addinivalue_line(
-        "filterwarnings", "ignore:Function 'semver.compare':DeprecationWarning"
-    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -160,9 +160,6 @@ insert into unique_id_users (user_id, uniqueid_hash) values (1, 'some_id');
 insert into unique_id_users (user_id, uniqueid_hash) values (2, 'another_id');
 insert into unique_id_users (user_id, uniqueid_hash) values (3, 'some_id');
 
--- Lobby version table
-insert into version_lobby (id, `file`, version) values (1, 'some-installer.msi', '0.10.125');
-
 -- Sample maps
 insert into map (id, display_name, map_type, battle_type, author) values
   (1, 'SCMP_001', 'FFA', 'skirmish', 1),

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -20,21 +20,6 @@ pytestmark = pytest.mark.asyncio
 TEST_ADDRESS = ("127.0.0.1", None)
 
 
-async def test_server_deprecated_client(lobby_server):
-    proto = await connect_client(lobby_server)
-
-    await proto.send_message({"command": "ask_session", "user_agent": "faf-client", "version": "0.0.0"})
-    msg = await proto.read_message()
-
-    assert msg["command"] == "notice"
-
-    proto = await connect_client(lobby_server)
-    await proto.send_message({"command": "ask_session", "version": "0.0.0"})
-    msg = await proto.read_message()
-
-    assert msg["command"] == "notice"
-
-
 @fast_forward(50)
 async def test_ping_message(lobby_server):
     _, _, proto = await connect_and_sign_in(("test", "test_password"), lobby_server)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -20,6 +20,21 @@ pytestmark = pytest.mark.asyncio
 TEST_ADDRESS = ("127.0.0.1", None)
 
 
+async def test_server_deprecated_client(lobby_server):
+    proto = await connect_client(lobby_server)
+
+    await proto.send_message({"command": "ask_session", "user_agent": "faf-client", "version": "0.0.0"})
+    msg = await proto.read_message()
+
+    assert msg["command"] == "notice"
+
+    proto = await connect_client(lobby_server)
+    await proto.send_message({"command": "ask_session", "version": "0.0.0"})
+    msg = await proto.read_message()
+
+    assert msg["command"] == "notice"
+
+
 @fast_forward(50)
 async def test_ping_message(lobby_server):
     _, _, proto = await connect_and_sign_in(("test", "test_password"), lobby_server)

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -114,9 +114,7 @@ async def test_mark_dirty(player_factory, player_service):
 
 async def test_update_data(player_factory, player_service):
     await player_service.update_data()
-
     assert player_service.is_uniqueid_exempt(1) is True
-    assert player_service.client_version_info == ("0.10.125", "some-installer.msi")
 
 
 async def test_broadcast_shutdown(player_factory, player_service):


### PR DESCRIPTION
Removed `client_version_info` from project.

1. `isort` show sorting error in file which I didn't edited
2. `flake8` throws tons of errors on local env
3. Didn't update Pipfile only because it's trying to upgrade all packages (it's ignoring `--keep-outdated` flag)

I can update PR later with all necessary changes.

Closes #676