### PR TITLE
Issue/#691 prevent joining a party while it is queued

### DIFF
--- a/server/party_service.py
+++ b/server/party_service.py
@@ -5,7 +5,7 @@ from .decorators import with_logger
 from .exceptions import ClientError
 from .factions import Faction
 from .game_service import GameService
-from .players import Player
+from .players import Player, PlayerState
 from .team_matchmaker.player_party import PlayerParty
 from .timing import at_interval
 
@@ -98,6 +98,10 @@ class PartyService(Service):
         ):
             # TODO: Localize with a proper message
             raise ClientError("You are not invited to that party (anymore)", recoverable=True)
+
+        if sender.state is PlayerState.SEARCHING_LADDER:
+            # TODO: Localize with a proper message
+            raise ClientError("That party is already in queue", recoverable=True)
 
         old_party = self.player_parties.get(recipient)
         if old_party is not None:

--- a/tests/unit_tests/test_party_service.py
+++ b/tests/unit_tests/test_party_service.py
@@ -6,6 +6,7 @@ from asynctest import CoroutineMock
 from server.exceptions import ClientError
 from server.factions import Faction
 from server.party_service import PartyService
+from server.players import PlayerState
 from server.team_matchmaker import PlayerParty
 
 # All test coroutines will be treated as marked.
@@ -90,6 +91,17 @@ async def test_accept_invite_two_invites(party_service, player_factory):
     assert receiver in party_service.player_parties
     assert sender2 in party_service.player_parties[receiver]
     assert sender1 not in party_service.player_parties[receiver]
+
+
+async def test_accept_invite_while_queued(party_service, player_factory):
+    sender = player_factory(player_id=1)
+    receiver = player_factory(player_id=2)
+
+    party_service.invite_player_to_party(sender, receiver)
+    sender.state = PlayerState.SEARCHING_LADDER
+
+    with pytest.raises(ClientError):
+        await party_service.accept_invite(receiver, sender)
 
 
 async def test_invite_player_to_party_not_owner(party_service, player_factory):


### PR DESCRIPTION
For now I'm still using the `ClientError` copout, but I have been thinking about ways to do it better in a future PR.

Fixes #691