### PR TITLE
Issue/#721 non ascii in matchmaker game names

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,5 @@
-comment: false
+comment:
+  layout: "files"
 
 coverage:
   status:

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -136,12 +136,19 @@ class Game():
     @name.setter
     def name(self, value: str):
         """
-        Avoids the game name to crash the mysql INSERT query by being longer
-        than the column's max size.
+        Verifies that names only contain ascii characters.
         """
         if not value.isascii():
             raise ValueError("Name must be ascii!")
 
+        self.set_name_unchecked(value)
+
+    def set_name_unchecked(self, value: str):
+        """
+        Sets the game name without doing any validity checks.
+
+        Truncates the game name to avoid crashing mysql INSERT statements.
+        """
         max_len = game_stats.c.gameName.type.length
         self._name = value[:max_len]
 

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -373,13 +373,14 @@ class LadderService(Service):
                 game_class=LadderGame,
                 game_mode=queue.featured_mod,
                 host=host,
-                name=game_name(team1, team2),
+                name="Matchmaker Game",
                 matchmaker_queue_id=queue.id,
                 rating_type=queue.rating_type,
                 max_players=len(all_players)
             )
             game.init_mode = InitMode.AUTO_LOBBY
             game.map_file_path = map_path
+            game.set_name_unchecked(game_name(team1, team2))
 
             def get_player_mean(player):
                 return player.ratings[queue.rating_type][0]

--- a/server/players.py
+++ b/server/players.py
@@ -166,7 +166,9 @@ class Player:
                 f"{self.ratings[RatingType.LADDER_1V1]})")
 
     def __repr__(self) -> str:
