### PR TITLE
Add generated map support to ladder_service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-  FAF_DB_VERSION: v110
+  FAF_DB_VERSION: v112
   FLYWAY_VERSION: 7.5.4
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ name: Test
 on: [push, pull_request]
 
 env:
-  FAF_DB_VERSION: v106
+  FAF_DB_VERSION: v110
+  FLYWAY_VERSION: 7.5.4
 
 jobs:
   # Static Analysis
@@ -58,8 +59,8 @@ jobs:
           FLYWAY_LOCATIONS: filesystem:db/migrations
         run: |
           git clone --depth 1 --branch ${FAF_DB_VERSION} https://github.com/FAForever/db
-          wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.5.3/flyway-commandline-6.5.3-linux-x64.tar.gz | tar xz
-          flyway-6.5.3/flyway migrate
+          wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}-linux-x64.tar.gz | tar xz
+          flyway-${FLYWAY_VERSION}/flyway migrate
 
       - name: Install dependencies with pipenv
         run: |

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -256,11 +256,11 @@ map_pool = Table(
 
 map_pool_map_version = Table(
     "map_pool_map_version", metadata,
-    Column("id",            Integer,        primary_key=True),
+    Column("id",             Integer,       primary_key=True),
     Column("map_pool_id",    Integer,       ForeignKey("map_pool.id"),      nullable=False),
     Column("map_version_id", Integer,       ForeignKey("map_version.id")),
-    Column("weight",        Integer,        nullable=False),
-    Column("map_params",    Text),
+    Column("weight",         Integer,       nullable=False),
+    Column("map_params",     Text),
 )
 
 map_version = Table(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -257,7 +257,7 @@ map_pool = Table(
 map_pool_map_version = Table(
     "map_pool_map_version", metadata,
     Column("id",            Integer,        primary_key=True),
-    Column("map_pool_id",   Integer,        ForeignKey("map_pool.id"),      nullable=False),
+    Column("map_pool_id",    Integer,       ForeignKey("map_pool.id"),      nullable=False),
     Column("map_version_id", Integer,       ForeignKey("map_version.id")),
     Column("weight",        Integer,        nullable=False),
     Column("map_params",    Text),

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -256,11 +256,11 @@ map_pool = Table(
 
 map_pool_map_version = Table(
     "map_pool_map_version", metadata,
-    Column("id",                Integer,    primary_key=True),
-    Column("map_pool_id",       Integer,    ForeignKey("map_pool.id"),     nullable=False),
-    Column("map_version_id",    Integer,    ForeignKey("map_version.id"),  nullable=True),
-    Column("weight",            Integer,    nullable=False),
-    Column("map_params",        Text,       nullable=True),
+    Column("id", Integer, primary_key=True),
+    Column("map_pool_id", Integer, ForeignKey("map_pool.id"), nullable=False),
+    Column("map_version_id", Integer, ForeignKey("map_version.id")),
+    Column("weight", Integer, nullable=False),
+    Column("map_params", Text),
 )
 
 map_version = Table(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -256,11 +256,11 @@ map_pool = Table(
 
 map_pool_map_version = Table(
     "map_pool_map_version", metadata,
-    Column("id", Integer, primary_key=True),
-    Column("map_pool_id", Integer, ForeignKey("map_pool.id"), nullable=False),
-    Column("map_version_id", Integer, ForeignKey("map_version.id")),
-    Column("weight", Integer, nullable=False),
-    Column("map_params", Text),
+    Column("id",            Integer,        primary_key=True),
+    Column("map_pool_id",   Integer,        ForeignKey("map_pool.id"),      nullable=False),
+    Column("map_version_id", Integer,       ForeignKey("map_version.id")),
+    Column("weight",        Integer,        nullable=False),
+    Column("map_params",    Text),
 )
 
 map_version = Table(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -256,8 +256,11 @@ map_pool = Table(
 
 map_pool_map_version = Table(
     "map_pool_map_version", metadata,
-    Column("map_pool_id",       Integer, ForeignKey("map_pool.id"),     nullable=False),
-    Column("map_version_id",    Integer, ForeignKey("map_version.id"),  nullable=False),
+    Column("id",                Integer,    primary_key=True),
+    Column("map_pool_id",       Integer,    ForeignKey("map_pool.id"),     nullable=False),
+    Column("map_version_id",    Integer,    ForeignKey("map_version.id"),  nullable=True),
+    Column("weight",            Integer,    nullable=False),
+    Column("map_params",        Text,       nullable=True),
 )
 
 map_version = Table(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -261,6 +261,8 @@ map_pool_map_version = Table(
     Column("map_version_id", Integer,       ForeignKey("map_version.id")),
     Column("weight",         Integer,       nullable=False),
     Column("map_params",     Text),
+    Column("create_time",    TIMESTAMP,     nullable=False),
+    Column("update_time",    TIMESTAMP,     nullable=False)
 )
 
 map_version = Table(

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -1,3 +1,4 @@
+import asyncio
 from server.abc.base_game import InitMode
 
 from .game import Game
@@ -21,6 +22,7 @@ class CoopGame(Game):
             "Difficulty": 3,
             "Expansion": "true"
         })
+        asyncio.get_event_loop().create_task(self.timeout_game(60))
 
     async def validate_game_mode_settings(self):
         """

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from server.abc.base_game import InitMode
 
 from .game import Game

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 from server.abc.base_game import InitMode
@@ -18,6 +19,7 @@ class CustomGame(Game):
         }
         new_kwargs.update(kwargs)
         super().__init__(id_, *args, **new_kwargs)
+        asyncio.get_event_loop().create_task(self.timeout_game())
 
     async def _run_pre_rate_validity_checks(self):
         limit = len(self.players) * 60

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -118,12 +118,9 @@ class Game():
         self._launch_fut = asyncio.Future()
 
         self._logger.debug("%s created", self)
-        asyncio.get_event_loop().create_task(self.timeout_game())
 
-    async def timeout_game(self):
-        # coop takes longer to set up
-        tm = 30 if self.game_mode != FeaturedModType.COOP else 60
-        await asyncio.sleep(tm)
+    async def timeout_game(self, timeout: int = 30):
+        await asyncio.sleep(timeout)
         if self.state is GameState.INITIALIZING:
             self._is_hosted.set_exception(
                 asyncio.TimeoutError("Game setup timed out")

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -135,8 +135,11 @@ class LadderService(Service):
                     if map_type == "neroxis":
                         map_list.append(NeroxisGeneratedMap.of(params=params, weight=row.weight))
                     else:
-                        self._logger.warning("Unsupported map type %s with parameters %s",
-                                             map_type, row.map_params)
+                        self._logger.warning(
+                            "Unsupported map type %s with parameters %s",
+                             map_type,
+                             row.map_params
+                        )
 
                 except Exception:
                     self._logger.warning(

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -134,6 +134,9 @@ class LadderService(Service):
                     map_type = params["type"]
                     if map_type == "neroxis":
                         map_list.append(NeroxisGeneratedMap.of(params=params, weight=row.weight))
+                    else:
+                        self._logger.warning("Unsupported map type %s with parameters %s",
+                                             map_type, row.map_params)
 
                 except Exception:
                     self._logger.warning(

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -133,7 +133,7 @@ class LadderService(Service):
                     params = json.loads(row.map_params)
                     map_type = params["type"]
                     if map_type == "neroxis":
-                        map_list.append(NeroxisGeneratedMap.of(params=params, weight=row.weight))
+                        map_list.append(NeroxisGeneratedMap.of(params, row.weight))
                     else:
                         self._logger.warning(
                             "Unsupported map type %s in pool %s",

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -136,9 +136,9 @@ class LadderService(Service):
                         map_list.append(NeroxisGeneratedMap.of(params=params, weight=row.weight))
                     else:
                         self._logger.warning(
-                            "Unsupported map type %s with parameters %s",
+                            "Unsupported map type %s in pool %s",
                              map_type,
-                             row.map_params
+                             row.id
                         )
 
                 except Exception:

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -137,7 +137,7 @@ class LadderService(Service):
 
                 except Exception:
                     self._logger.warning(
-                        "Failed to load map in map pool %d"
+                        "Failed to load map in map pool %d "
                         "parameters specified as %s",
                         row.id,
                         row.map_params,

--- a/server/types.py
+++ b/server/types.py
@@ -45,6 +45,8 @@ class NeroxisGeneratedMap(NamedTuple):
 
     @classmethod
     def of(cls, params: dict, weight: int = 1):
+        assert params["type"] == "neroxis"
+
         map_size_pixels = int(params["size"])
 
         if map_size_pixels <= 0:

--- a/server/types.py
+++ b/server/types.py
@@ -1,3 +1,5 @@
+import base64
+import random
 from typing import NamedTuple, Optional
 
 
@@ -27,3 +29,54 @@ class Map(NamedTuple):
     id: int
     name: str
     path: str
+    weight: int = 1
+
+    def get_map(self) -> "Map":
+        return self
+
+
+# FIXME: Use typing.Protocol in python3.8 to subtype with MAP
+class NeroxisGeneratedMap(NamedTuple):
+    id: int
+    version: str
+    spawns: int
+    map_size_pixels: int
+    weight: int = 1
+
+    @classmethod
+    def of(cls, params: dict, weight: int = 1):
+        map_size_pixels = int(params["size"])
+
+        if map_size_pixels <= 0:
+            raise Exception("Map size is zero or negative")
+
+        if map_size_pixels & (map_size_pixels - 1) != 0:
+            raise Exception("Map size is not a power of 2")
+
+        spawns = int(params["spawns"])
+        if spawns % 2 != 0:
+            raise Exception("spawns is not a multiple of 2")
+
+        version = params["version"]
+        return NeroxisGeneratedMap(
+            -int.from_bytes(bytes(f'{version}_{spawns}_{map_size_pixels}', encoding="ascii"), 'big'),
+            version,
+            spawns,
+            map_size_pixels,
+            weight
+        )
+
+    def get_map(self) -> Map:
+        """
+            Generate a map name based on the version and parameters. If invalid parameters are specified
+            hand back None
+        """
+        seed_bytes = random.getrandbits(64).to_bytes(8, 'big')
+        size_byte = (self.map_size_pixels // 64).to_bytes(1, 'big')
+        spawn_byte = self.spawns.to_bytes(1, 'big')
+        option_bytes = spawn_byte + size_byte
+        seed_str = base64.b32encode(seed_bytes).decode("ascii").replace("=", "").lower()
+        option_str = base64.b32encode(option_bytes).decode("ascii").replace("=", "").lower()
+        map_name = f'neroxis_map_generator_{self.version}_{seed_str}_{option_str}'
+        map_path = f'maps/{map_name}.zip'
+        return Map(self.id, map_name, map_path, self.weight)

--- a/server/types.py
+++ b/server/types.py
@@ -61,7 +61,7 @@ class NeroxisGeneratedMap(NamedTuple):
 
         version = params["version"]
         return NeroxisGeneratedMap(
-            -int.from_bytes(bytes(f'{version}_{spawns}_{map_size_pixels}', encoding="ascii"), 'big'),
+            -int.from_bytes(bytes(f"{version}_{spawns}_{map_size_pixels}", encoding="ascii"), "big"),
             version,
             spawns,
             map_size_pixels,
@@ -73,12 +73,12 @@ class NeroxisGeneratedMap(NamedTuple):
             Generate a map name based on the version and parameters. If invalid parameters are specified
             hand back None
         """
-        seed_bytes = random.getrandbits(64).to_bytes(8, 'big')
-        size_byte = (self.map_size_pixels // 64).to_bytes(1, 'big')
-        spawn_byte = self.spawns.to_bytes(1, 'big')
+        seed_bytes = random.getrandbits(64).to_bytes(8, "big")
+        size_byte = (self.map_size_pixels // 64).to_bytes(1, "big")
+        spawn_byte = self.spawns.to_bytes(1, "big")
         option_bytes = spawn_byte + size_byte
         seed_str = base64.b32encode(seed_bytes).decode("ascii").replace("=", "").lower()
         option_str = base64.b32encode(option_bytes).decode("ascii").replace("=", "").lower()
-        map_name = f'neroxis_map_generator_{self.version}_{seed_str}_{option_str}'
-        map_path = f'maps/{map_name}.zip'
+        map_name = f"neroxis_map_generator_{self.version}_{seed_str}_{option_str}"
+        map_path = f"maps/{map_name}.zip"
         return Map(self.id, map_name, map_path, self.weight)

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -33,94 +33,68 @@ DELETE FROM avatars_list;
 DELETE FROM ban;
 DELETE FROM clan_membership;
 DELETE FROM clan;
-DELETE
-FROM game_player_stats;
-DELETE
-FROM game_review;
-DELETE
-FROM game_reviews_summary;
-DELETE
-FROM game_stats;
-DELETE
-FROM game_featuredMods;
-DELETE
-FROM ladder_division_score;
-DELETE
-FROM ladder_division;
-DELETE
-FROM lobby_admin;
-DELETE
-FROM name_history;
-DELETE
-FROM user_group_assignment;
-DELETE
-FROM login;
-DELETE
-FROM email_domain_blacklist;
-DELETE
-FROM leaderboard_rating_journal;
-DELETE
-FROM leaderboard_rating;
-DELETE
-FROM leaderboard;
-DELETE
-FROM matchmaker_queue;
-DELETE
-FROM matchmaker_queue_game;
-DELETE
-FROM matchmaker_queue_map_pool;
-DELETE
-FROM map_pool;
-DELETE
-FROM map_pool_map_version;
-DELETE
-FROM user_group;
-DELETE
-FROM group_permission_assignment;
+DELETE FROM game_player_stats;
+DELETE FROM game_review;
+DELETE FROM game_reviews_summary;
+DELETE FROM game_stats;
+DELETE FROM game_featuredMods;
+DELETE FROM ladder_division_score;
+DELETE FROM ladder_division;
+DELETE FROM lobby_admin;
+DELETE FROM name_history;
+DELETE FROM user_group_assignment;
+DELETE FROM login;
+DELETE FROM email_domain_blacklist;
+DELETE FROM leaderboard_rating_journal;
+DELETE FROM leaderboard_rating;
+DELETE FROM leaderboard;
+DELETE FROM matchmaker_queue;
+DELETE FROM matchmaker_queue_game;
+DELETE FROM matchmaker_queue_map_pool;
+DELETE FROM map_pool;
+DELETE FROM map_pool_map_version;
+DELETE FROM user_group;
+DELETE FROM group_permission_assignment;
 
-SET
-FOREIGN_KEY_CHECKS=1;
+SET FOREIGN_KEY_CHECKS=1;
 
 -- Login table
 -- Most accounts get a creation time in the past so that they pass account
 -- age check.
-insert into login (id, login, email, password, steamid, create_time)
-values (1, 'test', 'test@example.com', SHA2('test_password', 256), null, '2000-01-01 00:00:00'),
-       (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256), null, '2000-01-01 00:00:00'),
-       (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256), null, '2000-01-01 00:00:00'),
-       (4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
-       (5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
-       (7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
-       (8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-       (9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-       (10, 'friends', 'friends@example.com', SHA2('friends', 256), null, '2000-01-01 00:00:00'),
-       (20, 'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
-       (50, 'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
-       (51, 'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null, '2000-01-01 00:00:00'),
-       (52, 'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
-       (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
-       (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
-       (102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
-       (103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
-       (104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
-       (105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
-       (106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
-       (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
-       (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
-       (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
-       (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null,
-        '2000-01-01 00:00:00'),
-       (204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null,
-        '2000-01-01 00:00:00'),
-       (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
+insert into login (id, login, email, password, steamid, create_time) values
+  (1, 'test', 'test@example.com', SHA2('test_password', 256),    null, '2000-01-01 00:00:00'),
+  (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256), null, '2000-01-01 00:00:00'),
+  (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256), null, '2000-01-01 00:00:00'),
+  (4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
+  (5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
+  (7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
+  (8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+  (9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+  (10,  'friends', 'friends@example.com', SHA2('friends', 256),  null, '2000-01-01 00:00:00'),
+  (20,  'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
+  (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
+  (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null,  '2000-01-01 00:00:00'),
+  (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
+  (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
+  (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
+  (102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
+  (103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
+  (104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
+  (105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
+  (106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
+  (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
+  (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
+  (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
+  (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
+  (204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null, '2000-01-01 00:00:00'),
+  (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
 ;
-insert into login (id, login, email, password)
-values (6, 'newbie', 'noob@example.com', SHA2('password', 256));
+insert into login (id, login, email, password) values (6, 'newbie', 'noob@example.com', SHA2('password', 256));
 
 -- Name history
-insert into name_history (id, change_time, user_id, previous_name)
-values (1, date_sub(now(), interval 12 month), 1, 'test_maniac'),
-       (2, date_sub(now(), interval 1 month), 2, 'YoungDostya');
+insert into name_history (id, change_time, user_id, previous_name) values
+  (1, date_sub(now(), interval 12 month), 1, 'test_maniac'),
+  (2, date_sub(now(), interval 1 month), 2, 'YoungDostya');
 
 insert into user_group (id, technical_name, public, name_key)
 values (1, 'faf_server_administrators', true, 'admins'),
@@ -128,33 +102,25 @@ values (1, 'faf_server_administrators', true, 'admins'),
 
 -- Permissions
 insert into group_permission_assignment (id, group_id, permission_id)
-values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
-        (SELECT id from group_permission WHERE technical_name = 'ADMIN_BROADCAST_MESSAGE')),
-       (2, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
-        (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER')),
-       (3, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
-        (SELECT id from group_permission WHERE technical_name = 'ADMIN_JOIN_CHANNEL')),
-       (4, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'),
-        (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER'));
+values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_BROADCAST_MESSAGE')),
+       (2, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER')),
+       (3, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_JOIN_CHANNEL')),
+       (4, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER'));
 
-insert into lobby_admin (user_id, `group`)
-values (1, 2);
-insert into user_group_assignment(user_id, group_id)
-values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'));
-insert into user_group_assignment(user_id, group_id)
-values (2, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
-insert into user_group_assignment(user_id, group_id)
-values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
+insert into lobby_admin (user_id, `group`) values (1, 2);
+insert into user_group_assignment(user_id, group_id) values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'));
+insert into user_group_assignment(user_id, group_id) values (2, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
+insert into user_group_assignment(user_id, group_id) values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
 
-insert into leaderboard (id, technical_name, name_key, description_key)
-values (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
-       (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
-       (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
+insert into leaderboard (id, technical_name, name_key, description_key) values
+  (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
+  (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
+  (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
 
 
-insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderboard_id)
-values (1, 2000, 125, 5, 1),
-       (1, 2000, 125, 5, 2),
+insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderboard_id) values
+  (1, 2000, 125, 5, 1),
+  (1, 2000, 125, 5, 2),
   (2, 1500, 75, 2, 1),
   (2, 1500, 75, 2, 2),
   (3, 1650, 62.52, 2, 1),
@@ -322,63 +288,55 @@ insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_i
   (4, "neroxis1v1", 1, 2, "matchmaker.neroxis", 1, true);
 
 insert into matchmaker_queue_game (matchmaker_queue_id, game_stats_id) values
-                                                                           (1, 1),
-                                                                           (1, 41935),
-                                                                           (1, 41936),
-                                                                           (1, 41937),
-                                                                           (1, 41938),
-                                                                           (1, 41939),
-                                                                           (1, 41940),
-                                                                           (1, 41941),
-                                                                           (1, 41942),
-                                                                           (1, 41943),
-                                                                           (1, 41944),
-                                                                           (1, 41945),
-                                                                           (1, 41946),
-                                                                           (1, 41947),
-                                                                           (1, 41948),
-                                                                           (2, 41949),
-                                                                           (2, 41950),
-                                                                           (2, 41951),
-                                                                           (2, 41952),
-                                                                           (2, 41953),
-                                                                           (2, 41954),
-                                                                           (2, 41955);
+  (1, 1),
+  (1, 41935),
+  (1, 41936),
+  (1, 41937),
+  (1, 41938),
+  (1, 41939),
+  (1, 41940),
+  (1, 41941),
+  (1, 41942),
+  (1, 41943),
+  (1, 41944),
+  (1, 41945),
+  (1, 41946),
+  (1, 41947),
+  (1, 41948),
+  (2, 41949),
+  (2, 41950),
+  (2, 41951),
+  (2, 41952),
+  (2, 41953),
+  (2, 41954),
+  (2, 41955);
 
-insert into map_pool (id, name)
-values (1, "Ladder1v1 season 1: 5-10k"),
-       (2, "Ladder1v1 season 1: all"),
-       (3, "Large maps"),
-       (4, "Generated Maps with Errors");
+insert into map_pool (id, name) values
+  (1, "Ladder1v1 season 1: 5-10k"),
+  (2, "Ladder1v1 season 1: all"),
+  (3, "Large maps"),
+  (4, "Generated Maps with Errors");
 
-insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_params)
-values (1, 15, 1, NULL),
-       (1, 16, 1, NULL),
-       (1, 17, 1, NULL),
-       (2, 11, 1, NULL),
-       (2, 14, 1, NULL),
-       (2, 15, 1, NULL),
-       (2, 16, 1, NULL),
-       (2, 17, 1, NULL),
-       (3, 1, 1, NULL),
-       (3, 2, 1, NULL),
-       (3, 3, 1, NULL),
-       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
-       -- Bad Generated Map Parameters should not be included in pool
-       (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
-       (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
-       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),
-       (4, NULL, 1, '{"type": "beroxis", "size": 512, "spawns": 2, "version": "0.0.0"}');
+insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_params) values
+  (1, 15, 1, NULL), (1, 16, 1, NULL), (1, 17, 1, NULL),
+  (2, 11, 1, NULL), (2, 14, 1, NULL), (2, 15, 1, NULL), (2, 16, 1, NULL), (2, 17, 1, NULL),
+  (3, 1, 1, NULL), (3, 2, 1, NULL), (3, 3, 1, NULL),
+  (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
+  -- Bad Generated Map Parameters should not be included in pool
+  (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
+  (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
+  (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),
+  (4, NULL, 1, '{"type": "beroxis", "size": 512, "spawns": 2, "version": "0.0.0"}');
 
-insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating)
-values (1, 1, NULL, 800),
-       (1, 2, 800, NULL),
-       (1, 3, 1000, NULL),
-       (2, 3, NULL, NULL),
-       (4, 4, NULL, NULL);
+insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating) values
+  (1, 1, NULL, 800),
+  (1, 2, 800, NULL),
+  (1, 3, 1000, NULL),
+  (2, 3, NULL, NULL),
+  (4, 4, NULL, NULL);
 
-insert into friends_and_foes (user_id, subject_id, `status`)
-values (1, 3, 'FOE'),
+insert into friends_and_foes (user_id, subject_id, `status`) values
+  (1, 3, 'FOE'),
   (2, 1, 'FRIEND'),
   (10, 1, 'FRIEND');
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -33,16 +33,26 @@ DELETE FROM avatars_list;
 DELETE FROM ban;
 DELETE FROM clan_membership;
 DELETE FROM clan;
-DELETE FROM game_player_stats;
-DELETE FROM game_review;
-DELETE FROM game_reviews_summary;
-DELETE FROM game_stats;
-DELETE FROM game_featuredMods;
-DELETE FROM ladder_division_score;
-DELETE FROM ladder_division;
-DELETE FROM lobby_admin;
-DELETE FROM name_history;
-DELETE FROM user_group_assignment;
+DELETE
+FROM game_player_stats;
+DELETE
+FROM game_review;
+DELETE
+FROM game_reviews_summary;
+DELETE
+FROM game_stats;
+DELETE
+FROM game_featuredMods;
+DELETE
+FROM ladder_division_score;
+DELETE
+FROM ladder_division;
+DELETE
+FROM lobby_admin;
+DELETE
+FROM name_history;
+DELETE
+FROM user_group_assignment;
 DELETE
 FROM login;
 DELETE
@@ -78,29 +88,31 @@ insert into login (id, login, email, password, steamid, create_time)
 values (1, 'test', 'test@example.com', SHA2('test_password', 256), null, '2000-01-01 00:00:00'),
        (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256), null, '2000-01-01 00:00:00'),
        (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256), null, '2000-01-01 00:00:00'),
-(4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
-(5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
-(7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
-(8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-(9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-(10, 'friends', 'friends@example.com', SHA2('friends', 256), null, '2000-01-01 00:00:00'),
-(20, 'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
-(50, 'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
-(51, 'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null, '2000-01-01 00:00:00'),
-(52, 'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
-(100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
-(101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
-(102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
-(103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
-(104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
-(105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
-(106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
-(200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
-  (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
-  (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
-(203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
-(204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null, '2000-01-01 00:00:00'),
-(300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
+       (4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
+       (5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
+       (7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
+       (8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+       (9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+       (10, 'friends', 'friends@example.com', SHA2('friends', 256), null, '2000-01-01 00:00:00'),
+       (20, 'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
+       (50, 'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
+       (51, 'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null, '2000-01-01 00:00:00'),
+       (52, 'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
+       (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
+       (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
+       (102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
+       (103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
+       (104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
+       (105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
+       (106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
+       (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
+       (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
+       (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
+       (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null,
+        '2000-01-01 00:00:00'),
+       (204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null,
+        '2000-01-01 00:00:00'),
+       (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
 ;
 insert into login (id, login, email, password)
 values (6, 'newbie', 'noob@example.com', SHA2('password', 256));
@@ -137,12 +149,12 @@ values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_gl
 insert into leaderboard (id, technical_name, name_key, description_key)
 values (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
        (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
-  (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
+       (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
 
 
-insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderboard_id) values
-  (1, 2000, 125, 5, 1),
-  (1, 2000, 125, 5, 2),
+insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderboard_id)
+values (1, 2000, 125, 5, 1),
+       (1, 2000, 125, 5, 2),
   (2, 1500, 75, 2, 1),
   (2, 1500, 75, 2, 2),
   (3, 1650, 62.52, 2, 1),
@@ -310,55 +322,63 @@ insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_i
   (4, "neroxis1v1", 1, 2, "matchmaker.neroxis", 1, true);
 
 insert into matchmaker_queue_game (matchmaker_queue_id, game_stats_id) values
-  (1, 1),
-  (1, 41935),
-  (1, 41936),
-  (1, 41937),
-  (1, 41938),
-  (1, 41939),
-  (1, 41940),
-  (1, 41941),
-  (1, 41942),
-  (1, 41943),
-  (1, 41944),
-  (1, 41945),
-  (1, 41946),
-  (1, 41947),
-  (1, 41948),
-  (2, 41949),
-  (2, 41950),
-  (2, 41951),
-  (2, 41952),
-  (2, 41953),
-  (2, 41954),
-  (2, 41955);
+                                                                           (1, 1),
+                                                                           (1, 41935),
+                                                                           (1, 41936),
+                                                                           (1, 41937),
+                                                                           (1, 41938),
+                                                                           (1, 41939),
+                                                                           (1, 41940),
+                                                                           (1, 41941),
+                                                                           (1, 41942),
+                                                                           (1, 41943),
+                                                                           (1, 41944),
+                                                                           (1, 41945),
+                                                                           (1, 41946),
+                                                                           (1, 41947),
+                                                                           (1, 41948),
+                                                                           (2, 41949),
+                                                                           (2, 41950),
+                                                                           (2, 41951),
+                                                                           (2, 41952),
+                                                                           (2, 41953),
+                                                                           (2, 41954),
+                                                                           (2, 41955);
 
-insert into map_pool (id, name) values
-  (1, "Ladder1v1 season 1: 5-10k"),
-  (2, "Ladder1v1 season 1: all"),
-  (3, "Large maps"),
-  (4, "Generated Maps with Errors");
+insert into map_pool (id, name)
+values (1, "Ladder1v1 season 1: 5-10k"),
+       (2, "Ladder1v1 season 1: all"),
+       (3, "Large maps"),
+       (4, "Generated Maps with Errors");
 
-insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_params) values
-                                                                                       (1, 15, 1, NULL),(1, 16, 1, NULL),(1, 17, 1, NULL),
-                                                                                       (2, 11, 1, NULL),(2, 14, 1, NULL),(2, 15, 1, NULL),(2, 16, 1, NULL),(2, 17, 1, NULL),
-                                                                                       (3, 1, 1, NULL),(3, 2, 1, NULL),(3, 3, 1, NULL),
-                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
-                                                                                       -- Bad Generated Map Parameters should not be included in pool
-                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
-                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
-                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),
-                                                                                       (4, NULL, 1, '{"type": "beroxis", "size": 512, "spawns": 2, "version": "0.0.0"}');
+insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_params)
+values (1, 15, 1, NULL),
+       (1, 16, 1, NULL),
+       (1, 17, 1, NULL),
+       (2, 11, 1, NULL),
+       (2, 14, 1, NULL),
+       (2, 15, 1, NULL),
+       (2, 16, 1, NULL),
+       (2, 17, 1, NULL),
+       (3, 1, 1, NULL),
+       (3, 2, 1, NULL),
+       (3, 3, 1, NULL),
+       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
+       -- Bad Generated Map Parameters should not be included in pool
+       (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
+       (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
+       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),
+       (4, NULL, 1, '{"type": "beroxis", "size": 512, "spawns": 2, "version": "0.0.0"}');
 
-insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating) values
-  (1, 1, NULL, 800),
-  (1, 2, 800, NULL),
-  (1, 3, 1000, NULL),
-  (2, 3, NULL, NULL),
-  (4, 4, NULL, NULL);
+insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating)
+values (1, 1, NULL, 800),
+       (1, 2, 800, NULL),
+       (1, 3, 1000, NULL),
+       (2, 3, NULL, NULL),
+       (4, 4, NULL, NULL);
 
-insert into friends_and_foes (user_id, subject_id, `status`) values
-  (1, 3, 'FOE'),
+insert into friends_and_foes (user_id, subject_id, `status`)
+values (1, 3, 'FOE'),
   (2, 1, 'FRIEND'),
   (10, 1, 'FRIEND');
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -43,66 +43,100 @@ DELETE FROM ladder_division;
 DELETE FROM lobby_admin;
 DELETE FROM name_history;
 DELETE FROM user_group_assignment;
-DELETE FROM login;
-DELETE FROM email_domain_blacklist;
-DELETE FROM leaderboard_rating_journal;
-DELETE FROM leaderboard_rating;
-DELETE FROM leaderboard;
-DELETE FROM matchmaker_queue;
-DELETE FROM matchmaker_queue_game;
-DELETE FROM matchmaker_queue_map_pool;
-DELETE FROM map_pool;
-DELETE FROM map_pool_map_version;
+DELETE
+FROM login;
+DELETE
+FROM email_domain_blacklist;
+DELETE
+FROM leaderboard_rating_journal;
+DELETE
+FROM leaderboard_rating;
+DELETE
+FROM leaderboard;
+DELETE
+FROM matchmaker_queue;
+DELETE
+FROM matchmaker_queue_game;
+DELETE
+FROM matchmaker_queue_map_pool;
+DELETE
+FROM map_pool;
+DELETE
+FROM map_pool_map_version;
+DELETE
+FROM user_group;
+DELETE
+FROM group_permission_assignment;
 
-SET FOREIGN_KEY_CHECKS=1;
+SET
+FOREIGN_KEY_CHECKS=1;
 
 -- Login table
 -- Most accounts get a creation time in the past so that they pass account
 -- age check.
-insert into login (id, login, email, password, steamid, create_time) values
-  (1, 'test', 'test@example.com', SHA2('test_password', 256),    null, '2000-01-01 00:00:00'),
-  (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256), null, '2000-01-01 00:00:00'),
-  (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256), null, '2000-01-01 00:00:00'),
-  (4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
-  (5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
-  (7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
-  (8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-  (9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
-  (10,  'friends', 'friends@example.com', SHA2('friends', 256),  null, '2000-01-01 00:00:00'),
-  (20,  'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
-  (50,  'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
-  (51,  'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null,  '2000-01-01 00:00:00'),
-  (52,  'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
-  (100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
-  (101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
-  (102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
-  (103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
-  (104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
-  (105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
-  (106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
-  (200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
+insert into login (id, login, email, password, steamid, create_time)
+values (1, 'test', 'test@example.com', SHA2('test_password', 256), null, '2000-01-01 00:00:00'),
+       (2, 'Dostya', 'dostya@cybran.example.com', SHA2('vodka', 256), null, '2000-01-01 00:00:00'),
+       (3, 'Rhiza', 'rhiza@aeon.example.com', SHA2('puff_the_magic_dragon', 256), null, '2000-01-01 00:00:00'),
+(4, 'No_UID', 'uid@uef.example.com', SHA2('his_pw', 256), null, '2000-01-01 00:00:00'),
+(5, 'postman', 'postman@postman.com', SHA2('postman', 256), null, '2000-01-01 00:00:00'),
+(7, 'test2', 'test2@example.com', SHA2('test2', 256), null, '2000-01-01 00:00:00'),
+(8, 'test3', 'test3@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+(9, 'test4', 'test4@example.com', SHA2('test3', 256), null, '2000-01-01 00:00:00'),
+(10, 'friends', 'friends@example.com', SHA2('friends', 256), null, '2000-01-01 00:00:00'),
+(20, 'moderator', 'moderator@example.com', SHA2('moderator', 256), null, '2000-01-01 00:00:00'),
+(50, 'player_service1', 'ps1@example.com', SHA2('player_service1', 256), null, '2000-01-01 00:00:00'),
+(51, 'player_service2', 'ps2@example.com', SHA2('player_service2', 256), null, '2000-01-01 00:00:00'),
+(52, 'player_service3', 'ps3@example.com', SHA2('player_service3', 256), null, '2000-01-01 00:00:00'),
+(100, 'ladder1', 'ladder1@example.com', SHA2('ladder1', 256), null, '2000-01-01 00:00:00'),
+(101, 'ladder2', 'ladder2@example.com', SHA2('ladder2', 256), null, '2000-01-01 00:00:00'),
+(102, 'ladder3', 'ladder3@example.com', SHA2('ladder3', 256), null, '2000-01-01 00:00:00'),
+(103, 'ladder4', 'ladder4@example.com', SHA2('ladder4', 256), null, '2000-01-01 00:00:00'),
+(104, 'ladder_ban', 'ladder_ban@example.com', SHA2('ladder_ban', 256), null, '2000-01-01 00:00:00'),
+(105, 'tmm1', 'tmm1@example.com', SHA2('tmm1', 256), null, '2000-01-01 00:00:00'),
+(106, 'tmm2', 'tmm2@example.com', SHA2('tmm2', 256), null, '2000-01-01 00:00:00'),
+(200, 'banme', 'banme@example.com', SHA2('banme', 256), null, '2000-01-01 00:00:00'),
   (201, 'ban_revoked', 'ban_revoked@example.com', SHA2('ban_revoked', 256), null, '2000-01-01 00:00:00'),
   (202, 'ban_expired', 'ban_expired@example.com', SHA2('ban_expired', 256), null, '2000-01-01 00:00:00'),
-  (203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
-  (204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null, '2000-01-01 00:00:00'),
-  (300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
+(203, 'ban_long_time', 'ban_null_expiration@example.com', SHA2('ban_long_time', 256), null, '2000-01-01 00:00:00'),
+(204, 'ban_46_hour', 'ban_46_hour_expiration@example.com', SHA2('ban_46_hour', 256), null, '2000-01-01 00:00:00'),
+(300, 'steam_id', 'steam_id@example.com', SHA2('steam_id', 256), 34632, '2000-01-01 00:00:00')
 ;
-insert into login (id, login, email, password) values (6, 'newbie', 'noob@example.com', SHA2('password', 256));
+insert into login (id, login, email, password)
+values (6, 'newbie', 'noob@example.com', SHA2('password', 256));
 
 -- Name history
-insert into name_history (id, change_time, user_id, previous_name) values
-  (1, date_sub(now(), interval 12 month), 1, 'test_maniac'),
-  (2, date_sub(now(), interval 1 month), 2, 'YoungDostya');
+insert into name_history (id, change_time, user_id, previous_name)
+values (1, date_sub(now(), interval 12 month), 1, 'test_maniac'),
+       (2, date_sub(now(), interval 1 month), 2, 'YoungDostya');
+
+insert into user_group (id, technical_name, public, name_key)
+values (1, 'faf_server_administrators', true, 'admins'),
+       (2, 'faf_moderators_global', true, 'mods');
 
 -- Permissions
-insert into lobby_admin (user_id, `group`) values (1,2);
-insert into user_group_assignment(user_id, group_id)  values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'));
-insert into user_group_assignment(user_id, group_id)  values (2, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
-insert into user_group_assignment(user_id, group_id)  values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
+insert into group_permission_assignment (id, group_id, permission_id)
+values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
+        (SELECT id from group_permission WHERE technical_name = 'ADMIN_BROADCAST_MESSAGE')),
+       (2, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
+        (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER')),
+       (3, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'),
+        (SELECT id from group_permission WHERE technical_name = 'ADMIN_JOIN_CHANNEL')),
+       (4, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'),
+        (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER'));
 
-insert into leaderboard (id, technical_name, name_key, description_key) values
-  (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
-  (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
+insert into lobby_admin (user_id, `group`)
+values (1, 2);
+insert into user_group_assignment(user_id, group_id)
+values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'));
+insert into user_group_assignment(user_id, group_id)
+values (2, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
+insert into user_group_assignment(user_id, group_id)
+values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
+
+insert into leaderboard (id, technical_name, name_key, description_key)
+values (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
+       (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
   (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
 
 
@@ -200,7 +234,7 @@ insert into map_version (id, description, max_players, width, height, version, f
   (15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 1, 15),
   (16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 1, 15),
   (17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 1, 15),
-  (18, 'Sneaky_Map', 8, 512, 512, 1, "maps/neroxis_map_generator_sneaky_map.zip", 0, 0, 16);
+  (18, 'Sneaky_Map', 8, 512, 512, 1, 'maps/neroxis_map_generator_sneaky_map.zip', 0, 0, 16);
 
 insert into ladder_map (id, idmap) values
   (1,1),
@@ -272,7 +306,8 @@ insert into game_player_stats (gameId, playerId, AI, faction, color, team, place
 insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, enabled) values
   (1, "ladder1v1", 6, 2, "matchmaker.ladder1v1", 1, true),
   (2, "tmm2v2", 1, 3, "matchmaker.tmm2v2", 2, true),
-  (3, "disabled", 1, 1, "matchmaker.disabled", 4, false);
+  (3, "disabled", 1, 1, "matchmaker.disabled", 4, false),
+  (4, "neroxis1v1", 1, 2, "matchmaker.neroxis", 1, true);
 
 insert into matchmaker_queue_game (matchmaker_queue_id, game_stats_id) values
   (1, 1),
@@ -301,18 +336,26 @@ insert into matchmaker_queue_game (matchmaker_queue_id, game_stats_id) values
 insert into map_pool (id, name) values
   (1, "Ladder1v1 season 1: 5-10k"),
   (2, "Ladder1v1 season 1: all"),
-  (3, "Large maps");
+  (3, "Large maps"),
+  (4, "Generated Maps with Errors");
 
-insert into map_pool_map_version (map_pool_id, map_version_id) values
-  (1, 15), (1, 16), (1, 17),
-  (2, 11), (2, 14), (2, 15), (2, 16), (2, 17),
-  (3, 1),  (3, 2),  (3, 3);
+insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_params) values
+                                                                                       (1, 15, 1, NULL),(1, 16, 1, NULL),(1, 17, 1, NULL),
+                                                                                       (2, 11, 1, NULL),(2, 14, 1, NULL),(2, 15, 1, NULL),(2, 16, 1, NULL),(2, 17, 1, NULL),
+                                                                                       (3, 1, 1, NULL),(3, 2, 1, NULL),(3, 3, 1, NULL),
+                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
+                                                                                       -- Bad Generated Map Parameters should not be included in pool
+                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
+                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
+                                                                                       (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),
+                                                                                       (4, NULL, 1, '{"type": "beroxis", "size": 512, "spawns": 2, "version": "0.0.0"}');
 
 insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rating, max_rating) values
   (1, 1, NULL, 800),
   (1, 2, 800, NULL),
   (1, 3, 1000, NULL),
-  (2, 3, NULL, NULL);
+  (2, 3, NULL, NULL),
+  (4, 4, NULL, NULL);
 
 insert into friends_and_foes (user_id, subject_id, `status`) values
   (1, 3, 'FOE'),

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -96,16 +96,16 @@ insert into name_history (id, change_time, user_id, previous_name) values
   (1, date_sub(now(), interval 12 month), 1, 'test_maniac'),
   (2, date_sub(now(), interval 1 month), 2, 'YoungDostya');
 
-insert into user_group (id, technical_name, public, name_key)
-values (1, 'faf_server_administrators', true, 'admins'),
-       (2, 'faf_moderators_global', true, 'mods');
+insert into user_group (id, technical_name, public, name_key) values
+  (1, 'faf_server_administrators', true, 'admins'),
+  (2, 'faf_moderators_global', true, 'mods');
 
 -- Permissions
-insert into group_permission_assignment (id, group_id, permission_id)
-values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_BROADCAST_MESSAGE')),
-       (2, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER')),
-       (3, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_JOIN_CHANNEL')),
-       (4, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER'));
+insert into group_permission_assignment (id, group_id, permission_id) values
+  (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_BROADCAST_MESSAGE')),
+  (2, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER')),
+  (3, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_JOIN_CHANNEL')),
+  (4, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'), (SELECT id from group_permission WHERE technical_name = 'ADMIN_KICK_SERVER'));
 
 insert into lobby_admin (user_id, `group`) values (1, 2);
 insert into user_group_assignment(user_id, group_id) values (1, (SELECT id from user_group WHERE technical_name = 'faf_server_administrators'));

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -68,29 +68,31 @@ async def open_fa(proto):
     })
 
 
-async def queue_player_for_matchmaking(user, lobby_server):
+async def queue_player_for_matchmaking(user, lobby_server, queue_name):
     _, _, proto = await connect_and_sign_in(user, lobby_server)
     await read_until_command(proto, "game_info")
     await proto.send_message({
         "command": "game_matchmaking",
         "state": "start",
-        "faction": "uef"
+        "faction": "uef",
+        "queue_name": queue_name
     })
     await read_until_command(
         proto,
         "search_info",
         state="start",
-        queue_name="ladder1v1",
+        queue_name=queue_name,
         timeout=5
     )
 
     return proto
 
 
-async def queue_players_for_matchmaking(lobby_server):
+async def queue_players_for_matchmaking(lobby_server, queue_name: str = "ladder1v1"):
     proto1 = await queue_player_for_matchmaking(
         ("ladder1", "ladder1"),
-        lobby_server
+        lobby_server,
+        queue_name
     )
     _, _, proto2 = await connect_and_sign_in(
         ("ladder2", "ladder2"),
@@ -102,7 +104,8 @@ async def queue_players_for_matchmaking(lobby_server):
     await proto2.send_message({
         "command": "game_matchmaking",
         "state": "start",
-        "faction": 1  # Python client sends factions as numbers
+        "faction": 1,  # Python client sends factions as numbers
+        "queue_name": queue_name
     })
     await read_until_command(proto2, "search_info")
 

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -132,8 +132,8 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
     # so the match is cancelled. However, the client does not know how to
     # handle `match_cancelled` messages so we still send `game_launch` to
     # prevent the client from showing that it is searching when it really isn't.
-    await read_until_command(proto2, "match_cancelled", timeout=120)
-    await read_until_command(proto1, "match_cancelled", timeout=120)
+    await read_until_command(proto2, "match_cancelled", timeout=180)
+    await read_until_command(proto1, "match_cancelled", timeout=180)
 
     assert msg1["uid"] == msg2["uid"]
     assert msg1["mod"] == "ladder1v1"
@@ -144,7 +144,7 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
         proto1,
         "game_info",
         state="closed",
-        timeout=5
+        timeout=15
     )
     assert game_service._games == {}
 
@@ -154,7 +154,7 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
         "state": "start",
         "faction": "uef"
     })
-    await read_until_command(proto1, "search_info", state="start", timeout=5)
+    await read_until_command(proto1, "search_info", state="start", timeout=15)
 
 
 @fast_forward(120)

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -125,15 +125,15 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
     proto1, proto2 = await queue_players_for_matchmaking(lobby_server)
 
     msg1, msg2 = await asyncio.gather(
-        read_until_command(proto1, "game_launch"),
-        read_until_command(proto2, "game_launch")
+        read_until_command(proto1, "game_launch", timeout=120),
+        read_until_command(proto2, "game_launch", timeout=120)
     )
     # LEGACY BEHAVIOUR: The host does not respond with the appropriate GameState
     # so the match is cancelled. However, the client does not know how to
     # handle `match_cancelled` messages so we still send `game_launch` to
     # prevent the client from showing that it is searching when it really isn't.
-    await read_until_command(proto2, "match_cancelled", timeout=180)
-    await read_until_command(proto1, "match_cancelled", timeout=180)
+    await read_until_command(proto2, "match_cancelled", timeout=120)
+    await read_until_command(proto1, "match_cancelled", timeout=120)
 
     assert msg1["uid"] == msg2["uid"]
     assert msg1["mod"] == "ladder1v1"

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -132,8 +132,8 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
     # so the match is cancelled. However, the client does not know how to
     # handle `match_cancelled` messages so we still send `game_launch` to
     # prevent the client from showing that it is searching when it really isn't.
-    await read_until_command(proto2, "match_cancelled")
-    await read_until_command(proto1, "match_cancelled")
+    await read_until_command(proto2, "match_cancelled", timeout=120)
+    await read_until_command(proto1, "match_cancelled", timeout=120)
 
     assert msg1["uid"] == msg2["uid"]
     assert msg1["mod"] == "ladder1v1"
@@ -229,7 +229,7 @@ async def test_game_matchmaking_disconnect(lobby_server):
     # One player disconnects before the game has launched
     await proto1.close()
 
-    msg = await read_until_command(proto2, "match_cancelled")
+    msg = await read_until_command(proto2, "match_cancelled", timeout=120)
 
     assert msg == {"command": "match_cancelled"}
 

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -314,7 +314,7 @@ async def test_game_matchmaking_multiqueue_timeout(lobby_server):
     assert msg["state"] == "stop"
 
     # Don't send any GPGNet messages so the match times out
-    await read_until_command(protos[0], "match_cancelled")
+    await read_until_command(protos[0], "match_cancelled", timeout=120)
 
     # Player's state is reset so they are able to queue again
     await protos[0].send_message({
@@ -401,7 +401,7 @@ async def test_game_matchmaking_timeout(lobby_server):
 
     # We don't send the `GameState: Lobby` command so the game should time out
     await asyncio.gather(*[
-        read_until_command(proto, "match_cancelled") for proto in protos
+        read_until_command(proto, "match_cancelled", timeout=120) for proto in protos
     ])
 
     # Player's state is reset so they are able to queue again

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -71,7 +71,12 @@ async def test_load_from_database(ladder_service, queue_factory):
         assert queue.name == "neroxis1v1"
         assert len(queue.map_pools) == 1
         assert list(queue.map_pools[4][0].maps.values()) == [
-            NeroxisGeneratedMap.of({"version": "0.0.0", "spawns": 2, "size": 512, "type": "neroxis"}),
+            NeroxisGeneratedMap.of({
+                "version": "0.0.0",
+                "spawns": 2,
+                "size": 512,
+                "type": "neroxis"
+            }),
         ]
 
 

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -79,14 +79,14 @@ async def test_load_from_database(ladder_service, queue_factory):
 async def test_load_from_database_new_data(ladder_service, database):
     async with database.acquire() as conn:
         await conn.execute(matchmaker_queue.insert().values(
-            id=5,
+            id=1000000,
             technical_name="test",
             featured_mod_id=1,
             leaderboard_id=1,
             name_key="test.name"
         ))
         await conn.execute(matchmaker_queue_map_pool.insert().values(
-            matchmaker_queue_id=5,
+            matchmaker_queue_id=1000000,
             map_pool_id=1
         ))
 

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -1,11 +1,13 @@
+import base64
 import random
+import re
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
 from server.matchmaker import MapPool
-from server.types import Map
+from server.types import Map, NeroxisGeneratedMap
 
 
 @pytest.fixture(scope="session")
@@ -31,7 +33,45 @@ def test_choose_map(map_pool_factory):
     # Make the probability very low that the test passes because we got lucky
     for _ in range(20):
         chosen_map = map_pool.choose_map([1, 2, 3])
-        assert chosen_map == (4, "CHOOSE_ME", "maps/choose_me.v001.zip")
+        assert chosen_map == (4, "CHOOSE_ME", "maps/choose_me.v001.zip", 1)
+
+
+def test_choose_map_with_weights(map_pool_factory):
+    map_pool = map_pool_factory(maps=[
+        Map(1, "some_map", "maps/some_map.v001.zip", 1),
+        Map(2, "some_map", "maps/some_map.v001.zip", 1),
+        Map(3, "some_map", "maps/some_map.v001.zip", 1),
+        Map(4, "CHOOSE_ME", "maps/choose_me.v001.zip", 10000000),
+    ])
+
+    # Make the probability very low that the test passes because we got lucky
+    for _ in range(20):
+        chosen_map = map_pool.choose_map()
+        assert chosen_map == (4, "CHOOSE_ME", "maps/choose_me.v001.zip", 10000000)
+
+
+def test_choose_map_generated_map(map_pool_factory):
+    version = "0.0.0"
+    spawns = 2
+    size = 512
+
+    map_pool = map_pool_factory(maps=[
+        NeroxisGeneratedMap.of({"version": "0.0.0", "spawns": 2, "size": 512, "type": "neroxis"}),
+    ])
+
+    chosen_map = map_pool.choose_map([])
+
+    map_id = -int.from_bytes(bytes(f'{version}_{spawns}_{size}', encoding="ascii"), 'big')
+    size_byte = (size // 64).to_bytes(1, 'big')
+    spawn_byte = spawns.to_bytes(1, 'big')
+    option_bytes = spawn_byte + size_byte
+    option_str = base64.b32encode(option_bytes).decode("ascii").replace("=", "").lower()
+    seed_match = "[0-9a-z]{13}"
+
+    assert chosen_map.id == map_id
+    assert re.match(f"maps/neroxis_map_generator_{version}_{seed_match}_{option_str}.zip", chosen_map.path)
+    assert re.match(f"neroxis_map_generator_{version}_{seed_match}_{option_str}", chosen_map.name)
+    assert chosen_map.weight == 1
 
 
 def test_choose_map_all_maps_played(map_pool_factory):
@@ -46,6 +86,24 @@ def test_choose_map_all_maps_played(map_pool_factory):
 
     assert chosen_map is not None
     assert chosen_map in maps
+
+
+def test_choose_map_all_played_but_generated_map_doesnt_dominate(map_pool_factory):
+    maps = [
+        Map(1, "some_map", "maps/some_map.v001.zip", 1000000),
+        Map(2, "some_map", "maps/some_map.v001.zip", 1000000),
+        Map(3, "some_map", "maps/some_map.v001.zip", 1000000),
+        NeroxisGeneratedMap.of({"version": "0.0.0", "spawns": 2, "size": 512, "type": "neroxis"}),
+    ]
+    map_pool = map_pool_factory(maps=maps)
+
+    # Make the probability very low that the test passes because we got lucky
+    for _ in range(20):
+        chosen_map = map_pool.choose_map([1, 2, 3])
+
+        assert chosen_map is not None
+        assert chosen_map in maps
+        assert chosen_map.id in [1, 2, 3]
 
 
 def test_choose_map_all_maps_played_not_in_pool(map_pool_factory):
@@ -84,7 +142,7 @@ def test_choose_map_all_maps_played_returns_least_played(map_pool_factory):
     chosen_map = map_pool.choose_map(played_map_ids)
 
     # Map 1 was played only once
-    assert chosen_map == (1, "some_map", "maps/some_map.v001.zip")
+    assert chosen_map == (1, "some_map", "maps/some_map.v001.zip", 1)
 
 
 @given(history=st.lists(st.integers()))
@@ -96,7 +154,7 @@ def test_choose_map_single_map(map_pool_factory, history):
     # Make the probability very low that the test passes because we got lucky
     for _ in range(20):
         chosen_map = map_pool.choose_map(history)
-        assert chosen_map == (1, "CHOOSE_ME", "maps/choose_me.v001.zip")
+        assert chosen_map == (1, "CHOOSE_ME", "maps/choose_me.v001.zip", 1)
 
 
 def test_choose_map_raises_on_empty_map_pool(map_pool_factory):

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -66,9 +66,9 @@ def test_choose_map_generated_map(map_pool_factory):
 
     chosen_map = map_pool.choose_map([])
 
-    map_id = -int.from_bytes(bytes(f'{version}_{spawns}_{size}', encoding="ascii"), 'big')
-    size_byte = (size // 64).to_bytes(1, 'big')
-    spawn_byte = spawns.to_bytes(1, 'big')
+    map_id = -int.from_bytes(bytes(f"{version}_{spawns}_{size}", encoding="ascii"), "big")
+    size_byte = (size // 64).to_bytes(1, "big")
+    spawn_byte = spawns.to_bytes(1, "big")
     option_bytes = spawn_byte + size_byte
     option_str = base64.b32encode(option_bytes).decode("ascii").replace("=", "").lower()
     seed_match = "[0-9a-z]{13}"

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -56,7 +56,12 @@ def test_choose_map_generated_map(map_pool_factory):
     size = 512
 
     map_pool = map_pool_factory(maps=[
-        NeroxisGeneratedMap.of({"version": "0.0.0", "spawns": 2, "size": 512, "type": "neroxis"}),
+        NeroxisGeneratedMap.of({
+            "version": "0.0.0",
+            "spawns": 2,
+            "size": 512,
+            "type": "neroxis"
+        }),
     ])
 
     chosen_map = map_pool.choose_map([])

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -93,7 +93,12 @@ def test_choose_map_all_played_but_generated_map_doesnt_dominate(map_pool_factor
         Map(1, "some_map", "maps/some_map.v001.zip", 1000000),
         Map(2, "some_map", "maps/some_map.v001.zip", 1000000),
         Map(3, "some_map", "maps/some_map.v001.zip", 1000000),
-        NeroxisGeneratedMap.of({"version": "0.0.0", "spawns": 2, "size": 512, "type": "neroxis"}),
+        NeroxisGeneratedMap.of({
+            "version": "0.0.0",
+            "spawns": 2,
+            "size": 512,
+            "type": "neroxis"
+        }),
     ]
     map_pool = map_pool_factory(maps=maps)
 


### PR DESCRIPTION
I went ahead and took a first swing at how supporting generated maps would look like in the server code.
The id for the generated maps is the negative integer of the bytes representing the seed and options. This allows for the map_pool choose maps to still work as intended while removing the possibility of collisions with authored maps in the pool and having a unique id for each generated map.

The current issue is that this would need for the map_version_id to be null in the map_pool_map_version table but that is currently being used as part of a primary key probably need to consult @Brutus5000 