### PR TITLE
Fix pop timer crash

### DIFF
--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -271,9 +271,8 @@ class CombinedSearch(Search):
         return list(itertools.chain(*[s.raw_ratings for s in self.searches]))
 
     @property
-    def failed_matching_attempts(self) -> List[int]:
-        """Used for logging so returning a different type here is fine"""
-        return [search.failed_matching_attempts for search in self.searches]
+    def failed_matching_attempts(self) -> int:
+        return max(search.failed_matching_attempts for search in self.searches)
 
     def register_failed_matching_attempt(self):
         for search in self.searches:

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -78,6 +78,8 @@ insert into login (id, login, email, password, steamid, create_time) values
   (102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
   (103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
   (104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
+  (105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
+  (106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
   (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
   (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
   (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
@@ -118,7 +120,9 @@ insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderbo
   (101, 1500, 500, 0, 1),
   (101, 1500, 500, 0, 2),
   (102, 1500, 500, 0, 1),
-  (102, 1500, 500, 0, 2)
+  (102, 1500, 500, 0, 2),
+  (105, 1400, 150, 20, 3),
+  (106, 1500, 75, 20, 3)
 ;
 
 -- legacy table for global rating

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -38,7 +38,7 @@ async def join_game(proto: Protocol, uid: int):
 
 
 async def client_response(proto):
-    msg = await read_until_command(proto, "game_launch")
+    msg = await read_until_command(proto, "game_launch", timeout=5)
     await open_fa(proto)
     return msg
 

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -207,13 +207,20 @@ async def test_search_await(matchmaker_players):
 
 def test_combined_search_attributes(matchmaker_players):
     p1, p2, p3, _, _, _ = matchmaker_players
-    search = CombinedSearch(Search([p1, p2]), Search([p3]))
+    s1 = Search([p1, p2])
+    s2 = Search([p3])
+    s2.register_failed_matching_attempt()
+    search = CombinedSearch(s1, s2)
     assert search.players == [p1, p2, p3]
     assert search.raw_ratings == [
         p1.ratings[RatingType.LADDER_1V1],
         p2.ratings[RatingType.LADDER_1V1],
         p3.ratings[RatingType.LADDER_1V1]
     ]
+    assert search.failed_matching_attempts == 1
+
+    search.register_failed_matching_attempt()
+    assert search.failed_matching_attempts == 2
 
 
 def test_queue_time_until_next_pop(queue_factory):

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -109,8 +109,16 @@ def test_search_threshold_of_team_new_players_is_low(player_factory):
 
 @given(rating1=st_rating(), rating2=st_rating())
 def test_search_quality_equivalence(player_factory, rating1, rating2):
-    p1 = player_factory("Player1", ladder_rating=rating1)
-    p2 = player_factory("Player2", ladder_rating=rating2)
+    p1 = player_factory(
+        "Player1",
+        ladder_rating=rating1,
+        with_lobby_connection=False
+    )
+    p2 = player_factory(
+        "Player2",
+        ladder_rating=rating2,
+        with_lobby_connection=False
+    )
     s1 = Search([p1])
     s2 = Search([p2])
     assert s1.quality_with(s2) == s2.quality_with(s1)


### PR DESCRIPTION
It was not directly the fault of the pop timer, but rather an exception that could sometimes occur during random newbie matching. `CombinedSearch` objects would return a list for `failed_matching_attempts` instead of an integer. This has been fixed and I made sure to add an integration test that covers newbie matching with two solo queue-ers who were placed together by the team creation code. I also wrapped the pop timer loop contents in a try block, since this sort of error should really only be failing the current matching attempt, and not crashing the entire timer loop.