-        return self.__str__()
+        return (f"Player(login={self.login}, session={self.session}, "
+                f"id={self.id}, ratings={dict(self.ratings)}, "
+                f"clan={self.clan}, game_count={dict(self.game_count)})")
 
     def __hash__(self) -> int:
         return self.id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,11 +180,13 @@ def make_game(database, uid, players):
 
 
 def make_player(
+    login=None,
     state=PlayerState.IDLE,
     global_rating=None,
     ladder_rating=None,
     global_games=0,
     ladder_games=0,
+    with_lobby_connection=False,
     **kwargs
 ):
     ratings = {k: v for k, v in {
@@ -197,42 +199,22 @@ def make_player(
         RatingType.LADDER_1V1: ladder_games
     }
 
-    p = Player(ratings=ratings, game_count=games, **kwargs)
+    p = Player(login=login, ratings=ratings, game_count=games, **kwargs)
     p.state = state
+
+    if with_lobby_connection:
+        # lobby_connection is a weak reference, but we want the mock
+        # to live for the full lifetime of the player object
+        p.__owned_lobby_connection = asynctest.create_autospec(LobbyConnection)
+        p.lobby_connection = p.__owned_lobby_connection
+        p.lobby_connection.player = p
+
     return p
 
 
 @pytest.fixture(scope="session")
 def player_factory():
-    def make(
-        login=None,
-        state=PlayerState.IDLE,
-        global_rating=None,
-        ladder_rating=None,
-        global_games=0,
-        ladder_games=0,
-        with_lobby_connection=False,
-        **kwargs
-    ):
-        p = make_player(
-            state=state,
-            global_rating=global_rating,
-            ladder_rating=ladder_rating,
-            global_games=global_games,
-            ladder_games=ladder_games,
-            login=login,
-            **kwargs
-        )
-
-        if with_lobby_connection:
-            # lobby_connection is a weak reference, but we want the mock
-            # to live for the full lifetime of the player object
-            p.__owned_lobby_connection = asynctest.create_autospec(LobbyConnection)
-            p.lobby_connection = p.__owned_lobby_connection
-            p.lobby_connection.player = p
-        return p
-
-    return make
+    return make_player
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def make_player(
     ladder_rating=None,
     global_games=0,
     ladder_games=0,
-    with_lobby_connection=False,
+    lobby_connection_spec=None,
     **kwargs
 ):
     ratings = {k: v for k, v in {
@@ -202,10 +202,19 @@ def make_player(
     p = Player(login=login, ratings=ratings, game_count=games, **kwargs)
     p.state = state
 
-    if with_lobby_connection:
+    if lobby_connection_spec:
+        if not isinstance(lobby_connection_spec, str):
+            conn = mock.Mock(spec=lobby_connection_spec)
+        elif lobby_connection_spec == "mock":
+            conn = mock.Mock(spec=LobbyConnection)
+        elif lobby_connection_spec == "auto":
+            conn = asynctest.create_autospec(LobbyConnection)
+        else:
+            raise ValueError(f"Unknown spec type '{lobby_connection_spec}'")
+
         # lobby_connection is a weak reference, but we want the mock
         # to live for the full lifetime of the player object
-        p.__owned_lobby_connection = asynctest.create_autospec(LobbyConnection)
+        p.__owned_lobby_connection = conn
         p.lobby_connection = p.__owned_lobby_connection
         p.lobby_connection.player = p
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -149,7 +149,7 @@ def game_add_players(player_factory):
                 player_id=i+1,
                 login=f"Player {i + 1}",
                 global_rating=(1500, 500),
-                with_lobby_connection=False
+                lobby_connection_spec=None
             )
             players.append(p)
 

--- a/tests/unit_tests/strategies.py
+++ b/tests/unit_tests/strategies.py
@@ -1,0 +1,56 @@
+# Custom hypothesis strategies
+
+import string
+
+from hypothesis import strategies as st
+
+from server.matchmaker import Search
+from tests.conftest import make_player
+
+
+@st.composite
+def st_rating(draw):
+    """Strategy for generating rating tuples"""
+    return (
+        draw(st.floats(min_value=-100., max_value=2500.)),
+        draw(st.floats(min_value=0.001, max_value=500.))
+    )
+
+
+@st.composite
+def st_players(draw, name=None, **kwargs):
+    """Strategy for generating Player objects"""
+    return make_player(
+        ladder_rating=(draw(st_rating())),
+        ladder_games=draw(st.integers(0, 1000)),
+        login=draw(st.text(
+            alphabet=list(string.ascii_letters + string.digits + "_-"),
+            min_size=1,
+            max_size=42
+        )) if name is None else name,
+        clan=draw(st.text(min_size=1, max_size=3)),
+        **kwargs
+    )
+
+
+@st.composite
+def st_searches(draw, num_players=1):
+    """Strategy for generating Search objects"""
+    return Search([
+        draw(st_players(f"p{i}")) for i in range(num_players)
+    ])
+
+
+@st.composite
+def st_searches_list(draw, min_players=1, max_players=10, max_size=30):
+    """Strategy for generating a list of Search objects"""
+    return draw(
+        st.lists(
+            st_searches(
+                num_players=draw(
+                    st.integers(min_value=min_players, max_value=max_players)
+                )
+            ),
+            max_size=max_size
+        )
+    )

--- a/tests/unit_tests/test_game_rating.py
+++ b/tests/unit_tests/test_game_rating.py
@@ -107,7 +107,6 @@ def add_players_with_rating(player_factory, game, ratings, teams):
                 player_id=i,
                 global_rating=rating,
                 ladder_rating=rating,
-                with_lobby_connection=False,
             ),
             team,
         )
@@ -857,7 +856,6 @@ async def test_single_wrong_report_still_rated_correctly(game: Game, player_fact
             login=f"{player_id}",
             player_id=player_id,
             global_rating=Rating(old_rating, 250),
-            with_lobby_connection=False,
         )
         for team in log_dict["teams"].values()
         for player_id in team

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -60,7 +60,7 @@ def test_game_info_invalid():
 
 @pytest.fixture
 def mock_player(player_factory):
-    return player_factory("Dummy", player_id=42, with_lobby_connection=False)
+    return player_factory("Dummy", player_id=42, lobby_connection_spec=None)
 
 
 @pytest.fixture
@@ -197,7 +197,7 @@ async def test_command_create_account_returns_error(lobbyconnection):
 
 async def test_double_login(lobbyconnection, mock_players, player_factory):
     lobbyconnection.check_policy_conformity = CoroutineMock(return_value=True)
-    old_player = player_factory(with_lobby_connection=True)
+    old_player = player_factory(lobby_connection_spec="auto")
     old_player.lobby_connection.player = old_player
     mock_players.get_player.return_value = old_player
 
@@ -219,7 +219,7 @@ async def test_double_login(lobbyconnection, mock_players, player_factory):
 async def test_double_login_disconnected(lobbyconnection, mock_players, player_factory):
     lobbyconnection.abort = CoroutineMock()
     lobbyconnection.check_policy_conformity = CoroutineMock(return_value=True)
-    old_player = player_factory(with_lobby_connection=True)
+    old_player = player_factory(lobby_connection_spec="auto")
     mock_players.get_player.return_value = old_player
 
     old_player.lobby_connection.send_warning.side_effect = DisconnectedError("Test disconnect")
@@ -552,7 +552,7 @@ async def test_coop_list(mocker, lobbyconnection):
 async def test_command_admin_closelobby(mocker, lobbyconnection, player_factory):
     player = lobbyconnection.player
     player.id = 1
-    tuna = player_factory("Tuna", player_id=55, with_lobby_connection=True)
+    tuna = player_factory("Tuna", player_id=55, lobby_connection_spec="auto")
     data = {
         player.id: player,
         tuna.id: tuna
@@ -571,7 +571,7 @@ async def test_command_admin_closelobby(mocker, lobbyconnection, player_factory)
 async def test_command_admin_closeFA(lobbyconnection, player_factory):
     player = lobbyconnection.player
     player.id = 1
-    tuna = player_factory("Tuna", player_id=55, with_lobby_connection=True)
+    tuna = player_factory("Tuna", player_id=55, lobby_connection_spec="auto")
     data = {
         player.id: player,
         tuna.id: tuna
@@ -716,7 +716,7 @@ async def test_broadcast(lobbyconnection: LobbyConnection, player_factory):
     player = lobbyconnection.player
     player.lobby_connection = lobbyconnection
     player.id = 1
-    tuna = player_factory("Tuna", player_id=55, with_lobby_connection=True)
+    tuna = player_factory("Tuna", player_id=55, lobby_connection_spec="auto")
     data = {
         player.id: player,
         tuna.id: tuna
@@ -741,7 +741,7 @@ async def test_broadcast_during_disconnect(lobbyconnection: LobbyConnection, pla
     # To simulate when a player has been recently disconnected so that they
     # still appear in the player_service list, but their lobby_connection
     # object has already been destroyed
-    tuna = player_factory("Tuna", player_id=55, with_lobby_connection=False)
+    tuna = player_factory("Tuna", player_id=55, lobby_connection_spec="auto")
     data = {
         player.id: player,
         tuna.id: tuna
@@ -763,7 +763,7 @@ async def test_broadcast_connection_error(lobbyconnection: LobbyConnection, play
     player = lobbyconnection.player
     player.lobby_connection = lobbyconnection
     player.id = 1
-    tuna = player_factory("Tuna", player_id=55, with_lobby_connection=True)
+    tuna = player_factory("Tuna", player_id=55, lobby_connection_spec="auto")
     tuna.lobby_connection.write_warning.side_effect = DisconnectedError("Some error")
     data = {
         player.id: player,
@@ -934,7 +934,7 @@ async def test_command_game_matchmaking_not_party_owner(
     mock_player,
     player_factory
 ):
-    party_owner = player_factory(player_id=2, with_lobby_connection=False)
+    party_owner = player_factory(player_id=2, lobby_connection_spec="auto")
     party = PlayerParty(party_owner)
     party.add_player(mock_player)
     lobbyconnection.player.id = 1

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -13,14 +13,7 @@ from server.matchmaker import CombinedSearch, MapPool, PopTimer, Search
 from server.players import PlayerState
 from server.rating import RatingType
 
-
-@st.composite
-def st_rating(draw):
-    """Strategy for generating rating tuples"""
-    return (
-        draw(st.floats(min_value=-100., max_value=2500.)),
-        draw(st.floats(min_value=0.001, max_value=500.))
-    )
+from .strategies import st_rating
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -16,7 +16,7 @@ from server.rating import RatingType
 from .strategies import st_rating
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def player_factory(player_factory):
     return functools.partial(
         player_factory,
@@ -102,16 +102,8 @@ def test_search_threshold_of_team_new_players_is_low(player_factory):
 
 @given(rating1=st_rating(), rating2=st_rating())
 def test_search_quality_equivalence(player_factory, rating1, rating2):
-    p1 = player_factory(
-        "Player1",
-        ladder_rating=rating1,
-        with_lobby_connection=False
-    )
-    p2 = player_factory(
-        "Player2",
-        ladder_rating=rating2,
-        with_lobby_connection=False
-    )
+    p1 = player_factory("Player1", ladder_rating=rating1)
+    p2 = player_factory("Player2", ladder_rating=rating2)
     s1 = Search([p1])
     s2 = Search([p2])
     assert s1.quality_with(s2) == s2.quality_with(s1)

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -9,40 +9,8 @@ from hypothesis import strategies as st
 from server import config
 from server.matchmaker import Search, algorithm
 from server.rating import RatingType
-from tests.conftest import make_player
 
-
-@st.composite
-def st_players(draw, name="Player"):
-    """Strategy for generating Player objects"""
-    return make_player(
-        ladder_rating=(draw(st.floats(0, 2500)), draw(st.floats(1, 500))),
-        ladder_games=draw(st.integers(0, 1000)),
-        login=name
-    )
-
-
-@st.composite
-def st_searches(draw, num_players=1):
-    """Strategy for generating Search objects"""
-    return Search([
-        draw(st_players(f"p{i}")) for i in range(num_players)
-    ])
-
-
-@st.composite
-def st_searches_list(draw, min_players=1, max_players=10, max_size=30):
-    """Strategy for generating a list of Search objects"""
-    return draw(
-        st.lists(
-            st_searches(
-                num_players=draw(
-                    st.integers(min_value=min_players, max_value=max_players)
-                )
-            ),
-            max_size=max_size
-        )
-    )
+from .strategies import st_searches_list
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit_tests/test_matchmaker_queue_algorithm.py
+++ b/tests/unit_tests/test_matchmaker_queue_algorithm.py
@@ -13,7 +13,7 @@ from server.rating import RatingType
 from .strategies import st_searches_list
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def player_factory(player_factory):
     def make(
         mean: int = 1500,
@@ -26,7 +26,7 @@ def player_factory(player_factory):
             ladder_rating=(mean, deviation),
             ladder_games=ladder_games,
             login=name,
-            with_lobby_connection=False,
+            lobby_connection_spec=None,
         )
         return player
     return make

--- a/tests/unit_tests/test_party_service.py
+++ b/tests/unit_tests/test_party_service.py
@@ -21,10 +21,10 @@ async def party_service(game_service):
     await service.shutdown()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def player_factory(player_factory):
     def make(*args, **kwargs):
-        passed_kwargs = dict(with_lobby_connection=False)
+        passed_kwargs = dict(lobby_connection_spec=None)
         passed_kwargs.update(kwargs)
         player = player_factory(*args, **passed_kwargs)
         player.send_message = CoroutineMock()
@@ -257,7 +257,7 @@ async def test_set_factions_creates_party(party_service, player_factory):
 
 
 async def test_player_disconnected(party_service, player_factory):
-    sender = player_factory(player_id=1, with_lobby_connection=True)
+    sender = player_factory(player_id=1, lobby_connection_spec="auto")
     receiver = player_factory(player_id=2)
 
     party_service.invite_player_to_party(sender, receiver)

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -115,7 +115,7 @@ def test_write_message():
 
 
 def test_write_message_while_disconnecting(player_factory):
-    p = player_factory("Test", with_lobby_connection=True)
+    p = player_factory("Test", lobby_connection_spec="auto")
     p.lobby_connection.write.side_effect = DisconnectedError()
 
     # Should not raise


### PR DESCRIPTION
Allow auto generated game names to include non-ascii characters. This lets us keep the team naming based on clans, since some clan tags include non-ascii characters.

I modified a few of the `start_game` tests to use hypothesis for fuzzing player attributes like clan tag, name, rating and number of games. See the commit descriptions.

Closes #721 