### PR TITLE
Ignore cancellation of non-existing search without error

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -211,7 +211,15 @@ class LadderService(Service):
         """
         Cancel search for a specific player/queue.
         """
-        cancelled_search = self._searches[initiator][queue_name]
+        cancelled_search = self._searches[initiator].get(queue_name)
+        if cancelled_search is None:
+            self._logger.debug(
+                "Ignoring request to cancel a search that does not exist: "
+                "%s, %s",
+                initiator,
+                queue_name
+            )
+            return
         cancelled_search.cancel()
 
         for player in cancelled_search.players:

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -172,6 +172,7 @@ async def test_game_matchmaking_timeout(lobby_server):
     assert msg2["mod"] == "ladder1v1"
 
 
+@fast_forward(15)
 async def test_game_matchmaking_cancel(lobby_server):
     proto = await queue_player_for_matchmaking(
         ("ladder1", "ladder1"),
@@ -191,6 +192,15 @@ async def test_game_matchmaking_cancel(lobby_server):
         "queue_name": "ladder1v1",
         "state": "stop",
     }
+
+    # Extra message even though the player is not in a queue
+    await proto.send_message({
+        "command": "game_matchmaking",
+        "state": "stop",
+        "queue": "ladder1v1"
+    })
+    with pytest.raises(asyncio.TimeoutError):
+        await read_until_command(proto, "search_info", timeout=5)
 
 
 @fast_forward(50)


### PR DESCRIPTION
During the TMM test we saw a lot of this exception:
```
ERROR    Oct 04  18:19:01 LobbyConnection                'ladder1v1'
Traceback (most recent call last):
 File "/code/server/lobbyconnection.py", line 147, in on_message_received
   await handler(message)
 File "/code/server/lobbyconnection.py", line 789, in wrapper
   return await func(self, message)
 File "/code/server/lobbyconnection.py", line 856, in command_game_matchmaking
   self.ladder_service.cancel_search(self.player, queue_name)
 File "/code/server/ladder_service.py", line 207, in cancel_search
   self._cancel_search(initiator, queue_name)
 File "/code/server/ladder_service.py", line 213, in _cancel_search
   cancelled_search = self._searches[initiator][queue_name]
KeyError: 'ladder1v1'
```

Which would cause players to be disconnected if their client sent a matchmaking stop command while the server already considered them out of queue. Now extra messages will just be ignored, as they likely just mean the client state was out of date.