### PR TITLE
Issue/#707 fix disconnect handlers not always triggering

### DIFF
--- a/integration_tests/test_matchmaking.py
+++ b/integration_tests/test_matchmaking.py
@@ -158,3 +158,17 @@ async def test_multiqueue(client_factory):
         "queue_name": "tmm2v2",
         "state": "stop"
     }
+
+
+async def test_party_cleanup_on_abort(client_factory):
+    for _ in range(2):
+        client, _ = await client_factory.login("test")
+        await client.read_until_command("game_info")
+
+        # This would time out on failure.
+        await client.join_queue("tmm2v2")
+
+        # Trigger an abort
+        await client.send_message({"some": "garbage"})
+
+        # Loop to reconnect

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -149,13 +149,13 @@ class ServerInstance(object):
 
             if dirty_queues:
                 self.write_broadcast({
-                        "command": "matchmaker_info",
-                        "queues": [queue.to_dict() for queue in dirty_queues]
-                    }
-                )
+                    "command": "matchmaker_info",
+                    "queues": [queue.to_dict() for queue in dirty_queues]
+                })
 
             if dirty_players:
-                self.write_broadcast({
+                self.write_broadcast(
+                    {
                         "command": "player_info",
                         "players": [player.to_dict() for player in dirty_players]
                     },
@@ -199,6 +199,7 @@ class ServerInstance(object):
         ctx = ServerContext(
             f"{self.name}[{protocol_class.__name__}]",
             self.connection_factory,
+            list(self.services.values()),
             protocol_class
         )
         self.contexts.add(ctx)

--- a/server/core/service.py
+++ b/server/core/service.py
@@ -42,6 +42,12 @@ class Service(metaclass=ServiceMeta):
         """
         pass  # pragma: no cover
 
+    def on_connection_lost(self, conn) -> None:
+        """
+        Called every time a connection ends.
+        """
+        pass  # pragma: no cover
+
 
 def create_services(injectables: Dict[str, object] = {}) -> Dict[str, Service]:
     """

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -482,7 +482,11 @@ class LadderService(Service):
                 ])
         return result
 
-    async def on_connection_lost(self, player):
+    def on_connection_lost(self, conn: "LobbyConnection") -> None:
+        if not conn.player:
+            return
+
+        player = conn.player
         self.cancel_search(player)
         del self._searches[player]
         if player in self._informed_players:

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -455,7 +455,7 @@ class LadderService(Service):
         self,
         players: List[Player],
         queue_id: int,
-        limit=3
+        limit: int = 3
     ) -> List[int]:
         async with self._db.acquire() as conn:
             result = []

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -832,7 +832,7 @@ class LobbyConnection:
 
         party = self.party_service.get_party(self.player)
 
