### PR TITLE
Improve matchmaking log messages

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -904,8 +904,8 @@ class Game():
     def __hash__(self):
         return self.id.__hash__()
 
-    def __str__(self):
-        return "Game({},{},{},{})".format(
-            self.id, self.host.login if self.host else "", self.map_file_path,
-            len(self.players)
+    def __str__(self) -> str:
+        return (
+            f"Game({self.id}, {self.host.login if self.host else ''}, "
+            f"{self.map_file_path})"
         )

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -195,9 +195,7 @@ class LadderService(Service):
 
             self._searches[player][queue_name] = search
 
-        self._logger.info(
-            "%s are searching for '%s': %s", players, queue_name, search
-        )
+        self._logger.info("%s started searching for %s", search, queue_name)
 
         asyncio.create_task(queue.search(search))
 
@@ -339,7 +337,10 @@ class LadderService(Service):
         assert len(team1) == len(team2)
 
         self._logger.debug(
-            "Starting %s game between %s and %s", queue.name, team1, team2
+            "Starting %s game between %s and %s",
+            queue.name,
+            [p.login for p in team1],
+            [p.login for p in team2]
         )
         game = None
         try:

--- a/server/matchmaker/algorithm.py
+++ b/server/matchmaker/algorithm.py
@@ -247,7 +247,7 @@ class _MatchingGraph:
 
     @staticmethod
     def is_possible_match(search: Search, other: Search, quality: float) -> bool:
-        log_string = "Quality between %s and %s: %s thresholds: [%s, %s]."
+        log_string = "Quality between %s and %s: %.3f thresholds: [%.3f, %.3f]."
         log_args = (
             search, other, quality,
             search.match_threshold, other.match_threshold

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -204,20 +204,21 @@ class Search:
         :param other:
         :return:
         """
-        self._logger.info("Matched %s with %s", self.players, other.players)
+        self._logger.info("Matched %s with %s", self, other)
 
         self.on_matched(self, other)
 
         for player, raw_rating in zip(self.players, self.raw_ratings):
             if self.is_ladder1v1_search() and self._is_ladder_newbie(player):
                 mean, dev = raw_rating
-                adjusted_mean = self.adjusted_rating(player)
-                self._logger.info("Adjusted mean rating for {player} with {ladder_games} games from {mean} to {adjusted_mean}".format(
-                    player=player,
-                    ladder_games=player.game_count[RatingType.LADDER_1V1],
-                    mean=mean,
-                    adjusted_mean=adjusted_mean
-                ))
+                adjusted_mean, adjusted_dev = self.adjusted_rating(player)
+                self._logger.info(
+                    "Adjusted mean rating for %s with %d games from %.1f to %.1f",
+                    player.login,
+                    player.game_count[self.rating_type],
+                    mean,
+                    adjusted_mean
+                )
         self._match.set_result(other)
 
     async def await_match(self):
@@ -234,10 +235,20 @@ class Search:
         """
         self._match.cancel()
 
-    def __str__(self):
-        return "Search({}, {}, {})".format(self.players, self.match_threshold, self.search_expansion)
+    def __str__(self) -> str:
+        return (
+            f"Search({self.rating_type}, {self._players_repr()}, threshold="
+            f"{self.match_threshold:.2}, expansion={self.search_expansion:.2})"
+        )
 
-    def __repr__(self):
+    def _players_repr(self) -> str:
+        contents = ', '.join(
+            f"Player({p.login}, {p.id}, {p.ratings[self.rating_type]})"
+            for p in self.players
+        )
+        return f"[{contents}]"
+
+    def __repr__(self) -> str:
         """For debugging"""
         return f"Search({[p.login for p in self.players]})"
 


### PR DESCRIPTION
Before it was difficult to sift through the log output for matchmaker messages because each player object would log both ladder and global ratings, at least one of which would be completely irrelevant. Now we log only the rating that is actually being used by the algorithm.

Here's what a matching lifecycle between two new players looks like now:
```
TRACE    Jan 24  16:07:56 LobbyConnection                << test: {'command': 'game_matchmaking', 'state': 'start', 'mod': 'ladder1v1', 'faction': 'uef'}
TRACE    Jan 24  16:07:56 LobbyConnection                >> test: {'command': 'search_info', 'queue_name': 'ladder1v1', 'state': 'start'}
INFO     Jan 24  16:07:56 LadderService                  Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0) started searching for ladder1v1
TRACE    Jan 24  16:07:56 LobbyServer                    ]]: {'command': 'matchmaker_info', 'queues': [{'queue_name': 'ladder1v1', 'queue_pop_time': '2021-01-25T01:08:04.543290+00:00', 'num_players': 1, 'boundary_80s': [(1050, 1450)], 'boundary_75s': [(1150, 1350)], 'team_size': 1}]}
TRACE    Jan 24  16:07:57 LobbyConnection                << Rhiza: {'command': 'game_matchmaking', 'state': 'start', 'mod': 'ladder1v1', 'faction': 'uef'}
TRACE    Jan 24  16:07:57 LobbyConnection                >> Rhiza: {'command': 'search_info', 'queue_name': 'ladder1v1', 'state': 'start'}
INFO     Jan 24  16:07:57 LadderService                  Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0) started searching for ladder1v1
TRACE    Jan 24  16:07:57 LobbyServer                    ]]: {'command': 'matchmaker_info', 'queues': [{'queue_name': 'ladder1v1', 'queue_pop_time': '2021-01-25T01:08:04.543290+00:00', 'num_players': 2, 'boundary_80s': [(1050, 1450), (530, 930)], 'boundary_75s': [(1150, 1350), (630, 830)], 'team_size': 1}]}
DEBUG    Jan 24  16:08:04 PopTimer                       Queue rate for ladder1v1: 0.133339/s
WARNING  Jan 24  16:08:04 PopTimer                       Required time (60.00s) for ladder1v1 is larger than max pop time (30s). Consider increasing the max pop time
INFO     Jan 24  16:08:04 MatchmakerQueue                Searching for matches: ladder1v1
DEBUG    Jan 24  16:08:04 Matchmaker                     Matching with stable marriage...
DEBUG    Jan 24  16:08:04 _MatchingGraph                 Quality between Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0) and Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0): 0.339 thresholds: [0.710, 0.774]. Will be discarded for stable marriage.
DEBUG    Jan 24  16:08:04 Matchmaker                     Matching randomly for remaining newbies...
DEBUG    Jan 24  16:08:04 MatchmakingPolicy              Matching Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0) and Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0) (<class 'server.matchmaker.algorithm.RandomlyMatchNewbies'>)
INFO     Jan 24  16:08:04 Search                         Matched Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0) with Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0)
INFO     Jan 24  16:08:04 Search                         Adjusted mean rating for Rhiza with 2 games from 1650.0 to 730.0
INFO     Jan 24  16:08:04 Search                         Matched Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0) with Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0)
INFO     Jan 24  16:08:04 Search                         Adjusted mean rating for test with 5 games from 2000.0 to 1250.0
TRACE    Jan 24  16:08:04 LobbyConnection                >> Rhiza: {'command': 'match_found', 'queue_name': 'ladder1v1'}
TRACE    Jan 24  16:08:04 LobbyConnection                >> test: {'command': 'match_found', 'queue_name': 'ladder1v1'}
INFO     Jan 24  16:08:04 PopTimer                       Next ladder1v1 wave happening in 29s
DEBUG    Jan 24  16:08:04 MatchmakerQueue                Search complete: Search(ladder_1v1, [Player(Rhiza, 3, (1650.0, 62.52))], threshold=0.77, expansion=0.0)
DEBUG    Jan 24  16:08:04 MatchmakerQueue                Search complete: Search(ladder_1v1, [Player(test, 1, (2000.0, 125.0))], threshold=0.71, expansion=0.0)
DEBUG    Jan 24  16:08:04 LadderService                  Starting ladder1v1 game between ['Rhiza'] and ['test']
DEBUG    Jan 24  16:08:04 LadderGame.41956               Game(41956, Rhiza, maps/None.zip) created
DEBUG    Jan 24  16:08:04 LadderService                  Starting ladder game: Game(41956, Rhiza, maps/scmp_015.v0003.zip)
```