### PR TITLE
Feature/#727 refactor matchmaker for 4v4 party algorithm

### DIFF
--- a/server/matchmaker/algorithm/bucket_teams.py
+++ b/server/matchmaker/algorithm/bucket_teams.py
@@ -1,0 +1,255 @@
+import itertools
+import math
+import random
+import statistics as stats
+from collections import OrderedDict
+from typing import (
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar
+)
+
+from ...decorators import with_logger
+from ..search import CombinedSearch, Match, Search
+
+T = TypeVar("T")
+Buckets = Dict[Search, List[Tuple[Search, float]]]
+
+
+def make_matches(searches: Iterable[Search]) -> List[Match]:
+    """
+    Main entrypoint for the matchmaker algorithm.
+    """
+    return Matchmaker(searches).find()
+
+def avg_mean(search: Search) -> float:
+    """
+    Get the average of all trueskill means for a search counting means with
+    high deviation as 0.
+    """
+    return stats.mean(mean if dev < 250 else 0 for mean, dev in search.ratings)
+
+
+def rotate(list_: List[T], amount: int) -> List[T]:
+    return list_[amount:] + list_[:amount]
+
+
+def make_teams_from_single(
+    searches: List[Search],
+    size: int
+) -> Tuple[List[Search], List[Search]]:
+    """
+    Make teams in the special case where all players are solo queued (no
+    parties).
+
+    Tries to put players of similar skill on the same team as long as there are
+    enough such players to form at least 2 teams. If there are not enough
+    similar players for two teams, then distributes similarly rated players
+    accross different teams.
+
+    # Algorithm
+    1. Group players into "buckets" by rating. This is a sort of heuristic for
+        determining which players have similar rating.
+    2. Create as many games as possible within each bucket.
+    3. Create games from remaining players by balancing teams with players from
+        different buckets.
+    """
+    assert all(len(s.players) == 1 for s in searches)
+
+    # Make buckets
+    buckets = _make_buckets(searches)
+    remaining: List[Tuple[Search, float]] = []
+
+    new_searches: List[Search] = []
+    # Match up players within buckets
+    for bucket in buckets.values():
+        # Always produce an even number of teams
+        num_groups = len(bucket) // (size * 2)
+        num_teams = num_groups * 2
+        num_players = num_teams * size
+
+        selected = random.sample(bucket, num_players)
+        # TODO: Optimize?
+        remaining.extend(s for s in bucket if s not in selected)
+        # Sort by trueskill mean
+        selected.sort(key=lambda item: item[1])
+        new_searches.extend(_distribute(selected, size))
+
+    # Match up players accross buckets
+    remaining.sort(key=lambda item: item[1])
+    while len(remaining) >= size:
+        if len(remaining) >= 2 * size:
+            # enough for at least 2 teams
+            selected = remaining[:2 * size]
+            new_searches.extend(_distribute(selected, size))
+        else:
+            selected = remaining[:size]
+            new_searches.append(CombinedSearch(*[s for s, m in selected]))
+
+        remaining = [item for item in remaining if item not in selected]
+
+    return new_searches, [search for search, _ in remaining]
+
+
+def _make_buckets(searches: List[Search]) -> Buckets:
+    """
+    Group players together by similar rating.
+
+    # Algorithm
+    1. Choose a random player as the "pivot".
+    2. Find all players with rating within 100 pts of this player and place
+        them in a bucket.
+    3. Repeat with remaining players.
+    """
+    remaining = list(map(lambda s: (s, avg_mean(s)), searches))
+    buckets: Buckets = {}
+
+    while remaining:
+        # Choose a pivot
+        pivot, mean = random.choice(remaining)
+        low, high = mean - 100, mean + 100
+
+        # Partition remaining based on how close their means are
+        bucket, not_bucket = [], []
+        for item in remaining:
+            (_, other_mean) = item
+            if low <= other_mean <= high:
+                bucket.append(item)
+            else:
+                not_bucket.append(item)
+
+        buckets[pivot] = bucket
+        remaining = not_bucket
+
+    return buckets
+
+
+def _distribute(
+    items: List[Tuple[Search, float]],
+    team_size: int
+) -> Iterator[CombinedSearch]:
+    """
+    Distributes a sorted list into teams of a given size in a balanced manner.
+    Player "skill" is determined by their position in the list.
+
+    For example (using numbers to represent list positions)
+    ```
+    _distribute([1,2,3,4], 2) == [[1,4], [2,3]]
+    ```
+    In this simple scenario, one team gets the best and the worst player and
+    the other player gets the two in the middle. This is the only way of
+    distributing these 4 items into 2 teams such that there is no obviously
+    favored team.
+    """
+    num_teams = len(items) // team_size
+    teams: List[List[Search]] = [[] for _ in range(num_teams)]
+    half = len(items) // 2
+    # Rotate the second half of the list
+    rotated = items[:half] + rotate(items[half:], half // 2)
+    for i, (search, _) in enumerate(rotated):
+        # Distribute the pairs to the appropriate team
+        teams[i % num_teams].append(search)
+
+    return (CombinedSearch(*team) for team in teams)
+
+
+def make_teams(
+    searches: List[Search],
+    size: int
+) -> Tuple[List[Search], List[Search]]:
+    """
+    Tries to group as many searches together into teams of the given size as
+    possible. Returns the new grouped searches, and the remaining searches that
+    were not succesfully grouped.
+
+    Does not try to balance teams so it should be used only as a last resort.
+    """
+
+    searches_by_size = _make_searches_by_size(searches)
+
+    new_searches = []
+    for search in searches:
+        if len(search.players) > size:
+            continue
+
+        new_search = _make_team_for_search(search, searches_by_size, size)
+        if new_search:
+            new_searches.append(new_search)
+
+    return new_searches, list(itertools.chain(*searches_by_size.values()))
+
+
+def _make_searches_by_size(searches: List[Search]) -> Dict[int, Set[Search]]:
+    """
+    Creates a lookup table indexed by number of players in the search.
+    """
+
+    searches_by_size: Dict[int, Set[Search]] = OrderedDict()
+
+    # Would be easier with defaultdict, but we want to preserve key order
+    for search in searches:
+        size = len(search.players)
+        if size not in searches_by_size:
+            searches_by_size[size] = set()
+        searches_by_size[size].add(search)
+
+    return searches_by_size
+
+
+def _make_team_for_search(
+    search: Search,
+    searches_by_size: Dict[int, Set[Search]],
+    size: int
+) -> Optional[Search]:
+    """
+    Match this search with other searches to create a new team of `size`
+    members.
+    """
+
+    num_players = len(search.players)
+    if search not in searches_by_size[num_players]:
+        return None
+    searches_by_size[num_players].remove(search)
+
+    if num_players == size:
+        return search
+
+    num_needed = size - num_players
+    try_size = num_needed
+    new_search = search
+    while num_needed > 0:
+        if try_size == 0:
+            _uncombine(new_search, searches_by_size)
+            return None
+
+        try:
+            other = searches_by_size[try_size].pop()
+            new_search = CombinedSearch(new_search, other)
+            num_needed -= try_size
+            try_size = num_needed
+        except KeyError:
+            try_size -= 1
+
+    return new_search
+
+
+def _uncombine(
+    search: Search,
+    searches_by_size: Dict[int, Set[Search]]
+) -> None:
+    """
+    Adds all of the searches in search back to their respective spots in
+    `searches_by_size`.
+    """
+
+    if not isinstance(search, CombinedSearch):
+        searches_by_size[len(search.players)].add(search)
+        return
+
+    for s in search.searches:
+        _uncombine(s, searches_by_size)

--- a/server/matchmaker/algorithm/bucket_teams.py
+++ b/server/matchmaker/algorithm/bucket_teams.py
@@ -24,14 +24,20 @@ Buckets = Dict[Search, List[Tuple[Search, float]]]
 
 @with_logger
 class BucketTeamMatchmaker(Matchmaker):
-    def find(self) -> List[Match]:
-        teams = self._find_teams()
-        matchmaker1v1 = StableMarriageMatchmaker(teams, 1)
-        return matchmaker1v1.find()
+    """
+    Uses heuristics to group searches of any size
+    into CombinedSearches of team_size
+    and then runs StableMarriageMatchmaker
+    to produce a list of matches from these.
+    """
+    def find(self, searches: Iterable[Search]) -> List[Match]:
+        teams = self._find_teams(searches)
+        matchmaker1v1 = StableMarriageMatchmaker(1)
+        return matchmaker1v1.find(teams)
 
-    def _find_teams(self) -> List[Search]:
+    def _find_teams(self, searches: Iterable[Search]) -> List[Search]:
         full_teams = []
-        unmatched = self.searches
+        unmatched = searches
         need_team = []
         for search in unmatched:
             if len(search.players) == self.team_size:

--- a/server/matchmaker/algorithm/bucket_teams.py
+++ b/server/matchmaker/algorithm/bucket_teams.py
@@ -40,8 +40,9 @@ class BucketTeamMatchmaker(Matchmaker):
         unmatched_searches.extend(searches_without_team)
         return matches, unmatched_searches
 
+    @staticmethod
     def _find_teams(
-        self, searches: Iterable[Search], team_size: int
+        searches: Iterable[Search], team_size: int
     ) -> Tuple[List[Search], List[Search]]:
         full_teams = []
         unmatched = searches

--- a/server/matchmaker/algorithm/bucket_teams.py
+++ b/server/matchmaker/algorithm/bucket_teams.py
@@ -1,7 +1,5 @@
 import itertools
-import math
 import random
-import statistics as stats
 from collections import OrderedDict
 from typing import (
     Dict,
@@ -30,6 +28,7 @@ class BucketTeamMatchmaker(Matchmaker):
     and then runs StableMarriageMatchmaker
     to produce a list of matches from these.
     """
+
     def find(self, searches: Iterable[Search]) -> List[Match]:
         teams = self._find_teams(searches)
         matchmaker1v1 = StableMarriageMatchmaker(1)
@@ -53,9 +52,9 @@ class BucketTeamMatchmaker(Matchmaker):
 
         return full_teams
 
+
 def _make_teams_from_single(
-    searches: List[Search],
-    size: int
+    searches: List[Search], size: int
 ) -> Tuple[List[Search], List[Search]]:
     """
     Make teams in the special case where all players are solo queued (no
@@ -99,7 +98,7 @@ def _make_teams_from_single(
     while len(remaining) >= size:
         if len(remaining) >= 2 * size:
             # enough for at least 2 teams
-            selected = remaining[:2 * size]
+            selected = remaining[: 2 * size]
             new_searches.extend(_distribute(selected, size))
         else:
             selected = remaining[:size]
@@ -144,8 +143,7 @@ def _make_buckets(searches: List[Search]) -> Buckets:
 
 
 def _distribute(
-    items: List[Tuple[Search, float]],
-    team_size: int
+    items: List[Tuple[Search, float]], team_size: int
 ) -> Iterator[CombinedSearch]:
     """
     Distributes a sorted list into teams of a given size in a balanced manner.
@@ -172,10 +170,7 @@ def _distribute(
     return (CombinedSearch(*team) for team in teams)
 
 
-def _make_teams(
-    searches: List[Search],
-    size: int
-) -> Tuple[List[Search], List[Search]]:
+def _make_teams(searches: List[Search], size: int) -> Tuple[List[Search], List[Search]]:
     """
     Tries to group as many searches together into teams of the given size as
     possible. Returns the new grouped searches, and the remaining searches that
@@ -216,9 +211,7 @@ def _make_searches_by_size(searches: List[Search]) -> Dict[int, Set[Search]]:
 
 
 def _make_team_for_search(
-    search: Search,
-    searches_by_size: Dict[int, Set[Search]],
-    size: int
+    search: Search, searches_by_size: Dict[int, Set[Search]], size: int
 ) -> Optional[Search]:
     """
     Match this search with other searches to create a new team of `size`
@@ -252,10 +245,7 @@ def _make_team_for_search(
     return new_search
 
 
-def _uncombine(
-    search: Search,
-    searches_by_size: Dict[int, Set[Search]]
-) -> None:
+def _uncombine(search: Search, searches_by_size: Dict[int, Set[Search]]) -> None:
     """
     Adds all of the searches in search back to their respective spots in
     `searches_by_size`.
@@ -267,6 +257,7 @@ def _uncombine(
 
     for s in search.searches:
         _uncombine(s, searches_by_size)
+
 
 def rotate(list_: List[T], amount: int) -> List[T]:
     return list_[amount:] + list_[:amount]

--- a/server/matchmaker/algorithm/matchmaker.py
+++ b/server/matchmaker/algorithm/matchmaker.py
@@ -1,20 +1,8 @@
-import itertools
-import math
-import random
-import statistics as stats
-from collections import OrderedDict
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
-)
+from typing import Iterable, List
 
 from ...decorators import with_logger
-from ..search import CombinedSearch, Match, Search
+from ..search import Match, Search
+
 
 @with_logger
 class Matchmaker(object):

--- a/server/matchmaker/algorithm/matchmaker.py
+++ b/server/matchmaker/algorithm/matchmaker.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Tuple
+from typing import Dict, Iterable, List, Set, Tuple
 
 from ...decorators import with_logger
 from ..search import Match, Search

--- a/server/matchmaker/algorithm/matchmaker.py
+++ b/server/matchmaker/algorithm/matchmaker.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 
 from ...decorators import with_logger
 from ..search import Match, Search
@@ -6,10 +6,38 @@ from ..search import Match, Search
 
 @with_logger
 class Matchmaker(object):
-    def __init__(self, team_size: int):
-        self.team_size = team_size
-
-    def find(self, searches: Iterable[Search]) -> List[Match]:
+    def find(
+        self, searches: Iterable[Search], team_size: int
+    ) -> Tuple[List[Match], List[Search]]:
         raise NotImplementedError(
             "Matchmaker.find should be implemented by concrete subclasses"
         )
+
+
+@with_logger
+class MatchmakingPolicy1v1(object):
+    def __init__(self):
+        self.matches: Dict[Search, Search] = {}
+        self.searches_remaining_unmatched: Set[Search] = set()
+
+    def _match(self, s1: Search, s2: Search):
+        self._logger.debug(
+            "Matching %s and %s (%s)",
+            s1, s2, self.__class__
+        )
+        self.matches[s1] = s2
+        self.matches[s2] = s1
+        self.searches_remaining_unmatched.discard(s1)
+        self.searches_remaining_unmatched.discard(s2)
+
+    def _unmatch(self, s1: Search):
+        s2 = self.matches[s1]
+        self._logger.debug(
+            "Unmatching %s and %s (%s)",
+            s1, s2, self.__class__
+        )
+        assert self.matches[s2] == s1
+        del self.matches[s1]
+        del self.matches[s2]
+        self.searches_remaining_unmatched.add(s1)
+        self.searches_remaining_unmatched.add(s2)

--- a/server/matchmaker/algorithm/matchmaker.py
+++ b/server/matchmaker/algorithm/matchmaker.py
@@ -1,0 +1,27 @@
+import itertools
+import math
+import random
+import statistics as stats
+from collections import OrderedDict
+from typing import (
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
+
+from ...decorators import with_logger
+from ..search import CombinedSearch, Match, Search
+
+@with_logger
+class Matchmaker(object):
+    def __init__(self, team_size: int):
+        self.team_size = team_size
+
+    def find(self, searches: Iterable[Search]) -> List[Match]:
+        raise NotImplementedError(
+            "Matchmaker.find should be implemented by concrete subclasses"
+        )

--- a/server/matchmaker/algorithm/matchmaker.py
+++ b/server/matchmaker/algorithm/matchmaker.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Dict, Iterable, List, Set, Tuple
 
 from ...decorators import with_logger
@@ -5,13 +6,14 @@ from ..search import Match, Search
 
 
 @with_logger
-class Matchmaker(object):
+class Matchmaker(ABC):
+    @abstractmethod
     def find(
-        self, searches: Iterable[Search], team_size: int
+        self,
+        searches: Iterable[Search],
+        team_size: int
     ) -> Tuple[List[Match], List[Search]]:
-        raise NotImplementedError(
-            "Matchmaker.find should be implemented by concrete subclasses"
-        )
+        pass
 
 
 @with_logger

--- a/server/matchmaker/algorithm/random_newbies.py
+++ b/server/matchmaker/algorithm/random_newbies.py
@@ -1,7 +1,7 @@
 from typing import Dict, Iterable, List, Tuple
 
 from ..search import Match, Search
-from .matchmaker import Matchmaker, MatchmakingPolicy1v1
+from .matchmaker import MatchmakingPolicy1v1
 
 
 class RandomlyMatchNewbies(MatchmakingPolicy1v1):

--- a/server/matchmaker/algorithm/random_newbies.py
+++ b/server/matchmaker/algorithm/random_newbies.py
@@ -1,6 +1,8 @@
-from .matchmaker import Matchmaker, MatchmakingPolicy1v1
-from typing import Iterable, Tuple, Dict, List
+from typing import Dict, Iterable, List, Tuple
+
 from ..search import Match, Search
+from .matchmaker import Matchmaker, MatchmakingPolicy1v1
+
 
 class RandomlyMatchNewbies(MatchmakingPolicy1v1):
     def find(
@@ -34,20 +36,3 @@ class RandomlyMatchNewbies(MatchmakingPolicy1v1):
             searches_remaining_unmatched.discard(first_opponent)
 
         return self.matches, list(searches_remaining_unmatched)
-
-
-class RandomNewbieMatchmaker(Matchmaker):
-    """
-    Generates random matchups for new players.
-    """
-    def find(
-        self, searches: Iterable[Search], team_size: int
-    ) -> Tuple[List[Match], List[Search]]:
-        if team_size != 1:
-            self._logger.error(
-                "Invalid team size %i for randomly matching newbies will be ignored",
-                team_size,
-            )
-
-        matched_searches, unmatched_searches = RandomlyMatchNewbies().find(searches)
-        return list(matched_searches.items()), unmatched_searches

--- a/server/matchmaker/algorithm/random_newbies.py
+++ b/server/matchmaker/algorithm/random_newbies.py
@@ -1,0 +1,53 @@
+from .matchmaker import Matchmaker, MatchmakingPolicy1v1
+from typing import Iterable, Tuple, Dict, List
+from ..search import Match, Search
+
+class RandomlyMatchNewbies(MatchmakingPolicy1v1):
+    def find(
+        self, searches: Iterable[Search]
+    ) -> Tuple[Dict[Search, Search], List[Match]]:
+        self.matches.clear()
+        searches_remaining_unmatched = set(searches)
+
+        unmatched_newbies: List[Search] = []
+        first_opponent = None
+        for search in searches:
+            if search.has_top_player():
+                continue
+            elif search.has_newbie():
+                unmatched_newbies.append(search)
+            elif not first_opponent and search.failed_matching_attempts >= 1:
+                first_opponent = search
+
+        while len(unmatched_newbies) >= 2:
+            newbie1 = unmatched_newbies.pop()
+            newbie2 = unmatched_newbies.pop()
+            self._match(newbie1, newbie2)
+            searches_remaining_unmatched.discard(newbie1)
+            searches_remaining_unmatched.discard(newbie2)
+
+        can_match_last_newbie_with_first_opponent = unmatched_newbies and first_opponent
+        if can_match_last_newbie_with_first_opponent:
+            newbie = unmatched_newbies[0]
+            self._match(newbie, first_opponent)
+            searches_remaining_unmatched.discard(newbie)
+            searches_remaining_unmatched.discard(first_opponent)
+
+        return self.matches, list(searches_remaining_unmatched)
+
+
+class RandomNewbieMatchmaker(Matchmaker):
+    """
+    Generates random matchups for new players.
+    """
+    def find(
+        self, searches: Iterable[Search], team_size: int
+    ) -> Tuple[List[Match], List[Search]]:
+        if team_size != 1:
+            self._logger.error(
+                "Invalid team size %i for randomly matching newbies will be ignored",
+                team_size,
+            )
+
+        matched_searches, unmatched_searches = RandomlyMatchNewbies().find(searches)
+        return list(matched_searches.items()), unmatched_searches

--- a/server/matchmaker/algorithm/stable_marriage.py
+++ b/server/matchmaker/algorithm/stable_marriage.py
@@ -108,7 +108,8 @@ class StableMarriageMatchmaker(Matchmaker):
 
         return self._remove_duplicates(matches), unmatched_searches
 
-    def _remove_duplicates(self, matches: Dict[Search, Search]) -> List[Match]:
+    @staticmethod
+    def _remove_duplicates(matches: Dict[Search, Search]) -> List[Match]:
         matches_set: Set[Match] = set()
         for s1, s2 in matches.items():
             if (s1, s2) in matches_set or (s2, s1) in matches_set:
@@ -178,7 +179,6 @@ class _MatchingGraph:
 
     @staticmethod
     def is_possible_match(search: Search, other: Search, quality: float) -> bool:
-        log_string = "Quality between %s and %s: %.3f thresholds: [%.3f, %.3f]."
         log_args = (
             search,
             other,

--- a/server/matchmaker/algorithm/stable_marriage.py
+++ b/server/matchmaker/algorithm/stable_marriage.py
@@ -11,26 +11,17 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    TypeVar
 )
 
-from ..decorators import with_logger
-from .search import CombinedSearch, Match, Search
+from ...decorators import with_logger
+from ..search import CombinedSearch, Match, Search
 
-T = TypeVar("T")
 WeightedGraph = Dict[Search, List[Tuple[Search, float]]]
-Buckets = Dict[Search, List[Tuple[Search, float]]]
 
-
-def make_matches(searches: Iterable[Search]) -> List[Match]:
-    """
-    Main entrypoint for the matchmaker algorithm.
-    """
-    return Matchmaker(searches).find()
 
 
 @with_logger
-class MatchmakingPolicy(object):
+class MatchmakingPolicy1v1(object):
     def __init__(self):
         self.matches: Dict[Search, Search] = {}
 
@@ -47,7 +38,7 @@ class MatchmakingPolicy(object):
         del self.matches[s2]
 
 
-class StableMarriage(MatchmakingPolicy):
+class StableMarriage(MatchmakingPolicy1v1):
     def find(self, ranks: WeightedGraph) -> Dict[Search, Search]:
         """ Perform the stable matching algorithm until a maximal stable matching
         is found.
@@ -106,7 +97,7 @@ class StableMarriage(MatchmakingPolicy):
             self._match(search, preferred)
 
 
-class RandomlyMatchNewbies(MatchmakingPolicy):
+class RandomlyMatchNewbies(MatchmakingPolicy1v1):
     def find(self, searches: Iterable[Search]) -> Dict[Search, Search]:
         self.matches.clear()
 
@@ -132,13 +123,31 @@ class RandomlyMatchNewbies(MatchmakingPolicy):
 
         return self.matches
 
-
 @with_logger
 class Matchmaker(object):
     def __init__(self, searches: Iterable[Search]):
         self.searches = searches
         self.matches: Dict[Search, Search] = {}
 
+    def _register_unmatched_searches(self):
+        """
+        Tells all unmatched searches that they went through a failed matching
+        attempt.
+        """
+        for search in self.searches:
+            if search in self.matches:
+                continue
+
+            search.register_failed_matching_attempt()
+            self._logger.debug(
+                "Search %s remained unmatched at threshold %f in attempt number %s",
+                search, search.match_threshold, search.failed_matching_attempts
+            )
+
+
+
+@with_logger
+class StableMarriageMatchmaker(Matchmaker):
     def find(self) -> List[Match]:
         self._logger.debug("Matching with stable marriage...")
         searches = list(self.searches)
@@ -158,21 +167,6 @@ class Matchmaker(object):
         self._register_unmatched_searches()
 
         return self._remove_duplicates()
-
-    def _register_unmatched_searches(self):
-        """
-        Tells all unmatched searches that they went through a failed matching
-        attempt.
-        """
-        for search in self.searches:
-            if search in self.matches:
-                continue
-
-            search.register_failed_matching_attempt()
-            self._logger.debug(
-                "Search %s remained unmatched at threshold %f in attempt number %s",
-                search, search.match_threshold, search.failed_matching_attempts
-            )
 
     def _remove_duplicates(self) -> List[Match]:
         matches_set: Set[Match] = set()
@@ -273,7 +267,6 @@ class _MatchingGraph:
             if not neighbors:
                 del graph[search]
 
-
 def avg_mean(search: Search) -> float:
     """
     Get the average of all trueskill means for a search counting means with
@@ -281,222 +274,3 @@ def avg_mean(search: Search) -> float:
     """
     return stats.mean(mean if dev < 250 else 0 for mean, dev in search.ratings)
 
-
-def rotate(list_: List[T], amount: int) -> List[T]:
-    return list_[amount:] + list_[:amount]
-
-
-def make_teams_from_single(
-    searches: List[Search],
-    size: int
-) -> Tuple[List[Search], List[Search]]:
-    """
-    Make teams in the special case where all players are solo queued (no
-    parties).
-
-    Tries to put players of similar skill on the same team as long as there are
-    enough such players to form at least 2 teams. If there are not enough
-    similar players for two teams, then distributes similarly rated players
-    accross different teams.
-
-    # Algorithm
-    1. Group players into "buckets" by rating. This is a sort of heuristic for
-        determining which players have similar rating.
-    2. Create as many games as possible within each bucket.
-    3. Create games from remaining players by balancing teams with players from
-        different buckets.
-    """
-    assert all(len(s.players) == 1 for s in searches)
-
-    # Make buckets
-    buckets = _make_buckets(searches)
-    remaining: List[Tuple[Search, float]] = []
-
-    new_searches: List[Search] = []
-    # Match up players within buckets
-    for bucket in buckets.values():
-        # Always produce an even number of teams
-        num_groups = len(bucket) // (size * 2)
-        num_teams = num_groups * 2
-        num_players = num_teams * size
-
-        selected = random.sample(bucket, num_players)
-        # TODO: Optimize?
-        remaining.extend(s for s in bucket if s not in selected)
-        # Sort by trueskill mean
-        selected.sort(key=lambda item: item[1])
-        new_searches.extend(_distribute(selected, size))
-
-    # Match up players accross buckets
-    remaining.sort(key=lambda item: item[1])
-    while len(remaining) >= size:
-        if len(remaining) >= 2 * size:
-            # enough for at least 2 teams
-            selected = remaining[:2 * size]
-            new_searches.extend(_distribute(selected, size))
-        else:
-            selected = remaining[:size]
-            new_searches.append(CombinedSearch(*[s for s, m in selected]))
-
-        remaining = [item for item in remaining if item not in selected]
-
-    return new_searches, [search for search, _ in remaining]
-
-
-def _make_buckets(searches: List[Search]) -> Buckets:
-    """
-    Group players together by similar rating.
-
-    # Algorithm
-    1. Choose a random player as the "pivot".
-    2. Find all players with rating within 100 pts of this player and place
-        them in a bucket.
-    3. Repeat with remaining players.
-    """
-    remaining = list(map(lambda s: (s, avg_mean(s)), searches))
-    buckets: Buckets = {}
-
-    while remaining:
-        # Choose a pivot
-        pivot, mean = random.choice(remaining)
-        low, high = mean - 100, mean + 100
-
-        # Partition remaining based on how close their means are
-        bucket, not_bucket = [], []
-        for item in remaining:
-            (_, other_mean) = item
-            if low <= other_mean <= high:
-                bucket.append(item)
-            else:
-                not_bucket.append(item)
-
-        buckets[pivot] = bucket
-        remaining = not_bucket
-
-    return buckets
-
-
-def _distribute(
-    items: List[Tuple[Search, float]],
-    team_size: int
-) -> Iterator[CombinedSearch]:
-    """
-    Distributes a sorted list into teams of a given size in a balanced manner.
-    Player "skill" is determined by their position in the list.
-
-    For example (using numbers to represent list positions)
-    ```
-    _distribute([1,2,3,4], 2) == [[1,4], [2,3]]
-    ```
-    In this simple scenario, one team gets the best and the worst player and
-    the other player gets the two in the middle. This is the only way of
-    distributing these 4 items into 2 teams such that there is no obviously
-    favored team.
-    """
-    num_teams = len(items) // team_size
-    teams: List[List[Search]] = [[] for _ in range(num_teams)]
-    half = len(items) // 2
-    # Rotate the second half of the list
-    rotated = items[:half] + rotate(items[half:], half // 2)
-    for i, (search, _) in enumerate(rotated):
-        # Distribute the pairs to the appropriate team
-        teams[i % num_teams].append(search)
-
-    return (CombinedSearch(*team) for team in teams)
-
-
-def make_teams(
-    searches: List[Search],
-    size: int
-) -> Tuple[List[Search], List[Search]]:
-    """
-    Tries to group as many searches together into teams of the given size as
-    possible. Returns the new grouped searches, and the remaining searches that
-    were not succesfully grouped.
-
-    Does not try to balance teams so it should be used only as a last resort.
-    """
-
-    searches_by_size = _make_searches_by_size(searches)
-
-    new_searches = []
-    for search in searches:
-        if len(search.players) > size:
-            continue
-
-        new_search = _make_team_for_search(search, searches_by_size, size)
-        if new_search:
-            new_searches.append(new_search)
-
-    return new_searches, list(itertools.chain(*searches_by_size.values()))
-
-
-def _make_searches_by_size(searches: List[Search]) -> Dict[int, Set[Search]]:
-    """
-    Creates a lookup table indexed by number of players in the search.
-    """
-
-    searches_by_size: Dict[int, Set[Search]] = OrderedDict()
-
-    # Would be easier with defaultdict, but we want to preserve key order
-    for search in searches:
-        size = len(search.players)
-        if size not in searches_by_size:
-            searches_by_size[size] = set()
-        searches_by_size[size].add(search)
-
-    return searches_by_size
-
-
-def _make_team_for_search(
-    search: Search,
-    searches_by_size: Dict[int, Set[Search]],
-    size: int
-) -> Optional[Search]:
-    """
-    Match this search with other searches to create a new team of `size`
-    members.
-    """
-
-    num_players = len(search.players)
-    if search not in searches_by_size[num_players]:
-        return None
-    searches_by_size[num_players].remove(search)
-
-    if num_players == size:
-        return search
-
-    num_needed = size - num_players
-    try_size = num_needed
-    new_search = search
-    while num_needed > 0:
-        if try_size == 0:
-            _uncombine(new_search, searches_by_size)
-            return None
-
-        try:
-            other = searches_by_size[try_size].pop()
-            new_search = CombinedSearch(new_search, other)
-            num_needed -= try_size
-            try_size = num_needed
-        except KeyError:
-            try_size -= 1
-
-    return new_search
-
-
-def _uncombine(
-    search: Search,
-    searches_by_size: Dict[int, Set[Search]]
-) -> None:
-    """
-    Adds all of the searches in search back to their respective spots in
-    `searches_by_size`.
-    """
-
-    if not isinstance(search, CombinedSearch):
-        searches_by_size[len(search.players)].add(search)
-        return
-
-    for s in search.searches:
-        _uncombine(s, searches_by_size)

--- a/server/matchmaker/algorithm/stable_marriage.py
+++ b/server/matchmaker/algorithm/stable_marriage.py
@@ -125,9 +125,10 @@ class RandomlyMatchNewbies(MatchmakingPolicy1v1):
 
 @with_logger
 class Matchmaker(object):
-    def __init__(self, searches: Iterable[Search]):
+    def __init__(self, searches: Iterable[Search], team_size: int):
         self.searches = searches
         self.matches: Dict[Search, Search] = {}
+        self.team_size = team_size
 
     def _register_unmatched_searches(self):
         """
@@ -148,6 +149,14 @@ class Matchmaker(object):
 
 @with_logger
 class StableMarriageMatchmaker(Matchmaker):
+    def __init__(self, searches: Iterable[Search], team_size: int):
+        super().__init__(searches, team_size)
+        if team_size != 1:
+            self._logger.error(
+                "Invalid team size %i for stable marriage matchmaker will be ignored",
+                team_size
+            )
+
     def find(self) -> List[Match]:
         self._logger.debug("Matching with stable marriage...")
         searches = list(self.searches)

--- a/server/matchmaker/algorithm/stable_marriage.py
+++ b/server/matchmaker/algorithm/stable_marriage.py
@@ -1,13 +1,7 @@
 import itertools
 import math
 import statistics as stats
-from typing import (
-    Dict,
-    Iterable,
-    List,
-    Set,
-    Tuple,
-)
+from typing import Dict, Iterable, List, Set, Tuple
 
 from ...decorators import with_logger
 from ..search import Match, Search

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -151,10 +151,11 @@ class MatchmakerQueue:
         """
         self._logger.info("Searching for matches: %s", self.name)
 
-        if self.num_players < 2 * self.team_size:
-            return
-
         searches = list(self._queue.keys())
+
+        if self.num_players < 2 * self.team_size:
+            self._register_unmatched_searches(searches)
+            return
 
         # Call self.match on all matches and filter out the ones that were cancelled
         loop = asyncio.get_running_loop()

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -172,8 +172,7 @@ class MatchmakerQueue:
             if self.match(match[0], match[1]):
                 matches.append(match)
             else:
-                unmatched_searches.append(match[0])
-                unmatched_searches.append(match[1])
+                unmatched_searches.extend(match)
 
         self._register_unmatched_searches(unmatched_searches)
 

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -11,10 +11,9 @@ from ..asyncio_extensions import SpinLock, synchronized
 from ..decorators import with_logger
 from ..players import PlayerState
 from .algorithm.bucket_teams import BucketTeamMatchmaker
-from .algorithm.stable_marriage import StableMarriageMatchmaker
 from .map_pool import MapPool
 from .pop_timer import PopTimer
-from .search import Search, Match
+from .search import Match, Search
 
 MatchFoundCallback = Callable[[Search, Search, "MatchmakerQueue"], Any]
 

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -165,7 +165,6 @@ class MatchmakerQueue:
             self.team_size,
         )
 
-
         # filter out matches that were cancelled
         matches: List[Match] = []
         for match in proposed_matches:

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -236,13 +236,6 @@ class Search:
         """For debugging"""
         return f"Search({[p.login for p in self.players]})"
 
-    def get_original_searches(self) -> List["Search"]:
-        """
-        Returns the searches of which this Search is comprised,
-        as if it were a CombinedSearch of one
-        """
-        return [self]
-
 
 class CombinedSearch(Search):
     def __init__(self, *searches: Search):
@@ -315,9 +308,3 @@ class CombinedSearch(Search):
 
     def __str__(self):
         return "CombinedSearch({})".format(",".join(str(s) for s in self.searches))
-
-    def get_original_searches(self) -> List[Search]:
-        """
-        Returns the searches of which this CombinedSearch is comprised
-        """
-        return list(self.searches)

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -236,6 +236,13 @@ class Search:
         """For debugging"""
         return f"Search({[p.login for p in self.players]})"
 
+    def get_original_searches(self) -> List["Search"]:
+        """
+        Returns the searches of which this Search is comprised,
+        as if it were a CombinedSearch of one
+        """
+        return [self]
+
 
 class CombinedSearch(Search):
     def __init__(self, *searches: Search):
@@ -308,3 +315,9 @@ class CombinedSearch(Search):
 
     def __str__(self):
         return "CombinedSearch({})".format(",".join(str(s) for s in self.searches))
+
+    def get_original_searches(self) -> List[Search]:
+        """
+        Returns the searches of which this CombinedSearch is comprised
+        """
+        return list(self.searches)

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -8,6 +8,7 @@ from hypothesis import strategies as st
 from server import config
 from server.matchmaker import Search, algorithm
 from server.matchmaker.algorithm.bucket_teams import (
+    BucketTeamMatchmaker,
     _make_teams,
     _make_teams_from_single
 )
@@ -21,8 +22,8 @@ def player_factory(player_factory):
     def make(
         mean: int = 1500,
         deviation: int = 500,
-        ladder_games: int = config.NEWBIE_MIN_GAMES+1,
-        name=None
+        ladder_games: int = config.NEWBIE_MIN_GAMES + 1,
+        name=None,
     ):
         """Make a player with the given ratings"""
         player = player_factory(
@@ -32,16 +33,14 @@ def player_factory(player_factory):
             lobby_connection_spec=None,
         )
         return player
+
     return make
 
 
-@pytest.mark.parametrize("make_teams_func", (
-    _make_teams,
-    _make_teams_from_single
-))
+@pytest.mark.parametrize("make_teams_func", (_make_teams, _make_teams_from_single))
 @given(
     searches=st_searches_list(max_players=1),
-    size=st.integers(min_value=1, max_value=10)
+    size=st.integers(min_value=1, max_value=10),
 )
 def test_make_teams_single_correct_size(searches, size, make_teams_func):
     matched, non_matched = make_teams_func(searches, size)
@@ -90,14 +89,12 @@ def test_make_teams_single_2v2_small_pool(player_factory):
     # Try a bunch of times so it is unlikely to pass by chance
     for _ in range(20):
         searches = [
-            Search(
-                [player_factory(random.gauss(1000, 5), 10, name=f"p{i}")]
-            ) for i in range(2)
+            Search([player_factory(random.gauss(1000, 5), 10, name=f"p{i}")])
+            for i in range(2)
         ]
         searches += [
-            Search(
-                [player_factory(random.gauss(500, 5), 10, name=f"r{i}")]
-            ) for i in range(2)
+            Search([player_factory(random.gauss(500, 5), 10, name=f"r{i}")])
+            for i in range(2)
         ]
         matched, non_matched = _make_teams_from_single(searches, size=2)
 
@@ -117,11 +114,7 @@ def test_make_teams_single_2v2_small_pool(player_factory):
 def test_make_buckets_performance(bench, player_factory):
     NUM_SEARCHES = 1000
     searches = [
-        Search([player_factory(
-            random.gauss(1500, 200),
-            500,
-            ladder_games=1
-        )])
+        Search([player_factory(random.gauss(1500, 200), 500, ladder_games=1)])
         for _ in range(NUM_SEARCHES)
     ]
 
@@ -133,77 +126,65 @@ def test_make_buckets_performance(bench, player_factory):
 
 def test_make_teams_1(player_factory):
     teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [
+            player_factory(name="p1"),
+            player_factory(name="p2"),
+            player_factory(name="p3"),
+        ],
         [player_factory(name="p4"), player_factory(name="p5")],
         [player_factory(name="p6"), player_factory(name="p7")],
         [player_factory(name="p8")],
         [player_factory(name="p9")],
         [player_factory(name="p10")],
-        [player_factory(name="p11")]
+        [player_factory(name="p11")],
     ]
-    do_test_make_teams(
-        teams,
-        team_size=3,
-        total_unmatched=2,
-        unmatched_sizes={1}
-    )
+    do_test_make_teams(teams, team_size=3, total_unmatched=2, unmatched_sizes={1})
 
 
 def test_make_teams_2(player_factory):
     teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [
+            player_factory(name="p1"),
+            player_factory(name="p2"),
+            player_factory(name="p3"),
+        ],
         [player_factory(name="p4"), player_factory(name="p5")],
         [player_factory(name="p6"), player_factory(name="p7")],
         [player_factory(name="p8")],
         [player_factory(name="p9")],
         [player_factory(name="p10")],
-        [player_factory(name="p11")]
+        [player_factory(name="p11")],
     ]
-    do_test_make_teams(
-        teams,
-        team_size=2,
-        total_unmatched=1,
-        unmatched_sizes={3}
-    )
+    do_test_make_teams(teams, team_size=2, total_unmatched=1, unmatched_sizes={3})
 
 
 def test_make_teams_3(player_factory):
-    teams = [
-        [player_factory(name=f"p{i+1}")] for i in range(9)
-    ]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=1,
-        unmatched_sizes={1}
-    )
+    teams = [[player_factory(name=f"p{i+1}")] for i in range(9)]
+    do_test_make_teams(teams, team_size=4, total_unmatched=1, unmatched_sizes={1})
 
 
 def test_make_teams_4(player_factory):
     teams = [[player_factory()] for i in range(9)]
     teams += [[player_factory(), player_factory()] for i in range(5)]
     teams += [[player_factory(), player_factory(), player_factory()] for i in range(15)]
-    teams += [[player_factory(), player_factory(), player_factory(), player_factory()] for i in range(4)]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=7,
-        unmatched_sizes={3, 2}
-    )
+    teams += [
+        [player_factory(), player_factory(), player_factory(), player_factory()]
+        for i in range(4)
+    ]
+    do_test_make_teams(teams, team_size=4, total_unmatched=7, unmatched_sizes={3, 2})
 
 
 def test_make_teams_5(player_factory):
     teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [
+            player_factory(name="p1"),
+            player_factory(name="p2"),
+            player_factory(name="p3"),
+        ],
         [player_factory(name="p4"), player_factory(name="p5")],
         [player_factory(name="p6"), player_factory(name="p7")],
     ]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=1,
-        unmatched_sizes={3}
-    )
+    do_test_make_teams(teams, team_size=4, total_unmatched=1, unmatched_sizes={3})
 
 
 def do_test_make_teams(teams, team_size, total_unmatched, unmatched_sizes):
@@ -224,7 +205,9 @@ def test_distribute_pairs_1(player_factory):
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4 = players
 
-    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 2)]
+    grouped = [
+        search.players for search in algorithm.bucket_teams._distribute(searches, 2)
+    ]
     assert grouped == [[p1, p4], [p2, p3]]
 
 
@@ -233,7 +216,9 @@ def test_distribute_pairs_2(player_factory):
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4, p5, p6, p7, p8 = players
 
-    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 2)]
+    grouped = [
+        search.players for search in algorithm.bucket_teams._distribute(searches, 2)
+    ]
     assert grouped == [[p1, p4], [p2, p3], [p5, p8], [p6, p7]]
 
 
@@ -242,6 +227,59 @@ def test_distribute_triples(player_factory):
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4, p5, p6 = players
 
-    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 3)]
+    grouped = [
+        search.players for search in algorithm.bucket_teams._distribute(searches, 3)
+    ]
 
     assert grouped == [[p1, p3, p6], [p2, p4, p5]]
+
+
+def test_BucketTeamMatchmaker_1v1(player_factory):
+    num_players = 6
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(num_players)]
+    searches = [Search([player]) for player in players]
+
+    team_size = 1
+    matchmaker = BucketTeamMatchmaker(team_size)
+    matches = matchmaker.find(searches)
+
+    assert len(matches) == num_players / 2 / team_size
+
+
+def test_BucketTeamMatchmaker_2v2_single_searches(player_factory):
+    num_players = 12
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(num_players)]
+    searches = [Search([player]) for player in players]
+
+    team_size = 2
+    matchmaker = BucketTeamMatchmaker(team_size)
+    matches = matchmaker.find(searches)
+
+    assert len(matches) == num_players / 2 / team_size
+
+
+def test_BucketTeamMatchmaker_2v2_full_party_searches(player_factory):
+    num_players = 12
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(num_players)]
+    searches = [Search([players[i], players[i + 1]]) for i in range(0, len(players), 2)]
+
+    team_size = 2
+    matchmaker = BucketTeamMatchmaker(team_size)
+    matches = matchmaker.find(searches)
+
+    assert len(matches) == num_players / 2 / team_size
+
+
+def test_BucketTeammatchmaker_2v2_mixed_party_sizes(player_factory):
+    num_players = 24
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(num_players)]
+    searches = [
+        Search([players[i], players[i + 1]]) for i in range(0, len(players) // 2, 2)
+    ]
+    searches.extend([Search([player]) for player in players[len(players) // 2 :]])
+
+    team_size = 2
+    matchmaker = BucketTeamMatchmaker(team_size)
+    matches = matchmaker.find(searches)
+
+    assert len(matches) == num_players / 2 / team_size

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -2,7 +2,7 @@ import math
 import random
 
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
 from server import config
@@ -44,6 +44,8 @@ def player_factory(player_factory):
 )
 def test_make_teams_single_correct_size(searches, size, make_teams_func):
     matched, _ = make_teams_func(searches, size)
+
+    assume(matched != [])
 
     for search in matched:
         assert len(search.players) == size

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -1,0 +1,243 @@
+import logging
+import math
+import random
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from server import config
+from server.matchmaker import Search, algorithm
+from server.rating import RatingType
+
+from .strategies import st_searches_list
+
+
+@pytest.fixture(scope="module")
+def player_factory(player_factory):
+    def make(
+        mean: int = 1500,
+        deviation: int = 500,
+        ladder_games: int = config.NEWBIE_MIN_GAMES+1,
+        name=None
+    ):
+        """Make a player with the given ratings"""
+        player = player_factory(
+            ladder_rating=(mean, deviation),
+            ladder_games=ladder_games,
+            login=name,
+            lobby_connection_spec=None,
+        )
+        return player
+    return make
+
+@pytest.mark.parametrize("make_teams_func", (
+    algorithm.bucket_teams.make_teams,
+    algorithm.bucket_teams.make_teams_from_single
+))
+@given(
+    searches=st_searches_list(max_players=1),
+    size=st.integers(min_value=1, max_value=10)
+)
+def test_make_teams_single_correct_size(searches, size, make_teams_func):
+    matched, non_matched = make_teams_func(searches, size)
+
+    for search in matched:
+        assert len(search.players) == size
+
+
+def test_make_teams_single_2v2_large_pool(player_factory):
+    """
+    When we have a large number of players all with similar ratings, we want
+    teams to be formed by putting players with the same rating on the same team.
+    """
+
+    # Large enough so the test is unlikely to pass by chance
+    num = 40
+
+    searches = [
+        Search([player_factory(random.uniform(950, 1050), 10, name=f"p{i}")])
+        for i in range(num)
+    ]
+    searches += [
+        Search([player_factory(random.uniform(450, 550), 10, name=f"p{i}")])
+        for i in range(num)
+    ]
+    matched, non_matched = algorithm.bucket_teams.make_teams_from_single(searches, size=2)
+
+    assert matched != []
+    assert non_matched == []
+
+    for search in matched:
+        p1, p2 = search.players
+        p1_mean, _ = p1.ratings[RatingType.LADDER_1V1]
+        p2_mean, _ = p2.ratings[RatingType.LADDER_1V1]
+        #
+        assert math.fabs(p1_mean - p2_mean) <= 100
+
+
+def test_make_teams_single_2v2_small_pool(player_factory):
+    """
+    When we have a small number of players, we want teams to be formed by
+    distributing players of equal skill to different teams so that we can
+    maximize the chances of getting a match.
+    """
+
+    # Try a bunch of times so it is unlikely to pass by chance
+    for _ in range(20):
+        searches = [
+            Search(
+                [player_factory(random.gauss(1000, 5), 10, name=f"p{i}")]
+            ) for i in range(2)
+        ]
+        searches += [
+            Search(
+                [player_factory(random.gauss(500, 5), 10, name=f"r{i}")]
+            ) for i in range(2)
+        ]
+        matched, non_matched = algorithm.bucket_teams.make_teams_from_single(searches, size=2)
+
+        assert matched != []
+        assert non_matched == []
+
+        for search in matched:
+            p1, p2 = search.players
+            # Order doesn't matter
+            if p1.ratings[RatingType.LADDER_1V1][0] > 900:
+                assert p2.ratings[RatingType.LADDER_1V1][0] < 600
+            else:
+                assert p1.ratings[RatingType.LADDER_1V1][0] < 600
+                assert p2.ratings[RatingType.LADDER_1V1][0] > 900
+
+
+def test_make_buckets_performance(bench, player_factory):
+    NUM_SEARCHES = 1000
+    searches = [
+        Search([player_factory(
+            random.gauss(1500, 200),
+            500,
+            ladder_games=1
+        )])
+        for _ in range(NUM_SEARCHES)
+    ]
+
+    with bench:
+        algorithm.bucket_teams._make_buckets(searches)
+
+    assert bench.elapsed() < 0.15
+
+
+def test_make_teams_1(player_factory):
+    teams = [
+        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [player_factory(name="p4"), player_factory(name="p5")],
+        [player_factory(name="p6"), player_factory(name="p7")],
+        [player_factory(name="p8")],
+        [player_factory(name="p9")],
+        [player_factory(name="p10")],
+        [player_factory(name="p11")]
+    ]
+    do_test_make_teams(
+        teams,
+        team_size=3,
+        total_unmatched=2,
+        unmatched_sizes={1}
+    )
+
+
+def test_make_teams_2(player_factory):
+    teams = [
+        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [player_factory(name="p4"), player_factory(name="p5")],
+        [player_factory(name="p6"), player_factory(name="p7")],
+        [player_factory(name="p8")],
+        [player_factory(name="p9")],
+        [player_factory(name="p10")],
+        [player_factory(name="p11")]
+    ]
+    do_test_make_teams(
+        teams,
+        team_size=2,
+        total_unmatched=1,
+        unmatched_sizes={3}
+    )
+
+
+def test_make_teams_3(player_factory):
+    teams = [
+        [player_factory(name=f"p{i+1}")] for i in range(9)
+    ]
+    do_test_make_teams(
+        teams,
+        team_size=4,
+        total_unmatched=1,
+        unmatched_sizes={1}
+    )
+
+
+def test_make_teams_4(player_factory):
+    teams = [[player_factory()] for i in range(9)]
+    teams += [[player_factory(), player_factory()] for i in range(5)]
+    teams += [[player_factory(), player_factory(), player_factory()] for i in range(15)]
+    teams += [[player_factory(), player_factory(), player_factory(), player_factory()] for i in range(4)]
+    do_test_make_teams(
+        teams,
+        team_size=4,
+        total_unmatched=7,
+        unmatched_sizes={3, 2}
+    )
+
+
+def test_make_teams_5(player_factory):
+    teams = [
+        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
+        [player_factory(name="p4"), player_factory(name="p5")],
+        [player_factory(name="p6"), player_factory(name="p7")],
+    ]
+    do_test_make_teams(
+        teams,
+        team_size=4,
+        total_unmatched=1,
+        unmatched_sizes={3}
+    )
+
+
+def do_test_make_teams(teams, team_size, total_unmatched, unmatched_sizes):
+    searches = [Search(t) for t in teams]
+
+    matched, non_matched = algorithm.bucket_teams.make_teams(searches, size=team_size)
+    players_non_matched = [s.players for s in non_matched]
+
+    for s in matched:
+        assert len(s.players) == team_size
+    assert len(players_non_matched) == total_unmatched
+    for players in players_non_matched:
+        assert len(players) in unmatched_sizes
+
+
+def test_distribute_pairs_1(player_factory):
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(4)]
+    searches = [(Search([player]), 0) for player in players]
+    p1, p2, p3, p4 = players
+
+    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 2)]
+    assert grouped == [[p1, p4], [p2, p3]]
+
+
+def test_distribute_pairs_2(player_factory):
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(8)]
+    searches = [(Search([player]), 0) for player in players]
+    p1, p2, p3, p4, p5, p6, p7, p8 = players
+
+    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 2)]
+    assert grouped == [[p1, p4], [p2, p3], [p5, p8], [p6, p7]]
+
+
+def test_distribute_triples(player_factory):
+    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(6)]
+    searches = [(Search([player]), 0) for player in players]
+    p1, p2, p3, p4, p5, p6 = players
+
+    grouped = [search.players for search in algorithm.bucket_teams._distribute(searches, 3)]
+
+    assert grouped == [[p1, p3, p6], [p2, p4, p5]]

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -75,7 +75,7 @@ def test_make_teams_single_2v2_large_pool(player_factory):
         p1, p2 = search.players
         p1_mean, _ = p1.ratings[RatingType.LADDER_1V1]
         p2_mean, _ = p2.ratings[RatingType.LADDER_1V1]
-        #
+
         assert math.fabs(p1_mean - p2_mean) <= 100
 
 
@@ -291,13 +291,13 @@ def test_BucketTeammatchmaker_2v2_mixed_party_sizes(player_factory):
 
 def test_2v2_count_unmatched_searches(player_factory):
     players = [
-            player_factory(500, 100, name="lowRating_unmatched_1"),
-            player_factory(500, 100, name="lowRating_unmatched_2"),
-            player_factory(1500, 100, name="midRating_matched_1"),
-            player_factory(1500, 100, name="midRating_matched_2"),
-            player_factory(1500, 100, name="midRating_matched_3"),
-            player_factory(1500, 100, name="midRating_matched_4"),
-            player_factory(2000, 100, name="highRating_unmatched_1"),
+        player_factory(500, 100, name="lowRating_unmatched_1"),
+        player_factory(500, 100, name="lowRating_unmatched_2"),
+        player_factory(1500, 100, name="midRating_matched_1"),
+        player_factory(1500, 100, name="midRating_matched_2"),
+        player_factory(1500, 100, name="midRating_matched_3"),
+        player_factory(1500, 100, name="midRating_matched_4"),
+        player_factory(2000, 100, name="highRating_unmatched_1"),
     ]
     searches = [Search([player]) for player in players]
 

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -8,6 +8,7 @@ from hypothesis import strategies as st
 
 from server import config
 from server.matchmaker import Search, algorithm
+from server.matchmaker.algorithm.bucket_teams import BucketTeamMatchmaker, _make_teams, _make_teams_from_single
 from server.rating import RatingType
 
 from .strategies import st_searches_list
@@ -32,8 +33,8 @@ def player_factory(player_factory):
     return make
 
 @pytest.mark.parametrize("make_teams_func", (
-    algorithm.bucket_teams.make_teams,
-    algorithm.bucket_teams.make_teams_from_single
+    _make_teams,
+    _make_teams_from_single
 ))
 @given(
     searches=st_searches_list(max_players=1),
@@ -63,7 +64,7 @@ def test_make_teams_single_2v2_large_pool(player_factory):
         Search([player_factory(random.uniform(450, 550), 10, name=f"p{i}")])
         for i in range(num)
     ]
-    matched, non_matched = algorithm.bucket_teams.make_teams_from_single(searches, size=2)
+    matched, non_matched = _make_teams_from_single(searches, size=2)
 
     assert matched != []
     assert non_matched == []
@@ -95,7 +96,7 @@ def test_make_teams_single_2v2_small_pool(player_factory):
                 [player_factory(random.gauss(500, 5), 10, name=f"r{i}")]
             ) for i in range(2)
         ]
-        matched, non_matched = algorithm.bucket_teams.make_teams_from_single(searches, size=2)
+        matched, non_matched = _make_teams_from_single(searches, size=2)
 
         assert matched != []
         assert non_matched == []
@@ -205,7 +206,7 @@ def test_make_teams_5(player_factory):
 def do_test_make_teams(teams, team_size, total_unmatched, unmatched_sizes):
     searches = [Search(t) for t in teams]
 
-    matched, non_matched = algorithm.bucket_teams.make_teams(searches, size=team_size)
+    matched, non_matched = _make_teams(searches, size=team_size)
     players_non_matched = [s.players for s in non_matched]
 
     for s in matched:

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -6,7 +6,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from server import config
-from server.matchmaker import Search, CombinedSearch, algorithm
+from server.matchmaker import Search, algorithm
 from server.matchmaker.algorithm.bucket_teams import (
     BucketTeamMatchmaker,
     _make_teams,
@@ -43,7 +43,7 @@ def player_factory(player_factory):
     size=st.integers(min_value=1, max_value=10),
 )
 def test_make_teams_single_correct_size(searches, size, make_teams_func):
-    matched, non_matched = make_teams_func(searches, size)
+    matched, _ = make_teams_func(searches, size)
 
     for search in matched:
         assert len(search.players) == size
@@ -304,10 +304,6 @@ def test_2v2_count_unmatched_searches(player_factory):
     team_size = 2
     matchmaker = BucketTeamMatchmaker()
     matches, unmatched_searches = matchmaker.find(searches, team_size)
-
-    #FIXME
-    print(f"matches {matches}")
-    print(f"unmat {unmatched_searches}")
 
     assert len(matches) == 1
     number_of_unmatched_players = sum(

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -1,14 +1,16 @@
-import logging
 import math
 import random
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from server import config
 from server.matchmaker import Search, algorithm
-from server.matchmaker.algorithm.bucket_teams import BucketTeamMatchmaker, _make_teams, _make_teams_from_single
+from server.matchmaker.algorithm.bucket_teams import (
+    _make_teams,
+    _make_teams_from_single
+)
 from server.rating import RatingType
 
 from .strategies import st_searches_list
@@ -31,6 +33,7 @@ def player_factory(player_factory):
         )
         return player
     return make
+
 
 @pytest.mark.parametrize("make_teams_func", (
     _make_teams,

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -32,7 +32,7 @@ def player_factory(player_factory):
     return make
 
 
-def add_graph_edge_weights(graph) -> algorithm.WeightedGraph:
+def add_graph_edge_weights(graph) -> algorithm.stable_marriage.WeightedGraph:
     return {
         s1: [(s2, s1.quality_with(s2)) for s2 in edges]
         for s1, edges in graph.items()
@@ -40,8 +40,8 @@ def add_graph_edge_weights(graph) -> algorithm.WeightedGraph:
 
 
 @pytest.mark.parametrize("build_func", (
-    algorithm._MatchingGraph.build_full,
-    algorithm._MatchingGraph.build_fast
+    algorithm.stable_marriage._MatchingGraph.build_full,
+    algorithm.stable_marriage._MatchingGraph.build_fast
 ))
 def test_build_full_matching_graph(player_factory, build_func):
     # For small numbers of searches, build_full and build_fast should create
@@ -61,8 +61,8 @@ def test_build_full_matching_graph(player_factory, build_func):
 
 
 @pytest.mark.parametrize("build_func", (
-    algorithm._MatchingGraph.build_full,
-    algorithm._MatchingGraph.build_fast
+    algorithm.stable_marriage._MatchingGraph.build_full,
+    algorithm.stable_marriage._MatchingGraph.build_fast
 ))
 def test_build_matching_graph_different_ranks(player_factory, build_func):
     s1 = Search([player_factory(1500, 64, ladder_games=20)])
@@ -89,7 +89,7 @@ def test_remove_isolated(player_factory):
         s3: [s1]
     })
 
-    algorithm._MatchingGraph.remove_isolated(ranks)
+    algorithm.stable_marriage._MatchingGraph.remove_isolated(ranks)
 
     assert ranks == add_graph_edge_weights({
         s1: [s3],
@@ -107,14 +107,14 @@ def test_remove_isolated_2(player_factory):
         s3: []
     }
 
-    algorithm._MatchingGraph.remove_isolated(ranks)
+    algorithm.stable_marriage._MatchingGraph.remove_isolated(ranks)
 
     assert ranks == {}
 
 
 @pytest.mark.parametrize("build_func", (
-    algorithm._MatchingGraph.build_full,
-    algorithm._MatchingGraph.build_fast
+    algorithm.stable_marriage._MatchingGraph.build_full,
+    algorithm.stable_marriage._MatchingGraph.build_fast
 ))
 def test_match_graph_will_not_include_matches_below_threshold_quality(player_factory, build_func):
     s1 = Search([player_factory(1500, 500)])
@@ -130,8 +130,8 @@ def test_match_graph_will_not_include_matches_below_threshold_quality(player_fac
 
 
 @pytest.mark.parametrize("build_func", (
-    algorithm._MatchingGraph.build_full,
-    algorithm._MatchingGraph.build_fast
+    algorithm.stable_marriage._MatchingGraph.build_full,
+    algorithm.stable_marriage._MatchingGraph.build_fast
 ))
 @given(searches=st_searches_list(max_players=2))
 @settings(deadline=300)
@@ -153,8 +153,8 @@ def test_matching_graph_symmetric(
 
 
 @pytest.mark.parametrize("build_func", (
-    algorithm._MatchingGraph.build_full,
-    algorithm._MatchingGraph.build_fast
+    algorithm.stable_marriage._MatchingGraph.build_full,
+    algorithm.stable_marriage._MatchingGraph.build_fast
 ))
 @given(searches=st_searches_list(max_players=2))
 @settings(deadline=300)
@@ -169,7 +169,7 @@ def test_stable_marriage_produces_symmetric_matchings(
 
         ranks = build_func(searches)
 
-        matches = algorithm.StableMarriage().find(ranks)
+        matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
         for search in matches:
             opponent = matches[search]
@@ -185,9 +185,9 @@ def test_stable_marriage(player_factory):
     s6 = Search([player_factory(1250, 175, name="p6")])
 
     searches = [s1, s2, s3, s4, s5, s6]
-    ranks = algorithm._MatchingGraph.build_full(searches)
+    ranks = algorithm.stable_marriage._MatchingGraph.build_full(searches)
 
-    matches = algorithm.StableMarriage().find(ranks)
+    matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
     assert matches[s1] == s4
     assert matches[s2] == s5
@@ -201,9 +201,9 @@ def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_differ
     old2 = Search([player_factory(2350, 75, name="old2", ladder_games=200)])
 
     searches = [new1, new2, old1, old2]
-    ranks = algorithm._MatchingGraph.build_full(searches)
+    ranks = algorithm.stable_marriage._MatchingGraph.build_full(searches)
 
-    matches = algorithm.StableMarriage().find(ranks)
+    matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
     assert matches[new1] == new2
     assert matches[old1] == old2
@@ -218,9 +218,9 @@ def test_stable_marriage_matches_new_players_with_new_and_old_with_old_if_same_m
     old2 = Search([player_factory(500, 75, name="old2", ladder_games=100)])
 
     searches = [new1, new2, old1, old2]
-    ranks = algorithm._MatchingGraph.build_full(searches)
+    ranks = algorithm.stable_marriage._MatchingGraph.build_full(searches)
 
-    matches = algorithm.StableMarriage().find(ranks)
+    matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
     assert matches[new1] == new2
     assert matches[old1] == old2
@@ -235,9 +235,9 @@ def test_stable_marriage_better_than_greedy(player_factory):
     s6 = Search([player_factory(2400, 64, name="p6")])
 
     searches = [s1, s2, s3, s4, s5, s6]
-    ranks = algorithm._MatchingGraph.build_full(searches)
+    ranks = algorithm.stable_marriage._MatchingGraph.build_full(searches)
 
-    matches = algorithm.StableMarriage().find(ranks)
+    matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
     # Note that the most balanced configuration would be
     # (s1, s6)  quality: 0.93
@@ -258,9 +258,9 @@ def test_stable_marriage_unmatch(player_factory):
     s4 = Search([player_factory(505, 64, name="p4")])
 
     searches = [s1, s2, s3, s4]
-    ranks = algorithm._MatchingGraph.build_full(searches)
+    ranks = algorithm.stable_marriage._MatchingGraph.build_full(searches)
 
-    matches = algorithm.StableMarriage().find(ranks)
+    matches = algorithm.stable_marriage.StableMarriage().find(ranks)
 
     assert matches[s1] == s4  # quality: 0.96622
     assert matches[s2] == s3  # quality: 0.96623
@@ -275,7 +275,7 @@ def test_random_newbie_matching_is_symmetric(player_factory):
     s6 = Search([player_factory(600, 500, name="p6", ladder_games=5)])
 
     searches = [s1, s2, s3, s4, s5, s6]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches
 
@@ -291,7 +291,7 @@ def test_newbies_are_forcefully_matched_with_newbies(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie1, pro, newbie2]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[newbie1] == newbie2
     assert matches[newbie2] == newbie1
@@ -308,7 +308,7 @@ def test_newbie_team_matched_with_newbie_team(player_factory):
     ])
 
     searches = [newbie1, newbie2]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[newbie1] == newbie2
     assert matches[newbie2] == newbie1
@@ -325,7 +325,7 @@ def test_partial_newbie_team_matched_with_newbie_team(player_factory):
     ])
 
     searches = [partial_newbie, newbie]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[partial_newbie] == newbie
     assert matches[newbie] == partial_newbie
@@ -342,7 +342,7 @@ def test_newbie_and_top_rated_team_not_matched_randomly(player_factory):
     ])
 
     searches = [newbie_and_top_rated, newbie]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert not matches
 
@@ -352,12 +352,12 @@ def test_unmatched_newbies_forcefully_match_pros(player_factory):
     pro = Search([player_factory(1400, 10, ladder_games=100)])
 
     searches = [newbie, pro]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
     # No match if the pro is on their first attempt
     assert len(matches) == 0
 
     pro.register_failed_matching_attempt()
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
     assert len(matches) == 2
 
 
@@ -372,12 +372,12 @@ def test_newbie_team_matched_with_pro_team(player_factory):
     ])
 
     searches = [newbie, pro]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
     # No match if the pros are on their first attempt
     assert len(matches) == 0
 
     pro.register_failed_matching_attempt()
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
     assert len(matches) == 2
 
 
@@ -387,7 +387,7 @@ def test_unmatched_newbies_do_not_forcefully_match_top_players(player_factory):
     top_player.register_failed_matching_attempt()
 
     searches = [newbie, top_player]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
 
@@ -404,7 +404,7 @@ def test_newbie_team_dos_not_match_with_top_players_team(player_factory):
     top_player.register_failed_matching_attempt()
 
     searches = [newbie, top_player]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
 
@@ -418,7 +418,7 @@ def unmatched_newbie_teams_do_not_forcefully_match_pros(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie_team, pro]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
 
@@ -431,7 +431,7 @@ def test_odd_number_of_unmatched_newbies(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie1, pro, newbie2, newbie3]
-    matches = algorithm.RandomlyMatchNewbies().find(searches)
+    matches = algorithm.stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 4
 
@@ -460,7 +460,8 @@ def test_matchmaker(player_factory):
         pro_alone,
         top_player
     ]
-    match_pairs = algorithm.make_matches(searches)
+    matchmaker = algorithm.stable_marriage.StableMarriageMatchmaker(searches)
+    match_pairs = matchmaker.find()
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie_that_matches1, newbie_that_matches2} in match_sets
@@ -478,7 +479,8 @@ def test_matchmaker_performance(player_factory, bench, caplog):
     searches = [Search([player_factory(1500, 500, ladder_games=1)]) for _ in range(NUM_SEARCHES)]
 
     with bench:
-        algorithm.make_matches(searches)
+        matchmaker = algorithm.stable_marriage.StableMarriageMatchmaker(searches)
+        matchmaker.find()
 
     assert bench.elapsed() < 0.5
 
@@ -488,25 +490,27 @@ def test_matchmaker_random_only(player_factory):
     newbie2 = Search([player_factory(200, 400, ladder_games=9)])
 
     searches = (newbie1, newbie2)
-    match_pairs = algorithm.make_matches(searches)
+    matchmaker = algorithm.stable_marriage.StableMarriageMatchmaker(searches)
+    match_pairs = matchmaker.find()
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie1, newbie2} in match_sets
 
 
-def test_make_matches_will_not_match_low_quality_games(player_factory):
+def test_find_will_not_match_low_quality_games(player_factory):
     s1 = Search([player_factory(100, 64, name="p1")])
     s2 = Search([player_factory(2000, 64, name="p2")])
 
     searches = [s1, s2]
 
-    matches = algorithm.make_matches(searches)
+    matchmaker = algorithm.stable_marriage.StableMarriageMatchmaker(searches)
+    matches = matchmaker.find()
 
     assert (s1, s2) not in matches
     assert (s2, s1) not in matches
 
 
-def test_make_matches_communicates_failed_attempts(player_factory):
+def test_find_communicates_failed_attempts(player_factory):
     s1 = Search([player_factory(100, 64, name="p1")])
     s2 = Search([player_factory(2000, 64, name="p2")])
 
@@ -515,221 +519,10 @@ def test_make_matches_communicates_failed_attempts(player_factory):
     assert s1.failed_matching_attempts == 0
     assert s2.failed_matching_attempts == 0
 
-    matches = algorithm.make_matches(searches)
+    matchmaker = algorithm.stable_marriage.StableMarriageMatchmaker(searches)
+    matches = matchmaker.find()
 
     # These searches should not have been matched
     assert not matches
     assert s1.failed_matching_attempts == 1
     assert s2.failed_matching_attempts == 1
-
-
-@pytest.mark.parametrize("make_teams_func", (
-    algorithm.make_teams,
-    algorithm.make_teams_from_single
-))
-@given(
-    searches=st_searches_list(max_players=1),
-    size=st.integers(min_value=1, max_value=10)
-)
-def test_make_teams_single_correct_size(searches, size, make_teams_func):
-    matched, non_matched = make_teams_func(searches, size)
-
-    for search in matched:
-        assert len(search.players) == size
-
-
-def test_make_teams_single_2v2_large_pool(player_factory):
-    """
-    When we have a large number of players all with similar ratings, we want
-    teams to be formed by putting players with the same rating on the same team.
-    """
-
-    # Large enough so the test is unlikely to pass by chance
-    num = 40
-
-    searches = [
-        Search([player_factory(random.uniform(950, 1050), 10, name=f"p{i}")])
-        for i in range(num)
-    ]
-    searches += [
-        Search([player_factory(random.uniform(450, 550), 10, name=f"p{i}")])
-        for i in range(num)
-    ]
-    matched, non_matched = algorithm.make_teams_from_single(searches, size=2)
-
-    assert matched != []
-    assert non_matched == []
-
-    for search in matched:
-        p1, p2 = search.players
-        p1_mean, _ = p1.ratings[RatingType.LADDER_1V1]
-        p2_mean, _ = p2.ratings[RatingType.LADDER_1V1]
-        #
-        assert math.fabs(p1_mean - p2_mean) <= 100
-
-
-def test_make_teams_single_2v2_small_pool(player_factory):
-    """
-    When we have a small number of players, we want teams to be formed by
-    distributing players of equal skill to different teams so that we can
-    maximize the chances of getting a match.
-    """
-
-    # Try a bunch of times so it is unlikely to pass by chance
-    for _ in range(20):
-        searches = [
-            Search(
-                [player_factory(random.gauss(1000, 5), 10, name=f"p{i}")]
-            ) for i in range(2)
-        ]
-        searches += [
-            Search(
-                [player_factory(random.gauss(500, 5), 10, name=f"r{i}")]
-            ) for i in range(2)
-        ]
-        matched, non_matched = algorithm.make_teams_from_single(searches, size=2)
-
-        assert matched != []
-        assert non_matched == []
-
-        for search in matched:
-            p1, p2 = search.players
-            # Order doesn't matter
-            if p1.ratings[RatingType.LADDER_1V1][0] > 900:
-                assert p2.ratings[RatingType.LADDER_1V1][0] < 600
-            else:
-                assert p1.ratings[RatingType.LADDER_1V1][0] < 600
-                assert p2.ratings[RatingType.LADDER_1V1][0] > 900
-
-
-def test_make_buckets_performance(bench, player_factory):
-    NUM_SEARCHES = 1000
-    searches = [
-        Search([player_factory(
-            random.gauss(1500, 200),
-            500,
-            ladder_games=1
-        )])
-        for _ in range(NUM_SEARCHES)
-    ]
-
-    with bench:
-        algorithm._make_buckets(searches)
-
-    assert bench.elapsed() < 0.15
-
-
-def test_make_teams_1(player_factory):
-    teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
-        [player_factory(name="p4"), player_factory(name="p5")],
-        [player_factory(name="p6"), player_factory(name="p7")],
-        [player_factory(name="p8")],
-        [player_factory(name="p9")],
-        [player_factory(name="p10")],
-        [player_factory(name="p11")]
-    ]
-    do_test_make_teams(
-        teams,
-        team_size=3,
-        total_unmatched=2,
-        unmatched_sizes={1}
-    )
-
-
-def test_make_teams_2(player_factory):
-    teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
-        [player_factory(name="p4"), player_factory(name="p5")],
-        [player_factory(name="p6"), player_factory(name="p7")],
-        [player_factory(name="p8")],
-        [player_factory(name="p9")],
-        [player_factory(name="p10")],
-        [player_factory(name="p11")]
-    ]
-    do_test_make_teams(
-        teams,
-        team_size=2,
-        total_unmatched=1,
-        unmatched_sizes={3}
-    )
-
-
-def test_make_teams_3(player_factory):
-    teams = [
-        [player_factory(name=f"p{i+1}")] for i in range(9)
-    ]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=1,
-        unmatched_sizes={1}
-    )
-
-
-def test_make_teams_4(player_factory):
-    teams = [[player_factory()] for i in range(9)]
-    teams += [[player_factory(), player_factory()] for i in range(5)]
-    teams += [[player_factory(), player_factory(), player_factory()] for i in range(15)]
-    teams += [[player_factory(), player_factory(), player_factory(), player_factory()] for i in range(4)]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=7,
-        unmatched_sizes={3, 2}
-    )
-
-
-def test_make_teams_5(player_factory):
-    teams = [
-        [player_factory(name="p1"), player_factory(name="p2"), player_factory(name="p3")],
-        [player_factory(name="p4"), player_factory(name="p5")],
-        [player_factory(name="p6"), player_factory(name="p7")],
-    ]
-    do_test_make_teams(
-        teams,
-        team_size=4,
-        total_unmatched=1,
-        unmatched_sizes={3}
-    )
-
-
-def do_test_make_teams(teams, team_size, total_unmatched, unmatched_sizes):
-    searches = [Search(t) for t in teams]
-
-    matched, non_matched = algorithm.make_teams(searches, size=team_size)
-    players_non_matched = [s.players for s in non_matched]
-
-    for s in matched:
-        assert len(s.players) == team_size
-    assert len(players_non_matched) == total_unmatched
-    for players in players_non_matched:
-        assert len(players) in unmatched_sizes
-
-
-def test_distribute_pairs_1(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(4)]
-    searches = [(Search([player]), 0) for player in players]
-    p1, p2, p3, p4 = players
-
-    grouped = [search.players for search in algorithm._distribute(searches, 2)]
-    assert grouped == [[p1, p4], [p2, p3]]
-
-
-def test_distribute_pairs_2(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(8)]
-    searches = [(Search([player]), 0) for player in players]
-    p1, p2, p3, p4, p5, p6, p7, p8 = players
-
-    grouped = [search.players for search in algorithm._distribute(searches, 2)]
-    assert grouped == [[p1, p4], [p2, p3], [p5, p8], [p6, p7]]
-
-
-def test_distribute_triples(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(6)]
-    searches = [(Search([player]), 0) for player in players]
-    p1, p2, p3, p4, p5, p6 = players
-
-    grouped = [search.players for search in algorithm._distribute(searches, 3)]
-
-    assert grouped == [[p1, p3, p6], [p2, p4, p5]]

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -272,9 +272,10 @@ def test_random_newbie_matching_is_symmetric(player_factory):
     s6 = Search([player_factory(600, 500, name="p6", ladder_games=5)])
 
     searches = [s1, s2, s3, s4, s5, s6]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
-    assert matches
+    assert len(matches) == len(searches)
+    assert len(unmatched_searches) == 0
 
     for search in matches:
         opponent = matches[search]
@@ -288,10 +289,11 @@ def test_newbies_are_forcefully_matched_with_newbies(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie1, pro, newbie2]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[newbie1] == newbie2
     assert matches[newbie2] == newbie1
+    assert unmatched_searches == [pro]
 
 
 def test_newbie_team_matched_with_newbie_team(player_factory):
@@ -305,7 +307,7 @@ def test_newbie_team_matched_with_newbie_team(player_factory):
     ])
 
     searches = [newbie1, newbie2]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[newbie1] == newbie2
     assert matches[newbie2] == newbie1
@@ -322,7 +324,7 @@ def test_partial_newbie_team_matched_with_newbie_team(player_factory):
     ])
 
     searches = [partial_newbie, newbie]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert matches[partial_newbie] == newbie
     assert matches[newbie] == partial_newbie
@@ -339,7 +341,7 @@ def test_newbie_and_top_rated_team_not_matched_randomly(player_factory):
     ])
 
     searches = [newbie_and_top_rated, newbie]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert not matches
 
@@ -349,13 +351,15 @@ def test_unmatched_newbies_forcefully_match_pros(player_factory):
     pro = Search([player_factory(1400, 10, ladder_games=100)])
 
     searches = [newbie, pro]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
     # No match if the pro is on their first attempt
     assert len(matches) == 0
+    assert len(unmatched_searches) == 2
 
     pro.register_failed_matching_attempt()
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
     assert len(matches) == 2
+    assert len(unmatched_searches) == 0
 
 
 def test_newbie_team_matched_with_pro_team(player_factory):
@@ -369,13 +373,15 @@ def test_newbie_team_matched_with_pro_team(player_factory):
     ])
 
     searches = [newbie, pro]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
     # No match if the pros are on their first attempt
     assert len(matches) == 0
+    assert len(unmatched_searches) == 2
 
     pro.register_failed_matching_attempt()
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
     assert len(matches) == 2
+    assert len(unmatched_searches) == 0
 
 
 def test_unmatched_newbies_do_not_forcefully_match_top_players(player_factory):
@@ -384,9 +390,10 @@ def test_unmatched_newbies_do_not_forcefully_match_top_players(player_factory):
     top_player.register_failed_matching_attempt()
 
     searches = [newbie, top_player]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
+    assert len(unmatched_searches) == 2
 
 
 def test_newbie_team_dos_not_match_with_top_players_team(player_factory):
@@ -401,9 +408,10 @@ def test_newbie_team_dos_not_match_with_top_players_team(player_factory):
     top_player.register_failed_matching_attempt()
 
     searches = [newbie, top_player]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
+    assert len(unmatched_searches) == 2
 
 
 def unmatched_newbie_teams_do_not_forcefully_match_pros(player_factory):
@@ -415,9 +423,10 @@ def unmatched_newbie_teams_do_not_forcefully_match_pros(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie_team, pro]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 0
+    assert len(unmatched_searches) == 2
 
 
 def test_odd_number_of_unmatched_newbies(player_factory):
@@ -428,9 +437,10 @@ def test_odd_number_of_unmatched_newbies(player_factory):
     pro.register_failed_matching_attempt()
 
     searches = [newbie1, pro, newbie2, newbie3]
-    matches = stable_marriage.RandomlyMatchNewbies().find(searches)
+    matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert len(matches) == 4
+    assert len(unmatched_searches) == 0
 
 
 def test_matchmaker(player_factory):
@@ -457,13 +467,15 @@ def test_matchmaker(player_factory):
         pro_alone,
         top_player
     ]
-    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
-    match_pairs = matchmaker.find(searches)
+    team_size = 1
+    matchmaker = stable_marriage.StableMarriageMatchmaker()
+    match_pairs, unmatched_searches = matchmaker.find(searches, team_size)
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie_that_matches1, newbie_that_matches2} in match_sets
     assert {pro_that_matches1, pro_that_matches2} in match_sets
     assert {newbie_force_matched, pro_alone} in match_sets
+    assert unmatched_searches == [top_player]
     for match_pair in match_pairs:
         assert top_player not in match_pair
 
@@ -476,8 +488,9 @@ def test_matchmaker_performance(player_factory, bench, caplog):
     searches = [Search([player_factory(1500, 500, ladder_games=1)]) for _ in range(NUM_SEARCHES)]
 
     with bench:
-        matchmaker = stable_marriage.StableMarriageMatchmaker(1)
-        matchmaker.find(searches)
+        team_size = 1
+        matchmaker = stable_marriage.StableMarriageMatchmaker()
+        matchmaker.find(searches, team_size)
 
     assert bench.elapsed() < 0.5
 
@@ -487,11 +500,13 @@ def test_matchmaker_random_only(player_factory):
     newbie2 = Search([player_factory(200, 400, ladder_games=9)])
 
     searches = (newbie1, newbie2)
-    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
-    match_pairs = matchmaker.find(searches)
+    team_size = 1
+    matchmaker = stable_marriage.StableMarriageMatchmaker()
+    match_pairs, unmatched_searches = matchmaker.find(searches, team_size)
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie1, newbie2} in match_sets
+    assert len(unmatched_searches) == 0
 
 
 def test_find_will_not_match_low_quality_games(player_factory):
@@ -500,8 +515,59 @@ def test_find_will_not_match_low_quality_games(player_factory):
 
     searches = [s1, s2]
 
-    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
-    matches = matchmaker.find(searches)
+    team_size = 1
+    matchmaker = stable_marriage.StableMarriageMatchmaker()
+    matches, unmatched_searches = matchmaker.find(searches, team_size)
 
-    assert (s1, s2) not in matches
-    assert (s2, s1) not in matches
+    assert len(matches) == 0
+    assert len(unmatched_searches) == len(searches)
+
+def test_unmatched_searches_without_newbies(player_factory):
+    players = [
+            player_factory(100, 10, name="lowRating_unmatched_1"),
+            player_factory(500, 10, name="lowRating_unmatched_2"),
+            player_factory(1500, 10, name="midRating_matched_1"),
+            player_factory(1500, 10, name="midRating_matched_2"),
+            player_factory(1500, 10, name="midRating_matched_3"),
+            player_factory(1500, 10, name="midRating_matched_4"),
+            player_factory(2000, 10, name="highRating_unmatched_1"),
+            player_factory(2500, 10, name="highRating_unmatched_2"),
+    ]
+    searches = [Search([player]) for player in players]
+
+    team_size = 1
+    matchmaker = stable_marriage.StableMarriageMatchmaker()
+    matches, unmatched_searches = matchmaker.find(searches, team_size)
+
+    expected_number_of_matches = 2
+    assert len(matches) == expected_number_of_matches
+    assert len(unmatched_searches) == len(searches) - 2 *team_size * expected_number_of_matches
+
+def test_unmatched_searches_with_newbies(player_factory):
+    players = [
+            player_factory(100, 10, name="newbie1", ladder_games=1),
+            player_factory(200, 10, name="newbie2", ladder_games=1),
+            player_factory(300, 10, name="newbie3", ladder_games=1),
+            player_factory(400, 10, name="newbie4", ladder_games=1),
+            player_factory(500, 10, name="newbie5", ladder_games=1),
+            player_factory(1500, 10, name="midRating_matched_1"),
+            player_factory(1500, 10, name="midRating_matched_2"),
+            player_factory(1500, 10, name="midRating_matched_3"),
+            player_factory(1500, 10, name="midRating_matched_4"),
+            player_factory(2000, 10, name="highRating_unmatched_1"),
+            player_factory(2500, 10, name="highRating_unmatched_2"),
+    ]
+    searches = [Search([player]) for player in players]
+
+    force_matched_player = player_factory(750, 10, name="lowRating_unmatched_1")
+    force_matched_search = Search([force_matched_player])
+    force_matched_search.register_failed_matching_attempt()
+    searches.append(force_matched_search)
+
+    team_size = 1
+    matchmaker = stable_marriage.StableMarriageMatchmaker()
+    matches, unmatched_searches = matchmaker.find(searches, team_size)
+
+    expected_number_of_matches = 5
+    assert len(matches) == expected_number_of_matches
+    assert len(unmatched_searches) == len(searches) - 2 *team_size * expected_number_of_matches

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -329,6 +329,7 @@ def test_partial_newbie_team_matched_with_newbie_team(player_factory):
 
     assert matches[partial_newbie] == newbie
     assert matches[newbie] == partial_newbie
+    assert len(unmatched_searches) == 0
 
 
 def test_newbie_and_top_rated_team_not_matched_randomly(player_factory):
@@ -345,6 +346,7 @@ def test_newbie_and_top_rated_team_not_matched_randomly(player_factory):
     matches, unmatched_searches = stable_marriage.RandomlyMatchNewbies().find(searches)
 
     assert not matches
+    assert len(unmatched_searches) == len(searches)
 
 
 def test_unmatched_newbies_forcefully_match_pros(player_factory):

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -1,15 +1,11 @@
 import logging
-import math
-import random
 
 import pytest
 from hypothesis import given, settings
-from hypothesis import strategies as st
 
 from server import config
 from server.matchmaker import Search
 from server.matchmaker.algorithm import stable_marriage
-from server.rating import RatingType
 
 from .strategies import st_searches_list
 

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -525,16 +525,17 @@ def test_find_will_not_match_low_quality_games(player_factory):
     assert len(matches) == 0
     assert len(unmatched_searches) == len(searches)
 
+
 def test_unmatched_searches_without_newbies(player_factory):
     players = [
-            player_factory(100, 10, name="lowRating_unmatched_1"),
-            player_factory(500, 10, name="lowRating_unmatched_2"),
-            player_factory(1500, 10, name="midRating_matched_1"),
-            player_factory(1500, 10, name="midRating_matched_2"),
-            player_factory(1500, 10, name="midRating_matched_3"),
-            player_factory(1500, 10, name="midRating_matched_4"),
-            player_factory(2000, 10, name="highRating_unmatched_1"),
-            player_factory(2500, 10, name="highRating_unmatched_2"),
+        player_factory(100, 10, name="lowRating_unmatched_1"),
+        player_factory(500, 10, name="lowRating_unmatched_2"),
+        player_factory(1500, 10, name="midRating_matched_1"),
+        player_factory(1500, 10, name="midRating_matched_2"),
+        player_factory(1500, 10, name="midRating_matched_3"),
+        player_factory(1500, 10, name="midRating_matched_4"),
+        player_factory(2000, 10, name="highRating_unmatched_1"),
+        player_factory(2500, 10, name="highRating_unmatched_2"),
     ]
     searches = [Search([player]) for player in players]
 
@@ -544,21 +545,22 @@ def test_unmatched_searches_without_newbies(player_factory):
 
     expected_number_of_matches = 2
     assert len(matches) == expected_number_of_matches
-    assert len(unmatched_searches) == len(searches) - 2 *team_size * expected_number_of_matches
+    assert len(unmatched_searches) == len(searches) - 2 * team_size * expected_number_of_matches
+
 
 def test_unmatched_searches_with_newbies(player_factory):
     players = [
-            player_factory(100, 10, name="newbie1", ladder_games=1),
-            player_factory(200, 10, name="newbie2", ladder_games=1),
-            player_factory(300, 10, name="newbie3", ladder_games=1),
-            player_factory(400, 10, name="newbie4", ladder_games=1),
-            player_factory(500, 10, name="newbie5", ladder_games=1),
-            player_factory(1500, 10, name="midRating_matched_1"),
-            player_factory(1500, 10, name="midRating_matched_2"),
-            player_factory(1500, 10, name="midRating_matched_3"),
-            player_factory(1500, 10, name="midRating_matched_4"),
-            player_factory(2000, 10, name="highRating_unmatched_1"),
-            player_factory(2500, 10, name="highRating_unmatched_2"),
+        player_factory(100, 10, name="newbie1", ladder_games=1),
+        player_factory(200, 10, name="newbie2", ladder_games=1),
+        player_factory(300, 10, name="newbie3", ladder_games=1),
+        player_factory(400, 10, name="newbie4", ladder_games=1),
+        player_factory(500, 10, name="newbie5", ladder_games=1),
+        player_factory(1500, 10, name="midRating_matched_1"),
+        player_factory(1500, 10, name="midRating_matched_2"),
+        player_factory(1500, 10, name="midRating_matched_3"),
+        player_factory(1500, 10, name="midRating_matched_4"),
+        player_factory(2000, 10, name="highRating_unmatched_1"),
+        player_factory(2500, 10, name="highRating_unmatched_2"),
     ]
     searches = [Search([player]) for player in players]
 
@@ -573,4 +575,4 @@ def test_unmatched_searches_with_newbies(player_factory):
 
     expected_number_of_matches = 5
     assert len(matches) == expected_number_of_matches
-    assert len(unmatched_searches) == len(searches) - 2 *team_size * expected_number_of_matches
+    assert len(unmatched_searches) == len(searches) - 2 * team_size * expected_number_of_matches

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import assume, given, settings
 
 from server import config
 from server.matchmaker import Search
@@ -167,6 +167,8 @@ def test_stable_marriage_produces_symmetric_matchings(
         ranks = build_func(searches)
 
         matches = stable_marriage.StableMarriage().find(ranks)
+
+        assume(matches != [])
 
         for search in matches:
             opponent = matches[search]

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -311,6 +311,7 @@ def test_newbie_team_matched_with_newbie_team(player_factory):
 
     assert matches[newbie1] == newbie2
     assert matches[newbie2] == newbie1
+    assert len(unmatched_searches) == 0
 
 
 def test_partial_newbie_team_matched_with_newbie_team(player_factory):

--- a/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_stable_marriage.py
@@ -461,8 +461,8 @@ def test_matchmaker(player_factory):
         pro_alone,
         top_player
     ]
-    matchmaker = stable_marriage.StableMarriageMatchmaker(searches, 1)
-    match_pairs = matchmaker.find()
+    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
+    match_pairs = matchmaker.find(searches)
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie_that_matches1, newbie_that_matches2} in match_sets
@@ -480,8 +480,8 @@ def test_matchmaker_performance(player_factory, bench, caplog):
     searches = [Search([player_factory(1500, 500, ladder_games=1)]) for _ in range(NUM_SEARCHES)]
 
     with bench:
-        matchmaker = stable_marriage.StableMarriageMatchmaker(searches, 1)
-        matchmaker.find()
+        matchmaker = stable_marriage.StableMarriageMatchmaker(1)
+        matchmaker.find(searches)
 
     assert bench.elapsed() < 0.5
 
@@ -491,8 +491,8 @@ def test_matchmaker_random_only(player_factory):
     newbie2 = Search([player_factory(200, 400, ladder_games=9)])
 
     searches = (newbie1, newbie2)
-    matchmaker = stable_marriage.StableMarriageMatchmaker(searches, 1)
-    match_pairs = matchmaker.find()
+    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
+    match_pairs = matchmaker.find(searches)
     match_sets = [set(pair) for pair in match_pairs]
 
     assert {newbie1, newbie2} in match_sets
@@ -504,26 +504,8 @@ def test_find_will_not_match_low_quality_games(player_factory):
 
     searches = [s1, s2]
 
-    matchmaker = stable_marriage.StableMarriageMatchmaker(searches, 1)
-    matches = matchmaker.find()
+    matchmaker = stable_marriage.StableMarriageMatchmaker(1)
+    matches = matchmaker.find(searches)
 
     assert (s1, s2) not in matches
     assert (s2, s1) not in matches
-
-
-def test_find_communicates_failed_attempts(player_factory):
-    s1 = Search([player_factory(100, 64, name="p1")])
-    s2 = Search([player_factory(2000, 64, name="p2")])
-
-    searches = [s1, s2]
-
-    assert s1.failed_matching_attempts == 0
-    assert s2.failed_matching_attempts == 0
-
-    matchmaker = stable_marriage.StableMarriageMatchmaker(searches, 1)
-    matches = matchmaker.find()
-
-    # These searches should not have been matched
-    assert not matches
-    assert s1.failed_matching_attempts == 1
-    assert s2.failed_matching_attempts == 1

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -476,13 +476,18 @@ async def test_queue_pop_communicates_failed_attempts(matchmaker_queue, player_f
     s2 = Search([player_factory("Player2", player_id=2, ladder_rating=(1000, 50))])
 
     matchmaker_queue.push(s1)
-    matchmaker_queue.push(s2)
-
     assert s1.failed_matching_attempts == 0
+
+    await matchmaker_queue.find_matches()
+
+    assert s1.failed_matching_attempts == 1
+
+    matchmaker_queue.push(s2)
+    assert s1.failed_matching_attempts == 1
     assert s2.failed_matching_attempts == 0
 
     await matchmaker_queue.find_matches()
 
     # These searches should not have been matched
-    assert s1.failed_matching_attempts == 1
+    assert s1.failed_matching_attempts == 2
     assert s2.failed_matching_attempts == 1

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -447,7 +447,26 @@ async def test_find_matches_synchronized(queue_factory):
                 mock.Mock(players=[2]): 2
             }
             queue.find_teams = mock.Mock()
+            queue._register_unmatched_searches = mock.Mock()
 
         await asyncio.gather(*[
             queue.find_matches() for queue in queues
         ])
+
+
+@pytest.mark.asyncio
+async def test_queue_pop_communicates_failed_attempts(matchmaker_queue, player_factory):
+    s1 = Search([player_factory("Player1", player_id=1, ladder_rating=(3000, 50))])
+    s2 = Search([player_factory("Player2", player_id=2, ladder_rating=(1000, 50))])
+
+    matchmaker_queue.push(s1)
+    matchmaker_queue.push(s2)
+
+    assert s1.failed_matching_attempts == 0
+    assert s2.failed_matching_attempts == 0
+
+    await matchmaker_queue.find_matches()
+
+    # These searches should not have been matched
+    assert s1.failed_matching_attempts == 1
+    assert s2.failed_matching_attempts == 1

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -424,7 +424,7 @@ async def test_queue_mid_cancel(matchmaker_queue, matchmaker_players_all_match):
 async def test_find_matches_synchronized(queue_factory):
     is_matching = False
 
-    def make_matches(*args):
+    def find(*args):
         nonlocal is_matching
 
         assert not is_matching, "Function call not synchronized"
@@ -436,8 +436,8 @@ async def test_find_matches_synchronized(queue_factory):
         return []
 
     with mock.patch(
-        "server.matchmaker.matchmaker_queue.make_matches",
-        make_matches
+        "server.matchmaker.matchmaker_queue.StableMarriageMatchmaker.find",
+        find
     ):
         queues = [queue_factory(f"Queue{i}") for i in range(5)]
         # Ensure that find_matches does not short circuit

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -420,8 +420,8 @@ async def test_queue_mid_cancel(matchmaker_queue, matchmaker_players_all_match):
 
 @pytest.mark.asyncio
 async def test_queue_cancel_while_being_matched_registers_failed_attempt(
-        matchmaker_queue, matchmaker_players_all_match
-    ):
+    matchmaker_queue, matchmaker_players_all_match
+):
     p1, p2, p3, p4,  _ = matchmaker_players_all_match
     searches = [Search([p1]), Search([p2]), Search([p3]), Search([p4])]
     for search in searches:

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -433,25 +433,22 @@ async def test_find_matches_synchronized(queue_factory):
         time.sleep(0.2)
 
         is_matching = False
-        return []
+        return [], []
 
-    with mock.patch(
-        "server.matchmaker.matchmaker_queue.StableMarriageMatchmaker.find",
-        find
-    ):
-        queues = [queue_factory(f"Queue{i}") for i in range(5)]
-        # Ensure that find_matches does not short circuit
-        for queue in queues:
-            queue._queue = {
-                mock.Mock(players=[1]): 1,
-                mock.Mock(players=[2]): 2
-            }
-            queue.find_teams = mock.Mock()
-            queue._register_unmatched_searches = mock.Mock()
+    queues = [queue_factory(f"Queue{i}") for i in range(5)]
+    # Ensure that find_matches does not short circuit
+    for queue in queues:
+        queue._queue = {
+            mock.Mock(players=[1]): 1,
+            mock.Mock(players=[2]): 2
+        }
+        queue.find_teams = mock.Mock()
+        queue._register_unmatched_searches = mock.Mock()
+        queue.matchmaker.find = mock.Mock(side_effect=find)
 
-        await asyncio.gather(*[
-            queue.find_matches() for queue in queues
-        ])
+    await asyncio.gather(*[
+        queue.find_matches() for queue in queues
+    ])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refactors `server/matchmaker/algorithm.py` such that the matchmaking algorithm is independent from the queue logic, with the intent that @BlackYps can simply subclass a new `Matchmaker` to propose a new algorithm.

For now I stuck to minimal/minor changes, although I think these files could still benefit a lot from more attention. For example I'm not convinced that these `Matchmaker`s should have instance variables at all but left that as-is for a chance to get feedback first.

Closes #801.