### PR TITLE
Feature/#713 Generalize newbie rating adjustments

### DIFF
--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -71,7 +71,7 @@ async def test_info_message(lobby_server):
         boundaries = queue["boundary_80s"]
 
         if queue["queue_name"] == "tmm2v2":
-            assert boundaries == [[1300, 1700]]
+            assert boundaries == [[300, 700]]
         else:
             assert boundaries == []
 


### PR DESCRIPTION
This makes random newbie matching apply to any rating type and for any team size. 

Team with at least one newbie and no top-rated players will be matched randomly amongst each other if no quality game is found. However, if there are an odd number of newbie teams, the last newbie team can only match with a non-newbie team that has at least one failed matching attempt. If a team has a top-rated player, that team will not be eligible for random matching at all.

Closes #713