### PR TITLE
Issue/#752 queue state track

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -373,10 +373,6 @@ class LadderService(Service):
             all_players = team1 + team2
             all_guests = all_players[1:]
 
-            host.state = PlayerState.HOSTING
-            for guest in all_guests:
-                guest.state = PlayerState.JOINING
-
             played_map_ids = await self.get_game_history(
                 all_players,
                 queue.id,
@@ -475,7 +471,8 @@ class LadderService(Service):
 
             msg = {"command": "match_cancelled"}
             for player in all_players:
-                player.state = PlayerState.IDLE
+                if player.state == PlayerState.STARTING_AUTOMATCH:
+                    player.state = PlayerState.IDLE
                 player.write_message(msg)
 
     async def get_game_history(

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -148,13 +148,27 @@ async def test_game_matchmaking_timeout(lobby_server, game_service):
     )
     assert game_service._games == {}
 
-    # Player's state is reset so they are able to queue again
+    # Player's state is reset once they leave the game
+    await proto1.send_message({
+        "command": "GameState",
+        "target": "game",
+        "args": ["Ended"]
+    })
     await proto1.send_message({
         "command": "game_matchmaking",
         "state": "start",
         "faction": "uef"
     })
-    await read_until_command(proto1, "search_info", state="start", timeout=15)
+    await read_until_command(proto1, "search_info", state="start", timeout=5)
+
+    # And not before they've left the game
+    await proto2.send_message({
+        "command": "game_matchmaking",
+        "state": "start",
+        "faction": "uef"
+    })
+    with pytest.raises(asyncio.TimeoutError):
+        await read_until_command(proto2, "search_info", state="start", timeout=5)
 
 
 @fast_forward(120)
@@ -182,13 +196,27 @@ async def test_game_matchmaking_timeout_guest(lobby_server, game_service):
     )
     assert game_service._games == {}
 
-    # Player's state is reset so they are able to queue again
+    # Player's state is reset once they leave the game
+    await proto1.send_message({
+        "command": "GameState",
+        "target": "game",
+        "args": ["Ended"]
+    })
     await proto1.send_message({
         "command": "game_matchmaking",
         "state": "start",
         "faction": "uef"
     })
     await read_until_command(proto1, "search_info", state="start", timeout=5)
+
+    # And not before they've left the game
+    await proto2.send_message({
+        "command": "game_matchmaking",
+        "state": "start",
+        "faction": "uef"
+    })
+    with pytest.raises(asyncio.TimeoutError):
+        await read_until_command(proto2, "search_info", state="start", timeout=5)
 
 
 @fast_forward(15)

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -136,7 +136,7 @@ async def test_start_game_1v1(
     game = game_service[game_service.game_id_counter]
 
     assert player1.lobby_connection.launch_game.called
-    # TODO: Once client supports `game_launch_timeout` change this to `assert not ...`
+    # TODO: Once client supports `match_cancelled` change this to `assert not`
     assert player2.lobby_connection.launch_game.called
     assert isinstance(game, LadderGame)
     assert game.rating_type == queue.rating_type
@@ -159,10 +159,11 @@ async def test_start_game_timeout(
     p1.lobby_connection.write.assert_called_once_with({"command": "match_cancelled"})
     p2.lobby_connection.write.assert_called_once_with({"command": "match_cancelled"})
     assert p1.lobby_connection.launch_game.called
-    # TODO: Once client supports `match_cancelled` change this to `assert not ...`
+    # TODO: Once client supports `match_cancelled` change this to `assert not`
+    # and uncomment the following lines.
     assert p2.lobby_connection.launch_game.called
-    assert p1.state is PlayerState.IDLE
-    assert p2.state is PlayerState.IDLE
+    # assert p1.state is PlayerState.IDLE
+    # assert p2.state is PlayerState.IDLE
 
 
 @given(


### PR DESCRIPTION
Turns out all we have to do is delete the state update when games time out, as the code in `GameConnection` already handles setting the state once players have actually left the game.

I adjusted the tests to reflect the desired behavior. They were a little to eager to see the state reset before.

Closes #752