### PR TITLE
Update to python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.7"
+  - "3.9-dev"
 
 cache: pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN python3 -m pip install -e .
 # Main entrypoint and the default command that will be run
 CMD ["/usr/local/bin/python3", "server.py"]
 
-# Game server runs on 8000/tcp, lobby server runs on 8001/tcp, nat echo server runs on 30351/udp
-EXPOSE 8000 8001 30351
+# lobby server runs on 8001/tcp (qdatastream) and 8002/tcp (json-utf8)
+EXPOSE 8001 8002
 
 RUN python3 -V

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.7-slim
+FROM python:3.9-slim
 
 # Need git for installing aiomysql
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
-        git && \
+        git g++ && \
     apt-get clean
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Pipfile
+++ b/Pipfile
@@ -37,4 +37,4 @@ asynctest = "*"
 hypothesis = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "50a4fcfda52274ccd3fadeb7bb41017263fe6bf9a6419a21fb84a2ea4f279bcf"
+            "sha256": "3869db669f181fe4d387a2d3073dd749dc514542b74d9470b39330d4394be8da"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -315,15 +315,6 @@
             "index": "pypi",
             "version": "==3.7.4.3"
         },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.7.4.3"
-        },
         "tzlocal": {
             "hashes": [
                 "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44",
@@ -451,11 +442,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:180507e78a4f52b1c470164d1a03b74b0032e473a98cc2933e85e72aee40c6a1",
-                "sha256:b3a6ae80e8661b6cab0a722cc437d26274d5e3d0759ef2f6a6a1c3b066dd3185"
+                "sha256:4c6c69cd02be7053361dceefee95983a1d9aa6e388061d17a4ed486f8c60bce0",
+                "sha256:9b524052b0c5ed584d8c3a1c21a5b5d6333378a8b20b652792af762827401681"
             ],
             "index": "pypi",
-            "version": "==5.37.0"
+            "version": "==5.37.1"
         },
         "idna": {
             "hashes": [
@@ -464,14 +455,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
-                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==2.0.0"
         },
         "iniconfig": {
             "hashes": [
@@ -596,14 +579,6 @@
             ],
             "index": "pypi",
             "version": "==2.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b",
-                "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.3.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FA Forever - Server
-![python](https://img.shields.io/badge/python-3.7-blue)
+![python](https://img.shields.io/badge/python-3.9-blue)
 [![Build Status](https://travis-ci.org/FAForever/server.svg?branch=develop)](https://travis-ci.org/FAForever/server)
 [![Coveralls Status](https://img.shields.io/coveralls/FAForever/server/develop.svg)](https://coveralls.io/github/FAForever/server)
 [![semver](https://img.shields.io/badge/license-GPLv3-blue)](license.txt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.isort]
+multi_line_output = 3
+known_first_party = ["server", "tests", "integration_tests"]
+default_section = "THIRDPARTY"
+
+[tool.pytest.ini_options]
+# Ignore DeprecationWarnings in third party libraries caused by internal python changes
+filterwarnings = ["ignore:.*Python 3\\.8.*:DeprecationWarning:^(?!server).*"]
+markers = ["slow: marks tests as slow."]

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -16,7 +16,6 @@ from sqlalchemy import and_, func, select
 import server.metrics as metrics
 from server.db import FAFDatabase
 
-from . import asyncio_extensions as asyncio_
 from .abc.base_game import GameConnectionState, InitMode
 from .config import TRACE, config
 from .db.models import (
@@ -127,8 +126,7 @@ class LobbyConnection:
 
         return str(self.session)
 
-    @asyncio.coroutine
-    def on_connection_made(self, protocol: Protocol, peername: Address):
+    async def on_connection_made(self, protocol: Protocol, peername: Address):
         self.protocol = protocol
         self.peer_address = peername
         metrics.server_connections.inc()

--- a/server/timing/timer.py
+++ b/server/timing/timer.py
@@ -16,7 +16,10 @@ async def null_callback(*args):
 def wrap_func(func):
     """wrap in a coroutine"""
     if not asyncio.iscoroutinefunction(func):
-        return asyncio.coroutine(func)
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            func(*args, **kwargs)
+        return wrapper
     return func
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[isort]
-multi_line_output=3
-known_first_party=server,tests,integration_tests
-default_section=THIRDPARTY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,12 +41,6 @@ def pytest_addoption(parser):
     parser.addoption("--mysql_port",     action="store", default=int(config.DB_PORT), help="mysql port to use for tests")
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
-    )
-
-
 @pytest.fixture(scope="session", autouse=True)
 async def test_data(request):
     db = await global_database(request)

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -420,7 +420,10 @@ async def test_cancel_twice(ladder_service: LadderService, player_factory):
 
 
 @fast_forward(5)
-async def test_start_game_called_on_match(ladder_service: LadderService, player_factory):
+async def test_start_game_called_on_match(
+    ladder_service: LadderService,
+    player_factory,
+):
     p1 = player_factory(
         "Dostya",
         player_id=1,
@@ -442,7 +445,7 @@ async def test_start_game_called_on_match(ladder_service: LadderService, player_
     ladder_service.start_search([p1], "ladder1v1")
     ladder_service.start_search([p2], "ladder1v1")
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(3)
 
     ladder_service.inform_player.assert_called()
     ladder_service.start_game.assert_called_once()

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -2,7 +2,6 @@ import asyncio
 import functools
 import random
 from collections import deque
-from concurrent.futures import CancelledError, TimeoutError
 
 import pytest
 from hypothesis import given
@@ -373,7 +372,7 @@ async def test_queue_race(matchmaker_queue, player_factory):
             asyncio.wait_for(matchmaker_queue.search(Search([p3])), 0.1),
             asyncio.create_task(find_matches())
         )
-    except (TimeoutError, CancelledError):
+    except (asyncio.TimeoutError, asyncio.CancelledError):
         pass
 
     assert len(matchmaker_queue._queue) == 0
@@ -388,7 +387,7 @@ async def test_queue_cancel(matchmaker_queue, matchmaker_players):
     s1.cancel()
     try:
         await asyncio.wait_for(matchmaker_queue.search(s2), 0.01)
-    except (TimeoutError, CancelledError):
+    except (asyncio.TimeoutError, asyncio.CancelledError):
         pass
 
     assert not s1.is_matched
@@ -414,7 +413,7 @@ async def test_queue_mid_cancel(matchmaker_queue, matchmaker_players_all_match):
             asyncio.wait_for(matchmaker_queue.search(s3), 0.1),
             asyncio.create_task(find_matches())
         )
-    except CancelledError:
+    except asyncio.CancelledError:
         pass
 
     assert not s1.is_matched


### PR DESCRIPTION
I finally ran into a scenario where I needed some >3.7 functionality, and since 3.9 was just released I figured lets skip straight to that.

The main useful improvements that have been made in 3.8 and 3.9 are enhancements to typing support. The main feature that prompted this was the addition of `typing.Protocol` which lets you do "static duck typing" so the typechecker can recognize types with a certain API even if they don't share a base class (for instance any object which has a `__len__` method defined). In 3.9 you can also use builtin types as generics, so instead of needing to import `typing.List` you can just annotate your types like `list[int]`.

Unfortunately there are a lot of deprecation warnings generated by `aiomysql`, `aiohttp`, and `asynctest` which we need to filter out in the tests.