### PR TITLE
Fixup codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,12 @@ jobs:
           pip install pipenv
           pipenv sync --dev
 
-      - run: pipenv run tests
+      - run: pipenv run tests --cov-report=xml
 
       - name: Report coverage
         uses: codecov/codecov-action@v1
         with:
-          files: .coverage
+          files: coverage.xml
           fail_ci_if_error: true
 
   docker-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
           pipenv sync --dev
 
       - run: pipenv run tests
-      - run: sed -i.bak s#/code/#$(pwd)/#g .coverage
 
       - name: Report coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
I think it wants the full file paths. In coveralls these were just clutter, but codecov needs to map them to files in the repo so it can compare them to the git diff.