### PR TITLE
Increase matchmaker game timeout

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -439,7 +439,7 @@ class LadderService(Service):
                     for guest in all_guests
                     if guest.lobby_connection is not None
                 ])
-            await game.wait_launched(30)
+            await game.wait_launched(30 + 10 * len(all_guests))
             self._logger.debug("Ladder game launched successfully")
         except Exception:
             if game:


### PR DESCRIPTION
Adds 10 seconds to the game launch timeout for each connection that a client needs to establish. For example in 2v2, a client needs to connect to 3 other players, so we add 30 seconds to the timeout. The total launch timeouts for each possible game size are summarized below.

| Game Type | Number of Players | Launch Timeout |
| :--------------- | :-----------------------: | ---------------------: |
| 1v1              |               2               |                    0:40 |
| 2v2              |               4               |                    1:00 |
| 3v3              |               6               |                    1:20 |
| 4v4              |               8               |                    1:40 |
| 5v5              |              10              |                    2:00 |
| 6v6              |              12              |                    2:20 |
| 7v7              |              14              |                    2:40 |
| 8v8              |              16              |                    3:00 |

Note there is still an additional 30 second game hosting timeout, so the total allowed time to set up a matchmaker game would be the above times + 30 seconds.