### PR TITLE
Issue/#624 fix map anti repetition

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -84,7 +84,7 @@ class ConfigurationStore:
         self.GEO_IP_DATABASE_MAX_AGE_DAYS = 22
 
         self.LADDER_1V1_OUTCOME_OVERRIDE = True
-        self.LADDER_ANTI_REPETITION_LIMIT = 3
+        self.LADDER_ANTI_REPETITION_LIMIT = 2
         self.LADDER_SEARCH_EXPANSION_MAX = 0.25
         self.LADDER_SEARCH_EXPANSION_STEP = 0.05
         # The maximum amount of time in seconds) to wait between pops.

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -141,7 +141,7 @@ game_stats = Table(
     Column("gameType",  Enum(Victory),  nullable=False),
     Column("gameMod",   Integer,        ForeignKey("game_featuredMods.id"), nullable=False),
     Column("host",      Integer,        nullable=False),
-    Column("mapId",     Integer),
+    Column("mapId",     Integer,        ForeignKey("map_version.id")),
     Column("gameName",  String(128),    nullable=False),
     Column("validity",  Integer,        nullable=False),
 )

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -108,7 +108,7 @@ class LadderService(Service):
                 map_pool.c.name,
                 map_pool_map_version.c.weight,
                 map_pool_map_version.c.map_params,
-                map_version.c.map_id,
+                map_version.c.id.label("map_id"),
                 map_version.c.filename,
                 t_map.c.display_name
             ]).select_from(

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -137,8 +137,8 @@ class LadderService(Service):
                     else:
                         self._logger.warning(
                             "Unsupported map type %s in pool %s",
-                             map_type,
-                             row.id
+                            map_type,
+                            row.id
                         )
 
                 except Exception:

--- a/server/matchmaker/map_pool.py
+++ b/server/matchmaker/map_pool.py
@@ -19,7 +19,7 @@ class MapPool(object):
         self.maps = None
         self.set_maps(maps)
 
-    def set_maps(self, maps: Iterable[Map]) -> None:
+    def set_maps(self, maps: Iterable[Union[Map, NeroxisGeneratedMap]]) -> None:
         self.maps = {map_.id: map_ for map_ in maps}
 
     def choose_map(self, played_map_ids: Iterable[int] = ()) -> Map:
@@ -55,5 +55,5 @@ class MapPool(object):
 
         return self.maps[random.choices(least_common, weights=weights, k=1)[0][0]].get_map()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"MapPool({self.id}, {self.name}, {list(self.maps.values())})"

--- a/server/matchmaker/map_pool.py
+++ b/server/matchmaker/map_pool.py
@@ -40,9 +40,9 @@ class MapPool(object):
 
         least_common = counter.most_common()[::-1]
         least_count = 1
-        for map_count in least_common:
-            if isinstance(self.maps[map_count[0]], Map):
-                least_count = map_count[1]
+        for id_, count in least_common:
+            if isinstance(self.maps[id_], Map):
+                least_count = count
                 break
 
         # Trim off the maps with higher play counts

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -54,12 +54,16 @@ async def test_load_from_database(ladder_service, queue_factory):
         assert queue.name == "ladder1v1"
         assert len(queue.map_pools) == 3
         assert list(queue.map_pools[1][0].maps.values()) == [
-            Map(id=15, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
+            Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
+            Map(id=16, name="SCMP_015", path="maps/scmp_015.v0002.zip"),
+            Map(id=17, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
         ]
         assert list(queue.map_pools[2][0].maps.values()) == [
             Map(id=11, name="SCMP_011", path="maps/scmp_011.zip"),
             Map(id=14, name="SCMP_014", path="maps/scmp_014.zip"),
-            Map(id=15, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
+            Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
+            Map(id=16, name="SCMP_015", path="maps/scmp_015.v0002.zip"),
+            Map(id=17, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
         ]
         assert list(queue.map_pools[3][0].maps.values()) == [
             Map(id=1, name="SCMP_001", path="maps/scmp_001.zip"),

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -116,7 +116,7 @@ async def test_load_from_database_new_data(ladder_service, database):
     player1=st_players("p1", player_id=1, lobby_connection_spec="mock"),
     player2=st_players("p2", player_id=2, lobby_connection_spec="mock")
 )
-@settings(deadline=300)
+@settings(deadline=None)
 @autocontext("ladder_and_game_service_context", "monkeypatch_context")
 async def test_start_game_1v1(
     ladder_and_game_service,
@@ -176,7 +176,7 @@ async def test_start_game_timeout(
     player3=st_players("p3", player_id=3, lobby_connection_spec="mock"),
     player4=st_players("p4", player_id=4, lobby_connection_spec="mock")
 )
-@settings(deadline=300)
+@settings(deadline=None)
 @autocontext("ladder_and_game_service_context", "monkeypatch_context")
 async def test_start_game_with_teams(
     ladder_and_game_service,


### PR DESCRIPTION
Map pools were fetching `map.id` instead of `map_version.id` which meant that the games played history would never match the ids in the map pool.

I'm also setting the default limit to 2, down from 3 since @FtXCommando wants that to be the number we use and its easier for me to do it now, than to remember to get @Brutus5000 to remember to do it in the server config when he deploys :P.

Closes #624