### PR TITLE
[WIP] Add game_type field to game_launch command message

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -39,6 +39,7 @@ from .games import (
     GameState,
     VisibilityState
 )
+from .games.typedefs import GameType
 from .geoip_service import GeoIpService
 from .ice_servers.coturn import CoturnHMAC
 from .ice_servers.nts import TwilioNTS
@@ -953,6 +954,8 @@ class LobbyConnection:
             # options are. Currently, options for ladder are hardcoded into the
             # client.
             "name": game.name,
+            "game_type": GameType.to_string(game.game_type),
+            # Use game_type instead, init_mode is depreciated
             "init_mode": game.init_mode.value,
             "rating_type": game.rating_type,
             **options._asdict()

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -389,7 +389,6 @@ async def test_should_reply_with_game_type_field_on_game_lauch(database,
     game.id = 42
     game.name = "Test Game Name"
     game_service._games[42] = game
-    lobbyconnection.player = players.hosting
     test_game_info["uid"] = 42
 
     await lobbyconnection.on_message_received({
@@ -398,12 +397,13 @@ async def test_should_reply_with_game_type_field_on_game_lauch(database,
     })
     expected_reply = {
         "command": "game_launch",
-        "game_type": "custom",
         "args": ["/numgames", players.hosting.game_count[RatingType.GLOBAL]],
-        "mod": "faf",
         "uid": 42,
+        "mod": "faf",
         "name": "Test Game Name",
+        "game_type": "custom",
         "init_mode": InitMode.NORMAL_LOBBY.value,
+        "rating_type": "global",
     }
     lobbyconnection.send.assert_called_with(expected_reply)
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -330,6 +330,7 @@ async def test_command_game_join_calls_join_game(
         "uid": 42,
         "mod": "faf",
         "name": "Test Game Name",
+        "game_type": "custom",
         "init_mode": InitMode.NORMAL_LOBBY.value,
         "rating_type": "global",
     }
@@ -369,6 +370,7 @@ async def test_command_game_join_uid_as_str(
         "mod": "faf",
         "uid": 42,
         "name": "Test Game Name",
+        "game_type": "custom",
         "init_mode": InitMode.NORMAL_LOBBY.value,
         "rating_type": "global",
     }


### PR DESCRIPTION
Closes #685

I've been getting these note's all night while running tests, looks like I still have some network configuration to fix but the DB is online:

.faf-db                   | 2021-04-20T00:57:20.848527Z 633 [Note] Aborted connection 633 to db: 'faf' user: 'root' host: '172.21.0.1' (Got an error reading communication packets)