### PR TITLE
Fix control server integration tests

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -10,7 +10,9 @@ import pytest
 from aiohttp import web
 from asynctest import exhaust_callbacks
 
-from server import GameService, ServerInstance, run_control_server
+from server import GameService, ServerInstance
+from server.config import config
+from server.control import ControlServer
 from server.db.models import login
 from server.ladder_service import LadderService
 from server.party_service import PartyService
@@ -102,7 +104,13 @@ async def lobby_server(
 
 @pytest.fixture
 async def control_server(player_service, game_service):
-    server = await run_control_server(player_service, game_service)
+    server = ControlServer(
+        game_service,
+        player_service,
+        "127.0.0.1",
+        config.CONTROL_SERVER_PORT
+    )
+    await server.start()
 
     yield server
 

--- a/tests/integration_tests/test_control_server.py
+++ b/tests/integration_tests/test_control_server.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import aiohttp
 import pytest
 


### PR DESCRIPTION
The control server seems to be unable to bind to the default address on github actions?

I guess it's primarily an issue of host name resolution not returning the correct address in github actions ubuntu VM's. So at least in theory binding directly to 127.0.0.1 should solve the issue by avoiding name resolution entirely.

#772