### PR TITLE
Remove references to equilibrium #744

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -10,13 +10,10 @@ from .core import Service
 from .db import FAFDatabase
 from .decorators import with_logger
 from .games import (
-    CoopGame,
-    CustomGame,
     FeaturedMod,
     FeaturedModType,
     Game,
     GameState,
-    LadderGame,
     ValidityState,
     VisibilityState
 )
@@ -154,15 +151,6 @@ class GameService(Service):
             "matchmaker_queue_id": matchmaker_queue_id,
         }
         game_args.update(kwargs)
-
-        if not game_class:
-            game_class = {
-                FeaturedModType.LADDER_1V1:   LadderGame,
-                FeaturedModType.COOP:         CoopGame,
-                FeaturedModType.FAF:          CustomGame,
-                FeaturedModType.FAFBETA:      CustomGame,
-                FeaturedModType.EQUILIBRIUM:  CustomGame
-            }.get(game_mode, Game)
         game = game_class(**game_args)
 
         self._games[game_id] = game

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -10,6 +10,7 @@ from .core import Service
 from .db import FAFDatabase
 from .decorators import with_logger
 from .games import (
+    CustomGame,
     FeaturedMod,
     FeaturedModType,
     Game,
@@ -126,7 +127,7 @@ class GameService(Service):
     def create_game(
         self,
         game_mode: str,
-        game_class: Type[Game] = None,
+        game_class: Type[Game] = CustomGame,
         visibility=VisibilityState.PUBLIC,
         host: Optional[Player] = None,
         name: Optional[str] = None,

--- a/server/games/typedefs.py
+++ b/server/games/typedefs.py
@@ -92,7 +92,6 @@ class FeaturedModType():
     """
 
     COOP = "coop"
-    EQUILIBRIUM = "equilibrium"
     FAF = "faf"
     FAFBETA = "fafbeta"
     LADDER_1V1 = "ladder1v1"

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -32,7 +32,15 @@ from .exceptions import AuthenticationError, BanError, ClientError
 from .factions import Faction
 from .game_service import GameService
 from .gameconnection import GameConnection
-from .games import FeaturedModType, GameState, VisibilityState
+from .games import (
+    CustomGame, 
+    CoopGame,
+    FeaturedModType,
+    Game,
+    GameState, 
+    LadderGame, 
+    VisibilityState
+)
 from .geoip_service import GeoIpService
 from .ice_servers.coturn import CoturnHMAC
 from .ice_servers.nts import TwilioNTS
@@ -895,9 +903,17 @@ class LobbyConnection:
         if rating_max is not None:
             rating_max = float(rating_max)
 
+        game_class = {
+            FeaturedModType.LADDER_1V1:   LadderGame,
+            FeaturedModType.COOP:         CoopGame,
+            FeaturedModType.FAF:          CustomGame,
+            FeaturedModType.FAFBETA:      CustomGame
+        }.get(game_mode, Game)
+
         game = self.game_service.create_game(
             visibility=visibility,
             game_mode=game_mode,
+            game_class=game_class,
             host=self.player,
             name=title,
             mapname=mapname,

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -903,12 +903,7 @@ class LobbyConnection:
         if rating_max is not None:
             rating_max = float(rating_max)
 
-        game_class = {
-            FeaturedModType.LADDER_1V1:   LadderGame,
-            FeaturedModType.COOP:         CoopGame,
-            FeaturedModType.FAF:          CustomGame,
-            FeaturedModType.FAFBETA:      CustomGame
-        }.get(game_mode, Game)
+        game_class = CoopGame if game_mode == FeaturedModType.COOP else CustomGame
 
         game = self.game_service.create_game(
             visibility=visibility,

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -33,12 +33,12 @@ from .factions import Faction
 from .game_service import GameService
 from .gameconnection import GameConnection
 from .games import (
-    CustomGame, 
     CoopGame,
+    CustomGame,
     FeaturedModType,
     Game,
-    GameState, 
-    LadderGame, 
+    GameState,
+    LadderGame,
     VisibilityState
 )
 from .geoip_service import GeoIpService

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -36,9 +36,7 @@ from .games import (
     CoopGame,
     CustomGame,
     FeaturedModType,
-    Game,
     GameState,
-    LadderGame,
     VisibilityState
 )
 from .geoip_service import GeoIpService

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -82,7 +82,6 @@ async def test_validate_game_settings(game: Game, game_add_players):
     mods = (
         FeaturedModType.FAF,
         FeaturedModType.LADDER_1V1,
-        FeaturedModType.EQUILIBRIUM,
         "AnythingReally"
     )
 

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -15,6 +15,7 @@ async def test_create_game(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="faf",
+        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",
@@ -32,6 +33,7 @@ async def test_all_games(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="faf",
+        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",
@@ -44,6 +46,7 @@ async def test_all_games(players, game_service):
 async def test_create_game_ladder1v1(players, game_service):
     game = game_service.create_game(
         game_mode="ladder1v1",
+        game_class=LadderGame,
         host=players.hosting,
         name="Test Ladder",
     )
@@ -57,6 +60,7 @@ async def test_create_game_other_gamemode(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="labwars",
+        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -15,7 +15,6 @@ async def test_create_game(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="faf",
-        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",
@@ -33,7 +32,6 @@ async def test_all_games(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="faf",
-        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",
@@ -60,7 +58,6 @@ async def test_create_game_other_gamemode(players, game_service):
     game = game_service.create_game(
         visibility=VisibilityState.PUBLIC,
         game_mode="labwars",
-        game_class=CustomGame,
         host=players.hosting,
         name="Test",
         mapname="SCMP_007",

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -246,6 +246,7 @@ async def test_command_game_host_creates_game(
     })
     expected_call = {
         "game_mode": "faf",
+        "game_class": CustomGame,
         "name": test_game_info["title"],
         "host": players.hosting,
         "visibility": VisibilityState.PUBLIC,


### PR DESCRIPTION
Remove references to equilibrium

I was able do three things as part of this change set.

- Remove Equilibrium from the `FeaturedModType` enum and all references
- Migrate game class detection out of the `game_service` class
- Update `game_service` tests to pass in a game class since the method signature technically changed

Please let me know if you have any questions or feedback for improvement!

Closes #744