-        if self.player is not party.owner:
+        if self.player != party.owner:
             raise ClientError(
                 "Only the party owner may enter the party into a queue.",
                 recoverable=True

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -275,3 +275,16 @@ class PlayerService(Service):
                 self._logger.debug(
                     "Could not send shutdown message to %s: %s", player, ex
                 )
+
+    def on_connection_lost(self, conn: "LobbyConnection") -> None:
+        if not conn.player:
+            return
+
+        self.remove_player(conn.player)
+
+        self._logger.debug(
+            "Removed player %d, %s, %d",
+            conn.player.id,
+            conn.player.login,
+            conn.session
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,6 +194,7 @@ def player_factory():
             # to live for the full lifetime of the player object
             p.__owned_lobby_connection = asynctest.create_autospec(LobbyConnection)
             p.lobby_connection = p.__owned_lobby_connection
+            p.lobby_connection.player = p
         return p
 
     return make

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -2,44 +2,55 @@ import asyncio
 import contextlib
 from unittest import mock
 
+import asynctest
 import pytest
 from asynctest import CoroutineMock, exhaust_callbacks
 
 from server import ServerContext
+from server.core import Service
 from server.lobbyconnection import LobbyConnection
 from server.protocol import DisconnectedError, QDataStreamProtocol
 
 pytestmark = pytest.mark.asyncio
 
 
+class MockConnection:
+    def __init__(self):
+        self.protocol = None
+        self.peername = None
+        self.user_agent = None
+        self.version = None
+        self.on_connection_lost = CoroutineMock()
+
+    async def on_connection_made(self, protocol, peername):
+        self.protocol = protocol
+        self.peername = peername
+        self.protocol.writer.write_eof()
+        self.protocol.reader.feed_eof()
+
+    async def on_message_received(self, msg):
+        pass
+
+
 @pytest.fixture
-def mock_server(event_loop):
-    class MockServer:
-        def __init__(self):
-            self.protocol, self.peername, self.user_agent, self.version = None, None, None, None
-            self.on_connection_lost = CoroutineMock()
-
-        async def on_connection_made(self, protocol, peername):
-            self.protocol = protocol
-            self.peername = peername
-            self.protocol.writer.write_eof()
-            self.protocol.reader.feed_eof()
-
-        async def on_message_received(self, msg):
-            pass
-
-    return MockServer()
+def mock_connection():
+    return MockConnection()
 
 
 @pytest.fixture
-async def mock_context(mock_server):
-    ctx = ServerContext("TestServer", lambda: mock_server)
+def mock_service():
+    return asynctest.create_autospec(Service)
+
+
+@pytest.fixture
+async def mock_context(mock_connection, mock_service):
+    ctx = ServerContext("TestServer", lambda: mock_connection, [mock_service])
     yield await ctx.listen("127.0.0.1", None), ctx
     ctx.close()
 
 
 @pytest.fixture
-async def context():
+async def context(mock_service):
     def make_connection() -> LobbyConnection:
         return LobbyConnection(
             database=mock.Mock(),
@@ -51,22 +62,28 @@ async def context():
             party_service=mock.Mock()
         )
 
-    ctx = ServerContext("TestServer", make_connection)
+    ctx = ServerContext("TestServer", make_connection, [mock_service])
     yield await ctx.listen("127.0.0.1", None), ctx
     ctx.close()
 
 
-async def test_serverside_abort(event_loop, mock_context, mock_server):
+async def test_serverside_abort(
+    event_loop,
+    mock_context,
+    mock_connection,
+    mock_service
+):
     srv, ctx = mock_context
     (reader, writer) = await asyncio.open_connection(*srv.sockets[0].getsockname())
     proto = QDataStreamProtocol(reader, writer)
     await proto.send_message({"some_junk": True})
     await exhaust_callbacks(event_loop)
 
-    mock_server.on_connection_lost.assert_any_call()
+    mock_connection.on_connection_lost.assert_any_call()
+    mock_service.on_connection_lost.assert_called_once()
 
 
-async def test_connection_broken_external(context, mock_server):
+async def test_connection_broken_external(context):
     """
     When the connection breaks while the server is calling protocol.send from
     somewhere other than the main read - response loop. Make sure that this

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -234,16 +234,16 @@ async def test_write_rating_progress(ladder_service: LadderService, player_facto
     )
 
     ladder_service.write_rating_progress(p1, RatingType.LADDER_1V1)
-
     # Message is sent after the first call
     p1.lobby_connection.write.assert_called_once()
+
     ladder_service.write_rating_progress(p1, RatingType.LADDER_1V1)
     p1.lobby_connection.write.reset_mock()
     # But not after the second
     p1.lobby_connection.write.assert_not_called()
-    await ladder_service.on_connection_lost(p1)
-    ladder_service.write_rating_progress(p1, RatingType.LADDER_1V1)
 
+    ladder_service.on_connection_lost(p1.lobby_connection)
+    ladder_service.write_rating_progress(p1, RatingType.LADDER_1V1)
     # But it is called if the player relogs
     p1.lobby_connection.write.assert_called_once()
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1001,18 +1001,10 @@ async def test_command_matchmaker_info(
 
 
 async def test_connection_lost(lobbyconnection):
+    lobbyconnection.game_connection = asynctest.create_autospec(GameConnection)
     await lobbyconnection.on_connection_lost()
 
-    lobbyconnection.ladder_service.on_connection_lost.assert_called_once_with(lobbyconnection.player)
-    lobbyconnection.player_service.remove_player.assert_called_once_with(lobbyconnection.player)
-
-
-async def test_connection_lost_no_player(lobbyconnection):
-    lobbyconnection.player = None
-    await lobbyconnection.on_connection_lost()
-
-    lobbyconnection.ladder_service.on_connection_lost.assert_not_called()
-    lobbyconnection.player_service.remove_player.assert_not_called()
+    lobbyconnection.game_connection.on_connection_lost.assert_called_once()
 
 
 async def test_connection_lost_send(lobbyconnection, mock_protocol):

--- a/tests/unit_tests/test_party_service.py
+++ b/tests/unit_tests/test_party_service.py
@@ -257,10 +257,10 @@ async def test_set_factions_creates_party(party_service, player_factory):
 
 
 async def test_player_disconnected(party_service, player_factory):
-    sender = player_factory(player_id=1)
+    sender = player_factory(player_id=1, with_lobby_connection=True)
     receiver = player_factory(player_id=2)
 
     party_service.invite_player_to_party(sender, receiver)
-    await party_service.on_player_disconnected(sender)
+    party_service.on_connection_lost(sender.lobby_connection)
 
     assert sender not in party_service.player_parties


### PR DESCRIPTION
This one's slightly more meaty than my recent PR's :)

I refactored `on_connection_lost` so it is triggered from `ServerContext` for all services whenever a connection closes or is forcibly closed. It seems like there was some cleanup code that was duplicated in `LobbyConnection.abort` and `LobbyConnection.on_connection_lost` which had gotten out of sync at some point meaning that if a player's connection was closed via `abort`, then the disconnect logic in `LadderService` and `PartyService` would not be triggered. This was causing some old `Player` objects to outlive their `LobbyConnection`'s and causing the `self.player is not party.owner` check to fail. Therefore, I've also refactored that check to use `==` comparison instead of `is`.

Closes #707 