### PR TITLE
Use correct rating type when choosing a map pool

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -354,7 +354,7 @@ class LadderService(Service):
                 limit=config.LADDER_ANTI_REPETITION_LIMIT
             )
             rating = min(
-                newbie_adjusted_ladder_mean(player)
+                newbie_adjusted_mean(player, queue.rating_type)
                 for player in all_players
             )
             pool = queue.get_map_pool_for_rating(rating)
@@ -510,10 +510,10 @@ def _team_name(team: List[Player]) -> str:
     return f"Team {name}"
 
 
-def newbie_adjusted_ladder_mean(player: Player):
-    """Get ladder rating mean with new player's always returning a mean of 0"""
-    if player.game_count[RatingType.LADDER_1V1] > config.NEWBIE_MIN_GAMES:
-        return player.ratings[RatingType.LADDER_1V1][0]
+def newbie_adjusted_mean(player: Player, rating_type: str) -> float:
+    """Get rating mean with new player's always returning a mean of 0"""
+    if player.game_count[rating_type] > config.NEWBIE_MIN_GAMES:
+        return player.ratings[rating_type][0]
     else:
         return 0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ def make_player(
     state=PlayerState.IDLE,
     global_rating=None,
     ladder_rating=None,
-    numGames=0,
+    global_games=0,
     ladder_games=0,
     **kwargs
 ):
@@ -158,7 +158,7 @@ def make_player(
     }.items() if v is not None}
 
     games = {
-        RatingType.GLOBAL: numGames,
+        RatingType.GLOBAL: global_games,
         RatingType.LADDER_1V1: ladder_games
     }
 
@@ -174,7 +174,7 @@ def player_factory():
         state=PlayerState.IDLE,
         global_rating=None,
         ladder_rating=None,
-        numGames=0,
+        global_games=0,
         ladder_games=0,
         with_lobby_connection=False,
         **kwargs
@@ -183,7 +183,7 @@ def player_factory():
             state=state,
             global_rating=global_rating,
             ladder_rating=ladder_rating,
-            numGames=numGames,
+            global_games=global_games,
             ladder_games=ladder_games,
             login=login,
             **kwargs

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -597,6 +597,36 @@ async def test_start_game_map_selection_pros(
     full_map_pool.choose_map.assert_called_once()
 
 
+async def test_start_game_map_selection_rating_type(
+    ladder_service: LadderService, player_factory
+):
+    p1 = player_factory(
+        ladder_rating=(2000, 50),
+        ladder_games=1000,
+        global_rating=(1500, 500),
+        global_games=0
+    )
+    p2 = player_factory(
+        ladder_rating=(2000, 50),
+        ladder_games=1000,
+        global_rating=(1500, 500),
+        global_games=0
+    )
+
+    queue = ladder_service.queues["ladder1v1"]
+    queue.rating_type = RatingType.GLOBAL
+    queue.map_pools.clear()
+    newbie_map_pool = mock.Mock()
+    full_map_pool = mock.Mock()
+    queue.add_map_pool(newbie_map_pool, None, 500)
+    queue.add_map_pool(full_map_pool, 500, None)
+
+    await ladder_service.start_game([p1], [p2], queue)
+
+    newbie_map_pool.choose_map.assert_called_once()
+    full_map_pool.choose_map.assert_not_called()
+
+
 async def test_get_ladder_history(ladder_service: LadderService, players):
     ladder1v1_queue_id = 1
     history = await ladder_service.get_game_history(


### PR DESCRIPTION
The map pool selection was still hardcoded to use ladder rating, I must have missed this spot when switching to getting the rating type from the queue.