### PR TITLE
Issue/#724 generalize rating initialization

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -192,7 +192,8 @@ class ServerInstance(object):
             players=self.services["player_service"],
             ladder_service=self.services["ladder_service"],
             party_service=self.services["party_service"],
-            oauth_service=self.services["oauth_service"]
+            rating_service=self.services["rating_service"],
+            oauth_service=self.services["oauth_service"],
         )
 
     def write_broadcast(

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -200,7 +200,8 @@ ladder1v1_rating = Table(
 leaderboard = Table(
     "leaderboard", metadata,
     Column("id",                Integer, primary_key=True),
-    Column("technical_name",    String, nullable=False, unique=True),
+    Column("technical_name",    String,  nullable=False, unique=True),
+    Column("initializer_id",    Integer, ForeignKey("leaderboard.id")),
 )
 
 leaderboard_rating = Table(

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -56,6 +56,7 @@ from .player_service import PlayerService
 from .players import Player, PlayerState
 from .protocol import DisconnectedError, Protocol
 from .rating import InclusiveRange, RatingType
+from .rating_service import RatingService
 from .types import Address, GameLaunchOptions
 
 
@@ -71,7 +72,8 @@ class LobbyConnection:
         geoip: GeoIpService,
         ladder_service: LadderService,
         party_service: PartyService,
-        oauth_service: OAuthService
+        rating_service: RatingService,
+        oauth_service: OAuthService,
     ):
         self._db = database
         self.geoip_service = geoip
@@ -81,6 +83,7 @@ class LobbyConnection:
         self.coturn_generator = CoturnHMAC(config.COTURN_HOSTS, config.COTURN_KEYS)
         self.ladder_service = ladder_service
         self.party_service = party_service
+        self.rating_service = rating_service
         self.oauth_service = oauth_service
         self._authenticated = False
         self.player = None  # type: Player
@@ -603,7 +606,8 @@ class LobbyConnection:
             login=username,
             session=self.session,
             player_id=player_id,
-            lobby_connection=self
+            lobby_connection=self,
+            leaderboards=self.rating_service.leaderboards
         )
 
         old_player = self.player_service.get_player(self.player.id)

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -111,12 +111,15 @@ class MatchmakerQueue:
                 # match this round and will have higher priority next round.
 
                 self.game_service.mark_dirty(self)
+            except asyncio.CancelledError:
+                break
             except Exception:
                 self._logger.exception(
                     "Unexpected error during queue pop timer loop!"
                 )
                 # To avoid potential busy loops
                 await asyncio.sleep(1)
+        self._logger.info("%s queue stopped", self.name)
 
     async def search(self, search: Search) -> None:
         """

--- a/server/players.py
+++ b/server/players.py
@@ -2,15 +2,14 @@
 Player type definitions
 """
 
+from collections import defaultdict
 from contextlib import suppress
 from enum import Enum, unique
-from typing import Optional, Union
-
-from server.config import config
-from server.rating import PlayerRatings, RatingType, RatingTypeMap
+from typing import Dict, Optional, Union
 
 from .factions import Faction
 from .protocol import DisconnectedError
+from .rating import Leaderboard, PlayerRatings, RatingType
 from .weakattr import WeakAttribute
 
 
@@ -41,6 +40,7 @@ class Player:
         login: str = None,
         session: int = 0,
         player_id: int = 0,
+        leaderboards: Dict[str, Leaderboard] = {},
         ratings=None,
         clan=None,
         game_count=None,
@@ -54,13 +54,11 @@ class Player:
         # The player_id of the user in the `login` table of the database.
         self.session = session
 
-        self.ratings = PlayerRatings(
-            lambda: (config.START_RATING_MEAN, config.START_RATING_DEV)
-        )
+        self.ratings = PlayerRatings(leaderboards)
         if ratings is not None:
             self.ratings.update(ratings)
 
-        self.game_count = RatingTypeMap(int)
+        self.game_count = defaultdict(int)
         if game_count is not None:
             self.game_count.update(game_count)
 

--- a/server/rating.py
+++ b/server/rating.py
@@ -57,7 +57,7 @@ class PlayerRatings(Dict[str, Rating]):
         # Rating types which are present but should be recomputed.
         self.transient: Set[str] = set()
 
-        # Initialize known rating types so the client can display them
+        # DEPRECATED: Initialize known rating types so the client can display them
         if init:
             _ = self[RatingType.GLOBAL]
             _ = self[RatingType.LADDER_1V1]

--- a/server/rating.py
+++ b/server/rating.py
@@ -2,13 +2,46 @@
 Type definitions for player ratings
 """
 
+from dataclasses import dataclass
 from typing import DefaultDict, Optional, Tuple, TypeVar, Union
 
 from trueskill import Rating
 
+from server.weakattr import WeakAttribute
 
-# Values correspond to legacy table names. This will be fixed when db gets
-# migrated.
+
+@dataclass(init=False)
+class Leaderboard():
+    id: int
+    technical_name: str
+    # Need the type annotation here so that the dataclass decorator sees it as
+    # a field and includes it in generated methods (such as __eq__)
+    initializer: WeakAttribute["Leaderboard"] = WeakAttribute["Leaderboard"]()
+
+    def __init__(
+        self,
+        id: int,
+        technical_name: str,
+        initializer: Optional["Leaderboard"] = None
+    ):
+        self.id = id
+        self.technical_name = technical_name
+        if initializer:
+            self.initializer = initializer
+
+    def __repr__(self) -> str:
+        initializer = self.initializer
+        initializer_name = "None"
+        if initializer:
+            initializer_name = initializer.technical_name
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self.id}, technical_name={self.technical_name}, "
+            f"initializer={initializer_name})"
+        )
+
+
+# Some places have references to these ratings hardcoded.
 class RatingType():
     GLOBAL = "global"
     LADDER_1V1 = "ladder_1v1"

--- a/server/rating.py
+++ b/server/rating.py
@@ -107,12 +107,10 @@ class PlayerRatings(Dict[str, Rating]):
             return default_rating()
 
         history.add(rating_type)
-        mean, dev = self.__getitem__(
-            leaderboard.initializer.technical_name,
-            history=history
-        )
+        init_rating_type = leaderboard.initializer.technical_name
+        mean, dev = self.__getitem__(init_rating_type, history=history)
 
-        if dev > 250:
+        if dev > 250 or init_rating_type in self.transient:
             return (mean, dev)
 
         return (mean, min(dev + 150, 250))

--- a/server/rating_service/rating_service.py
+++ b/server/rating_service/rating_service.py
@@ -119,7 +119,7 @@ class RatingService(Service):
                 rating_service_backlog.set(self._queue.qsize())
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception:  # pragma: no cover
             self._logger.critical(
                 "Unexpected exception while handling rating queue.",
                 exc_info=True
@@ -439,6 +439,8 @@ class RatingService(Service):
         self._logger.debug(
             "Shutdown initiated. Waiting on current queue: %s", self._queue
         )
+        if self._queue.empty() and self._task:
+            self._task.cancel()
         await self._queue.join()
         self._task = None
         self._logger.debug("Queue emptied: %s", self._queue)

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -110,10 +110,10 @@ insert into user_group_assignment(user_id, group_id) values (1, (SELECT id from 
 insert into user_group_assignment(user_id, group_id) values (2, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
 insert into user_group_assignment(user_id, group_id) values (20, (SELECT id from user_group WHERE technical_name = 'faf_moderators_global'));
 
-insert into leaderboard (id, technical_name, name_key, description_key) values
-  (1, "global", "leaderboard.global.name", "leaderboard.global.desc"),
-  (2, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
-  (3, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
+insert into leaderboard (id, initializer_id, technical_name, name_key, description_key) values
+  (1, NULL, "global", "leaderboard.global.name", "leaderboard.global.desc"),
+  (2, NULL, "ladder_1v1", "leaderboard.ladder_1v1.name", "leaderboard.ladder_1v1.desc"),
+  (3, 1, "tmm_2v2", "leaderboard.tmm_2v2.name", "leaderboard.tmm_2v2.desc");
 
 
 insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderboard_id) values

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -46,7 +46,7 @@ async def join_game(proto: Protocol, uid: int):
         "command": "game_join",
         "uid": uid
     })
-    await read_until_command(proto, "game_launch")
+    await read_until_command(proto, "game_launch", timeout=10)
     await open_fa(proto)
     # HACK: Yield long enough for the server to process our message
     await asyncio.sleep(0.5)

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -60,7 +60,8 @@ async def context(mock_service):
             geoip=mock.Mock(),
             ladder_service=mock.Mock(),
             party_service=mock.Mock(),
-            oauth_service=mock.Mock()
+            rating_service=mock.Mock(),
+            oauth_service=mock.Mock(),
         )
 
     ctx = ServerContext("TestServer", make_connection, [mock_service])

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -456,7 +456,7 @@ async def test_game_matchmaking_timeout(lobby_server):
         await read_until_command(protos[1], "search_info", state="start", timeout=5)
 
 
-@fast_forward(60)
+@fast_forward(120)
 async def test_game_ratings(lobby_server):
     protos, ids = await queue_players_for_matchmaking(lobby_server)
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -80,7 +80,7 @@ def mock_games():
 
 @pytest.fixture
 def mock_protocol():
-    return asynctest.create_autospec(QDataStreamProtocol(mock.Mock(), mock.Mock()))
+    return asynctest.create_autospec(QDataStreamProtocol)
 
 
 @pytest.fixture
@@ -97,7 +97,8 @@ def lobbyconnection(
     mock_players,
     mock_player,
     mock_geoip,
-    mock_nts_client
+    mock_nts_client,
+    rating_service
 ):
     lc = LobbyConnection(
         database=database,
@@ -107,7 +108,8 @@ def lobbyconnection(
         nts_client=mock_nts_client,
         ladder_service=asynctest.create_autospec(LadderService),
         party_service=asynctest.create_autospec(PartyService),
-        oauth_service=asynctest.create_autospec(OAuthService)
+        rating_service=rating_service,
+        oauth_service=asynctest.create_autospec(OAuthService),
     )
 
     lc.player = mock_player

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -53,7 +53,7 @@ def test_equality_by_id():
 
 
 def test_weak_references():
-    p = Player(login="Test")
+    p = Player("Test")
     weak_properties = ["lobby_connection", "game", "game_connection"]
     referent = mock.Mock()
     for prop in weak_properties:
@@ -67,7 +67,7 @@ def test_weak_references():
 
 
 def test_unlink_weakref():
-    p = Player(login="Test")
+    p = Player("Test")
     mock_game = mock.Mock()
     p.game = mock_game
     assert p.game == mock_game
@@ -108,7 +108,7 @@ def test_serialize():
 
 @pytest.mark.asyncio
 async def test_send_message():
-    p = Player(login="Test")
+    p = Player("Test")
 
     assert p.lobby_connection is None
     with pytest.raises(DisconnectedError):
@@ -116,7 +116,7 @@ async def test_send_message():
 
 
 def test_write_message():
-    p = Player(login="Test")
+    p = Player("Test")
 
     assert p.lobby_connection is None
     # Should not raise

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -7,11 +7,21 @@ from trueskill import Rating
 from server.factions import Faction
 from server.players import Player
 from server.protocol import DisconnectedError
-from server.rating import RatingType
+from server.rating import Leaderboard, RatingType
 
 
-def test_ratings():
-    p = Player("Schroedinger")
+@pytest.fixture
+def leaderboards():
+    global_ = Leaderboard(1, "global")
+    return {
+        "global": global_,
+        "ladder_1v1": Leaderboard(2, "ladder_1v1"),
+        "tmm_2v2": Leaderboard(3, "tmm_2v2", global_)
+    }
+
+
+def test_ratings(leaderboards):
+    p = Player("Schroedinger", leaderboards=leaderboards)
     p.ratings[RatingType.GLOBAL] = (1500, 20)
     assert p.ratings[RatingType.GLOBAL] == (1500, 20)
     p.ratings[RatingType.GLOBAL] = Rating(1700, 20)

--- a/tests/unit_tests/test_rating.py
+++ b/tests/unit_tests/test_rating.py
@@ -8,6 +8,13 @@ def ratings():
     return PlayerRatings(lambda: (1500, 500))
 
 
+def test_leaderboard_class():
+    global_l = Leaderboard(1, "global", None)
+    assert global_l == Leaderboard(1, "global", None)
+    assert global_l != Leaderboard(2, "ladder1v1", global_l)
+    assert global_l != Leaderboard(1, "global", global_l)
+
+
 def test_rating_type_default(ratings):
     for rating_type in (RatingType.GLOBAL, RatingType.LADDER_1V1):
         assert ratings[rating_type] == (1500, 500)

--- a/tests/unit_tests/test_rating.py
+++ b/tests/unit_tests/test_rating.py
@@ -5,7 +5,7 @@ from server.rating import PlayerRatings, RatingType
 
 @pytest.fixture
 def ratings():
-    return PlayerRatings(lambda: (1500, 500))
+    return PlayerRatings({})
 
 
 def test_leaderboard_class():

--- a/tests/unit_tests/test_rating.py
+++ b/tests/unit_tests/test_rating.py
@@ -98,16 +98,16 @@ def test_long_initialization_cycle(long_cyclic_ratings):
 
 
 def test_initialization_cycle_with_rating(cyclic_ratings):
-    cyclic_ratings["global"] = (1000, 100)
-    assert cyclic_ratings["global"] == (1000, 100)
-    assert cyclic_ratings["tmm_2v2"] == (1000, 250)
+    cyclic_ratings["global"] = (1000, 50)
+    assert cyclic_ratings["global"] == (1000, 50)
+    assert cyclic_ratings["tmm_2v2"] == (1000, 200)
 
 
 def test_long_initialization_cycle_with_rating(long_cyclic_ratings):
-    long_cyclic_ratings["global"] = (1000, 100)
-    assert long_cyclic_ratings["ladder_1v1"] == (1000, 250)
-    assert long_cyclic_ratings["global"] == (1000, 100)
-    assert long_cyclic_ratings["tmm_2v2"] == (1000, 250)
+    long_cyclic_ratings["global"] = (1000, 50)
+    assert long_cyclic_ratings["global"] == (1000, 50)
+    assert long_cyclic_ratings["tmm_2v2"] == (1000, 200)
+    assert long_cyclic_ratings["ladder_1v1"] == (1000, 200)
 
 
 def test_initialization_chain(chained_ratings):
@@ -117,26 +117,39 @@ def test_initialization_chain(chained_ratings):
 
 
 def test_initialization_chain_with_rating(chained_ratings):
-    chained_ratings["ladder_1v1"] = (1000, 100)
-    assert chained_ratings["ladder_1v1"] == (1000, 100)
-    assert chained_ratings["tmm_2v2"] == (1000, 250)
+    chained_ratings["ladder_1v1"] = (1000, 50)
+    assert chained_ratings["ladder_1v1"] == (1000, 50)
+    assert chained_ratings["global"] == (1000, 200)
+    assert chained_ratings["tmm_2v2"] == (1000, 200)
 
 
 def test_initialization_transient(chained_ratings):
-    chained_ratings["global"] = (1000, 100)
-    assert chained_ratings["tmm_2v2"] == (1000, 250)
+    chained_ratings["global"] = (1000, 50)
+    assert chained_ratings["tmm_2v2"] == (1000, 200)
 
-    chained_ratings["global"] = (700, 100)
-    assert chained_ratings["tmm_2v2"] == (700, 250)
+    chained_ratings["global"] = (700, 50)
+    assert chained_ratings["tmm_2v2"] == (700, 200)
 
     chained_ratings["global"] = (500, 100)
     chained_ratings["tmm_2v2"] = (300, 200)
     assert chained_ratings["tmm_2v2"] == (300, 200)
 
 
+def test_initialization_with_high_deviation(chained_ratings):
+    chained_ratings["ladder_1v1"] = (1000, 150)
+    assert chained_ratings["ladder_1v1"] == (1000, 150)
+    assert chained_ratings["tmm_2v2"] == (1000, 250)
+
+
+def test_initialization_with_very_high_deviation(chained_ratings):
+    chained_ratings["ladder_1v1"] = (1000, 350)
+    assert chained_ratings["ladder_1v1"] == (1000, 350)
+    assert chained_ratings["tmm_2v2"] == (1000, 350)
+
+
 def test_dict_update(chained_ratings):
-    chained_ratings["ladder_1v1"] = (1000, 100)
-    assert chained_ratings["global"] == (1000, 250)
+    chained_ratings["ladder_1v1"] = (1000, 50)
+    assert chained_ratings["global"] == (1000, 200)
 
     chained_ratings.update({
         "ladder_1v1": (500, 100),
@@ -152,21 +165,21 @@ def test_ratings_update_same_leaderboards(chained_leaderboards):
     ratings1 = PlayerRatings(chained_leaderboards)
     ratings2 = PlayerRatings(chained_leaderboards)
     # Global is initialized based on ladder, and should be marked as transient
-    ratings1["ladder_1v1"] = (1000, 100)
-    assert ratings1["global"] == (1000, 250)
+    ratings1["ladder_1v1"] = (1000, 50)
+    assert ratings1["global"] == (1000, 200)
 
     ratings2.update(ratings1)
     # Existing keys should be copied
     assert ratings2 == {
-        "ladder_1v1": (1000, 100),
-        "global": (1000, 250)
+        "ladder_1v1": (1000, 50),
+        "global": (1000, 200)
     }
-    assert ratings2["ladder_1v1"] == (1000, 100)
-    assert ratings2["global"] == (1000, 250)
+    assert ratings2["ladder_1v1"] == (1000, 50)
+    assert ratings2["global"] == (1000, 200)
 
     # Global should be re-initialized
-    ratings2["ladder_1v1"] = (500, 100)
-    assert ratings2["global"] == (500, 250)
+    ratings2["ladder_1v1"] = (500, 50)
+    assert ratings2["global"] == (500, 200)
 
 
 def test_ratings_update_different_leaderboards(
@@ -176,21 +189,21 @@ def test_ratings_update_different_leaderboards(
     ratings1 = PlayerRatings(chained_leaderboards)
     ratings2 = PlayerRatings(cyclic_leaderboards)
     # Global is initialized based on ladder, and should be marked as transient
-    ratings1["ladder_1v1"] = (1000, 100)
-    assert ratings1["global"] == (1000, 250)
+    ratings1["ladder_1v1"] = (1000, 50)
+    assert ratings1["global"] == (1000, 200)
 
     ratings2.update(ratings1)
     # Existing keys should be copied
     assert ratings2 == {
-        "tmm_2v2": (1500, 500),
-        "global": (1000, 250),
-        "ladder_1v1": (1000, 100)
+        "tmm_2v2": DEFAULT_RATING,
+        "global": (1000, 200),
+        "ladder_1v1": (1000, 50)
     }
 
     # Global should be re-initialized based on a the other rating
-    ratings2["ladder_1v1"] = (500, 100)
-    ratings2["tmm_2v2"] = (750, 100)
-    assert ratings2["global"] == (750, 250)
+    ratings2["ladder_1v1"] = (500, 50)
+    ratings2["tmm_2v2"] = (750, 50)
+    assert ratings2["global"] == (750, 200)
 
 
 def test_ratings_update_nontransient_with_transient(chained_leaderboards):
@@ -199,17 +212,17 @@ def test_ratings_update_nontransient_with_transient(chained_leaderboards):
 
     assert ratings_t["ladder_1v1"] == DEFAULT_RATING
     assert ratings_t["global"] == DEFAULT_RATING
-    ratings_nt["ladder_1v1"] = (500, 100)
-    ratings_nt["global"] = (1000, 100)
+    ratings_nt["ladder_1v1"] = (500, 50)
+    ratings_nt["global"] = (1000, 50)
     # Global is not re-initialized
-    assert ratings_nt["global"] == (1000, 100)
+    assert ratings_nt["global"] == (1000, 50)
 
     ratings_nt.update(ratings_t)
     assert ratings_nt == {"ladder_1v1": DEFAULT_RATING, "global": DEFAULT_RATING}
 
-    ratings_nt["ladder_1v1"] = (750, 100)
+    ratings_nt["ladder_1v1"] = (750, 50)
     # Now global is re-initialized
-    assert ratings_nt["global"] == (750, 250)
+    assert ratings_nt["global"] == (750, 200)
 
 
 def test_ratings_update_transient_with_nontransient(chained_leaderboards):
@@ -218,14 +231,14 @@ def test_ratings_update_transient_with_nontransient(chained_leaderboards):
 
     assert ratings_t["ladder_1v1"] == DEFAULT_RATING
     assert ratings_t["global"] == DEFAULT_RATING
-    ratings_nt["ladder_1v1"] = (500, 100)
-    ratings_nt["global"] = (1000, 100)
+    ratings_nt["ladder_1v1"] = (500, 50)
+    ratings_nt["global"] = (1000, 50)
     # Global is not re-initialized
-    assert ratings_nt["global"] == (1000, 100)
+    assert ratings_nt["global"] == (1000, 50)
 
     ratings_t.update(ratings_nt)
-    assert ratings_t == {"ladder_1v1": (500, 100), "global": (1000, 100)}
+    assert ratings_t == {"ladder_1v1": (500, 50), "global": (1000, 50)}
 
-    ratings_t["ladder_1v1"] = (750, 100)
+    ratings_t["ladder_1v1"] = (750, 50)
     # Global is still not re-initialized
-    assert ratings_t["global"] == (1000, 100)
+    assert ratings_t["global"] == (1000, 50)

--- a/tests/unit_tests/test_rating.py
+++ b/tests/unit_tests/test_rating.py
@@ -1,11 +1,59 @@
 import pytest
 
-from server.rating import PlayerRatings, RatingType
+from server.rating import Leaderboard, PlayerRatings, RatingType
+
+DEFAULT_RATING = (1500, 500)
 
 
 @pytest.fixture
 def ratings():
     return PlayerRatings({})
+
+
+@pytest.fixture
+def cyclic_leaderboards():
+    global_l = Leaderboard(1, "global")
+    tmm2v2_l = Leaderboard(2, "tmm_2v2", global_l)
+    global_l.initializer = tmm2v2_l
+    return {
+        global_l.technical_name: global_l,
+        tmm2v2_l.technical_name: tmm2v2_l
+    }
+
+
+@pytest.fixture
+def cyclic_ratings(cyclic_leaderboards):
+    return PlayerRatings(cyclic_leaderboards)
+
+
+@pytest.fixture
+def long_cyclic_ratings():
+    ladder_l = Leaderboard(3, "ladder_1v1")
+    global_l = Leaderboard(1, "global", ladder_l)
+    tmm2v2_l = Leaderboard(2, "tmm_2v2", global_l)
+    ladder_l.initializer = tmm2v2_l
+    return PlayerRatings({
+        ladder_l.technical_name: ladder_l,
+        global_l.technical_name: global_l,
+        tmm2v2_l.technical_name: tmm2v2_l
+    })
+
+
+@pytest.fixture
+def chained_leaderboards():
+    ladder_l = Leaderboard(3, "ladder_1v1")
+    global_l = Leaderboard(1, "global", ladder_l)
+    tmm2v2_l = Leaderboard(2, "tmm_2v2", global_l)
+    return {
+        ladder_l.technical_name: ladder_l,
+        global_l.technical_name: global_l,
+        tmm2v2_l.technical_name: tmm2v2_l
+    }
+
+
+@pytest.fixture
+def chained_ratings(chained_leaderboards):
+    return PlayerRatings(chained_leaderboards)
 
 
 def test_leaderboard_class():
@@ -17,7 +65,11 @@ def test_leaderboard_class():
 
 def test_rating_type_default(ratings):
     for rating_type in (RatingType.GLOBAL, RatingType.LADDER_1V1):
-        assert ratings[rating_type] == (1500, 500)
+        assert ratings[rating_type] == DEFAULT_RATING
+
+
+def test_rating_missing_key(ratings):
+    assert ratings["Not a Rating"] == DEFAULT_RATING
 
 
 def test_str_keys(ratings):
@@ -30,5 +82,150 @@ def test_key_type(ratings):
     ratings[RatingType.GLOBAL]
     ratings[RatingType.LADDER_1V1]
 
-    assert ratings == {"global": (1500, 500), "ladder_1v1": (1500, 500)}
+    assert ratings == {"global": DEFAULT_RATING, "ladder_1v1": DEFAULT_RATING}
     assert list(ratings) == ["global", "ladder_1v1"]
+
+
+def test_initialization_cycle(cyclic_ratings):
+    assert cyclic_ratings["global"] == DEFAULT_RATING
+    assert cyclic_ratings["tmm_2v2"] == DEFAULT_RATING
+
+
+def test_long_initialization_cycle(long_cyclic_ratings):
+    assert long_cyclic_ratings["ladder_1v1"] == DEFAULT_RATING
+    assert long_cyclic_ratings["global"] == DEFAULT_RATING
+    assert long_cyclic_ratings["tmm_2v2"] == DEFAULT_RATING
+
+
+def test_initialization_cycle_with_rating(cyclic_ratings):
+    cyclic_ratings["global"] = (1000, 100)
+    assert cyclic_ratings["global"] == (1000, 100)
+    assert cyclic_ratings["tmm_2v2"] == (1000, 250)
+
+
+def test_long_initialization_cycle_with_rating(long_cyclic_ratings):
+    long_cyclic_ratings["global"] = (1000, 100)
+    assert long_cyclic_ratings["ladder_1v1"] == (1000, 250)
+    assert long_cyclic_ratings["global"] == (1000, 100)
+    assert long_cyclic_ratings["tmm_2v2"] == (1000, 250)
+
+
+def test_initialization_chain(chained_ratings):
+    assert chained_ratings["ladder_1v1"] == DEFAULT_RATING
+    assert chained_ratings["global"] == DEFAULT_RATING
+    assert chained_ratings["tmm_1v1"] == DEFAULT_RATING
+
+
+def test_initialization_chain_with_rating(chained_ratings):
+    chained_ratings["ladder_1v1"] = (1000, 100)
+    assert chained_ratings["ladder_1v1"] == (1000, 100)
+    assert chained_ratings["tmm_2v2"] == (1000, 250)
+
+
+def test_initialization_transient(chained_ratings):
+    chained_ratings["global"] = (1000, 100)
+    assert chained_ratings["tmm_2v2"] == (1000, 250)
+
+    chained_ratings["global"] = (700, 100)
+    assert chained_ratings["tmm_2v2"] == (700, 250)
+
+    chained_ratings["global"] = (500, 100)
+    chained_ratings["tmm_2v2"] = (300, 200)
+    assert chained_ratings["tmm_2v2"] == (300, 200)
+
+
+def test_dict_update(chained_ratings):
+    chained_ratings["ladder_1v1"] = (1000, 100)
+    assert chained_ratings["global"] == (1000, 250)
+
+    chained_ratings.update({
+        "ladder_1v1": (500, 100),
+        "global": (750, 100)
+    })
+
+    assert chained_ratings["ladder_1v1"] == (500, 100)
+    # Global should not be re-initialized after dict update
+    assert chained_ratings["global"] == (750, 100)
+
+
+def test_ratings_update_same_leaderboards(chained_leaderboards):
+    ratings1 = PlayerRatings(chained_leaderboards)
+    ratings2 = PlayerRatings(chained_leaderboards)
+    # Global is initialized based on ladder, and should be marked as transient
+    ratings1["ladder_1v1"] = (1000, 100)
+    assert ratings1["global"] == (1000, 250)
+
+    ratings2.update(ratings1)
+    # Existing keys should be copied
+    assert ratings2 == {
+        "ladder_1v1": (1000, 100),
+        "global": (1000, 250)
+    }
+    assert ratings2["ladder_1v1"] == (1000, 100)
+    assert ratings2["global"] == (1000, 250)
+
+    # Global should be re-initialized
+    ratings2["ladder_1v1"] = (500, 100)
+    assert ratings2["global"] == (500, 250)
+
+
+def test_ratings_update_different_leaderboards(
+    cyclic_leaderboards,
+    chained_leaderboards
+):
+    ratings1 = PlayerRatings(chained_leaderboards)
+    ratings2 = PlayerRatings(cyclic_leaderboards)
+    # Global is initialized based on ladder, and should be marked as transient
+    ratings1["ladder_1v1"] = (1000, 100)
+    assert ratings1["global"] == (1000, 250)
+
+    ratings2.update(ratings1)
+    # Existing keys should be copied
+    assert ratings2 == {
+        "tmm_2v2": (1500, 500),
+        "global": (1000, 250),
+        "ladder_1v1": (1000, 100)
+    }
+
+    # Global should be re-initialized based on a the other rating
+    ratings2["ladder_1v1"] = (500, 100)
+    ratings2["tmm_2v2"] = (750, 100)
+    assert ratings2["global"] == (750, 250)
+
+
+def test_ratings_update_nontransient_with_transient(chained_leaderboards):
+    ratings_t = PlayerRatings(chained_leaderboards)
+    ratings_nt = PlayerRatings(chained_leaderboards)
+
+    assert ratings_t["ladder_1v1"] == DEFAULT_RATING
+    assert ratings_t["global"] == DEFAULT_RATING
+    ratings_nt["ladder_1v1"] = (500, 100)
+    ratings_nt["global"] = (1000, 100)
+    # Global is not re-initialized
+    assert ratings_nt["global"] == (1000, 100)
+
+    ratings_nt.update(ratings_t)
+    assert ratings_nt == {"ladder_1v1": DEFAULT_RATING, "global": DEFAULT_RATING}
+
+    ratings_nt["ladder_1v1"] = (750, 100)
+    # Now global is re-initialized
+    assert ratings_nt["global"] == (750, 250)
+
+
+def test_ratings_update_transient_with_nontransient(chained_leaderboards):
+    ratings_t = PlayerRatings(chained_leaderboards)
+    ratings_nt = PlayerRatings(chained_leaderboards)
+
+    assert ratings_t["ladder_1v1"] == DEFAULT_RATING
+    assert ratings_t["global"] == DEFAULT_RATING
+    ratings_nt["ladder_1v1"] = (500, 100)
+    ratings_nt["global"] = (1000, 100)
+    # Global is not re-initialized
+    assert ratings_nt["global"] == (1000, 100)
+
+    ratings_t.update(ratings_nt)
+    assert ratings_t == {"ladder_1v1": (500, 100), "global": (1000, 100)}
+
+    ratings_t["ladder_1v1"] = (750, 100)
+    # Global is still not re-initialized
+    assert ratings_t["global"] == (1000, 100)

--- a/tests/unit_tests/test_rating_service.py
+++ b/tests/unit_tests/test_rating_service.py
@@ -201,29 +201,6 @@ async def get_all_ratings(db: FAFDatabase, player_id: int):
     return rows
 
 
-async def test_get_player_rating_legacy(semiinitialized_service):
-    service = semiinitialized_service
-    # Player 51 should have no leaderboard_rating entry
-    # but entries in the legacy global_rating and ladder1v1_rating tables
-    player_id = 51
-    legacy_global_rating = Rating(1201, 250)
-    legacy_ladder_rating = Rating(1301, 400)
-
-    db_ratings = await get_all_ratings(service._db, player_id)
-    assert len(db_ratings) == 0  # no new rating entries yet
-
-    rating = await service._get_player_rating(player_id, RatingType.GLOBAL)
-    assert rating == legacy_global_rating
-
-    rating = await service._get_player_rating(player_id, RatingType.LADDER_1V1)
-    assert rating == legacy_ladder_rating
-
-    db_ratings = await get_all_ratings(service._db, player_id)
-    assert len(db_ratings) == 2  # new rating entries were created
-    assert db_ratings[0]["mean"] == 1201
-    assert db_ratings[1]["mean"] == 1301
-
-
 async def test_get_new_player_rating_created(semiinitialized_service):
     """
     Upon rating games of players without a rating entry in both new and legacy

--- a/tests/unit_tests/test_rating_service.py
+++ b/tests/unit_tests/test_rating_service.py
@@ -17,7 +17,7 @@ from server.games.typedefs import (
     TeamRatingSummary,
     ValidityState
 )
-from server.rating import RatingType
+from server.rating import Leaderboard, RatingType
 from server.rating_service.rating_service import (
     RatingService,
     ServiceNotReadyError
@@ -153,14 +153,23 @@ async def test_get_rating_uninitialized(uninitialized_service):
         await service._get_player_rating(1, RatingType.GLOBAL)
 
 
-async def test_load_rating_type_ids(uninitialized_service):
+async def test_load_from_database(uninitialized_service):
     service = uninitialized_service
+    assert service._rating_type_ids is None
+    assert service.leaderboards == {}
+
     await service.update_data()
 
     assert service._rating_type_ids == {
         "global": 1,
         "ladder_1v1": 2,
         "tmm_2v2": 3
+    }
+    global_ = Leaderboard(1, "global")
+    assert service.leaderboards == {
+        "global": global_,
+        "ladder_1v1": Leaderboard(2, "ladder_1v1"),
+        "tmm_2v2": Leaderboard(3, "tmm_2v2", global_)
     }
 
 


### PR DESCRIPTION
Implement reading the initializer from the database.

One question is whether the `global` and `ladder_1v1` ratings need to continue to be eagerly created. Right now even completely new players will have a global and ladder rating in their `ratings` dictionary, however is this really necessary?

Closes #724