### PR TITLE
Issue/#771 send broadcast info to rabbitmq

### DIFF
--- a/server/broadcast_service.py
+++ b/server/broadcast_service.py
@@ -48,6 +48,12 @@ class BroadcastService(Service):
         self._logger.debug("Broadcast service initialized")
 
     async def report_dirties(self):
+        """
+        Send updates about any dirty (changed) entities to connected players.
+        This function is called at a fixed interval, which guarantees that any
+        given object will not be written out to the clients more than once per
+        interval.
+        """
         self.game_service.update_active_game_metrics()
         dirty_games = self.game_service.pop_dirty_games()
         dirty_queues = self.game_service.pop_dirty_queues()

--- a/server/broadcast_service.py
+++ b/server/broadcast_service.py
@@ -65,10 +65,7 @@ class BroadcastService(Service):
                 "command": "player_info",
                 "players": [player.to_dict() for player in dirty_players]
             }
-            self.server.write_broadcast(
-                player_info,
-                lambda lobby_conn: lobby_conn.authenticated
-            )
+            self.server.write_broadcast(player_info)
 
         game_info = {
             "command": "game_info",

--- a/server/broadcast_service.py
+++ b/server/broadcast_service.py
@@ -49,11 +49,9 @@ class BroadcastService(Service):
 
     async def report_dirties(self):
         self.game_service.update_active_game_metrics()
-        dirty_games = self.game_service.dirty_games
-        dirty_queues = self.game_service.dirty_queues
-        dirty_players = self.player_service.dirty_players
-        self.game_service.clear_dirty()
-        self.player_service.clear_dirty()
+        dirty_games = self.game_service.pop_dirty_games()
+        dirty_queues = self.game_service.pop_dirty_queues()
+        dirty_players = self.player_service.pop_dirty_players()
 
         if dirty_queues:
             matchmaker_info = {

--- a/server/broadcast_service.py
+++ b/server/broadcast_service.py
@@ -1,0 +1,89 @@
+from .config import config
+from .core import Service
+from .decorators import with_logger
+from .game_service import GameService
+from .games import GameState
+from .message_queue_service import MessageQueueService
+from .player_service import PlayerService
+from .timing import LazyIntervalTimer
+
+
+@with_logger
+class BroadcastService(Service):
+    """
+    Broadcast updates about changed entities.
+    """
+
+    def __init__(
+        self,
+        server: "ServerInstance",
+        message_queue_service: MessageQueueService,
+        game_service: GameService,
+        player_service: PlayerService,
+    ):
+        self.server = server
+        self.message_queue_service = message_queue_service
+        self.game_service = game_service
+        self.player_service = player_service
+
+    async def initialize(self):
+        await self.message_queue_service.declare_exchange(
+            config.MQ_EXCHANGE_NAME
+        )
+
+        # Using a lazy interval timer so that the intervals can be changed
+        # without restarting the server.
+        self._broadcast_dirties_timer = LazyIntervalTimer(
+            lambda: config.DIRTY_REPORT_INTERVAL,
+            self.report_dirties,
+            start=True
+        )
+        self._broadcast_ping_timer = LazyIntervalTimer(
+            lambda: config.PING_INTERVAL,
+            self.broadcast_ping,
+            start=True
+        )
+        self._logger.debug("Broadcast service initialized")
+
+    def report_dirties(self):
+        self.game_service.update_active_game_metrics()
+        dirty_games = self.game_service.dirty_games
+        dirty_queues = self.game_service.dirty_queues
+        dirty_players = self.player_service.dirty_players
+        self.game_service.clear_dirty()
+        self.player_service.clear_dirty()
+
+        if dirty_queues:
+            self.server.write_broadcast({
+                "command": "matchmaker_info",
+                "queues": [queue.to_dict() for queue in dirty_queues]
+            })
+
+        if dirty_players:
+            self.server.write_broadcast(
+                {
+                    "command": "player_info",
+                    "players": [player.to_dict() for player in dirty_players]
+                },
+                lambda lobby_conn: lobby_conn.authenticated
+            )
+
+        # TODO: This spams squillions of messages: we should implement per-
+        # connection message aggregation at the next abstraction layer down :P
+        for game in dirty_games:
+            if game.state == GameState.ENDED:
+                self.game_service.remove_game(game)
+
+            # So we're going to be broadcasting this to _somebody_...
+            message = game.to_dict()
+
+            self.server.write_broadcast(
+                message,
+                lambda conn: (
+                    conn.authenticated
+                    and game.is_visible_to_player(conn.player)
+                )
+            )
+
+    def broadcast_ping(self):
+        self.server.write_broadcast({"command": "ping"})

--- a/server/config.py
+++ b/server/config.py
@@ -39,6 +39,9 @@ class ConfigurationStore:
         self.PROFILING_DURATION = 2
         self.PROFILING_INTERVAL = -1
 
+        self.DIRTY_REPORT_INTERVAL = 1
+        self.PING_INTERVAL = 45
+
         self.CONTROL_SERVER_PORT = 4000
         self.METRICS_PORT = 8011
         self.ENABLE_METRICS = False

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -3,7 +3,7 @@ Manages the lifecycle of active games
 """
 
 from collections import Counter
-from typing import Dict, List, Optional, Type, Union, ValuesView
+from typing import Dict, List, Optional, Set, Type, Union, ValuesView
 
 import aiocron
 
@@ -104,23 +104,23 @@ class GameService(Service):
             # Turn resultset into a list of uids
             self.ranked_mods = set(map(lambda x: x[0], rows))
 
-    @property
-    def dirty_games(self):
-        return self._dirty_games
-
-    @property
-    def dirty_queues(self):
-        return self._dirty_queues
-
     def mark_dirty(self, obj: Union[Game, MatchmakerQueue]):
         if isinstance(obj, Game):
             self._dirty_games.add(obj)
         elif isinstance(obj, MatchmakerQueue):
             self._dirty_queues.add(obj)
 
-    def clear_dirty(self):
+    def pop_dirty_games(self) -> Set[Game]:
+        dirty_games = self._dirty_games
         self._dirty_games = set()
+
+        return dirty_games
+
+    def pop_dirty_queues(self) -> Set[MatchmakerQueue]:
+        dirty_queues = self._dirty_queues
         self._dirty_queues = set()
+
+        return dirty_queues
 
     def create_uid(self) -> int:
         self.game_id_counter += 1

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -16,7 +16,6 @@ from .decorators import with_logger
 from .games import (
     CustomGame,
     FeaturedMod,
-    FeaturedModType,
     Game,
     GameState,
     ValidityState,

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -560,7 +560,10 @@ class LobbyConnection:
 
         old_player = self.player_service.get_player(self.player.id)
         if old_player:
-            self._logger.debug("player {} already signed in: {}".format(self.player.id, old_player))
+            self._logger.debug(
+                "player %s already signed in: %s",
+                self.player.id, old_player
+            )
             if old_player.lobby_connection is not None:
                 with contextlib.suppress(DisconnectedError):
                     old_player.lobby_connection.write_warning(

--- a/server/message_queue_service.py
+++ b/server/message_queue_service.py
@@ -125,6 +125,7 @@ class MessageQueueService(Service):
         exchange_name: str,
         routing: str,
         payload: Dict,
+        mandatory: bool = False,
         delivery_mode: DeliveryMode = DeliveryMode.PERSISTENT,
     ) -> None:
         if not self._is_ready:
@@ -142,7 +143,11 @@ class MessageQueueService(Service):
         )
 
         async with self._channel.transaction():
-            await exchange.publish(message, routing_key=routing)
+            await exchange.publish(
+                message,
+                routing_key=routing,
+                mandatory=mandatory
+            )
             self._logger.log(
                 TRACE, "Published message %s to %s/%s", payload, exchange_name, routing
             )

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -66,15 +66,14 @@ class PlayerService(Service):
     def all_players(self) -> ValuesView[Player]:
         return self._players.values()
 
-    @property
-    def dirty_players(self) -> Set[Player]:
-        return self._dirty_players
-
     def mark_dirty(self, player: Player):
         self._dirty_players.add(player)
 
-    def clear_dirty(self):
+    def pop_dirty_players(self) -> Set[Player]:
+        dirty_players = self._dirty_players
         self._dirty_players = set()
+
+        return dirty_players
 
     async def fetch_player_data(self, player):
         async with self._db.acquire() as conn:

--- a/server/timing/__init__.py
+++ b/server/timing/__init__.py
@@ -2,6 +2,6 @@
 Helpers for executing async functions on a timer
 """
 
-from .timer import Timer, at_interval
+from .timer import LazyIntervalTimer, Timer, at_interval
 
-__all__ = ("Timer", "at_interval")
+__all__ = ("LazyIntervalTimer", "Timer", "at_interval")

--- a/server/timing/timer.py
+++ b/server/timing/timer.py
@@ -87,10 +87,34 @@ class Timer(object):
         return self
 
     def __str__(self):
-        return f"{self.interval} {self.func}"
+        return f"{self.get_delay()} {self.func}"
 
     def __repr__(self):
         return f"<Timer {str(self)}>"
+
+
+class LazyIntervalTimer(Timer):
+    """A timer that calls a function to get the next interval"""
+
+    def __init__(
+        self,
+        interval_func,
+        func=None,
+        args=(),
+        start=False,
+        loop=None
+    ):
+        super().__init__(
+            interval=None,
+            func=func,
+            args=args,
+            start=start,
+            loop=loop
+        )
+        self.interval_func = interval_func
+
+    def get_delay(self):
+        return self.interval_func()
 
 
 def at_interval(interval, func=None, args=(), start=True, loop=None):

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -82,7 +82,7 @@ async def queue_player_for_matchmaking(user, lobby_server, queue_name):
         "search_info",
         state="start",
         queue_name=queue_name,
-        timeout=5
+        timeout=10
     )
 
     return proto

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -342,8 +342,10 @@ async def test_anti_map_repetition(lobby_server):
     # was played. We don't actually play the game out here, so the players
     # game history should remain unchanged.
     for _ in range(20):
-        await proto1.close()
-        await proto2.close()
+        await asyncio.gather(
+            proto1.close(),
+            proto2.close()
+        )
 
         proto1, proto2 = await queue_players_for_matchmaking(lobby_server)
         msg = await read_until_command(proto1, "game_launch")

--- a/tests/integration_tests/test_server_instance.py
+++ b/tests/integration_tests/test_server_instance.py
@@ -25,6 +25,7 @@ def has_player(msg, name):
 @pytest.mark.asyncio
 async def test_multiple_contexts(
     database,
+    broadcast_service,
     game_service,
     player_service,
     geoip_service,
@@ -43,6 +44,7 @@ async def test_multiple_contexts(
         twilio_nts=None,
         loop=event_loop,
         _override_services={
+            "broadcast_service": broadcast_service,
             "game_service": game_service,
             "player_service": player_service,
             "geo_ip_service": geoip_service,
@@ -50,6 +52,8 @@ async def test_multiple_contexts(
             "party_service": party_service,
         }
     )
+    broadcast_service.server = instance
+
     await instance.listen(("127.0.0.1", 8111), QDataStreamProtocol)
     await instance.listen(("127.0.0.1", 8112), SimpleJsonProtocol)
 

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -609,13 +609,18 @@ async def test_ratings_initialized_based_on_global_persisted(
     )
     protos = [proto1, proto2, proto3, proto4]
     for proto in protos:
-        await read_until_command(proto, "game_info")
+        # Read the initial game list
+        await read_until_command(proto, "player_info")
+        # Read the broadcasted update
+        await read_until_command(proto, "player_info")
+
+    for proto in protos:
         await proto.send_message({
             "command": "game_matchmaking",
             "state": "start",
             "mod": "tmm2v2"
         })
-        await read_until_command(proto, "player_info")
+        await read_until_command(proto, "search_info")
 
     msg1, msg2, msg3, msg4 = await asyncio.gather(*[
         client_response(proto) for proto in protos

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -428,11 +428,12 @@ async def test_game_sim_ends_when_connections_ended_sim(game: Game, players):
 
 
 @fast_forward(90)
-async def test_game_marked_dirty_when_timed_out(game: Game):
+async def test_game_marked_dirty_when_timed_out(game: Game, game_service):
     game.state = GameState.INITIALIZING
     await game.timeout_game()
+
     assert game.state is GameState.ENDED
-    assert game in game.game_service.dirty_games
+    assert game in game_service.pop_dirty_games()
 
 
 async def test_clear_slot(

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -7,7 +7,8 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_initialization(game_service):
-    assert len(game_service.dirty_games) == 0
+    assert len(game_service._dirty_games) == 0
+    assert game_service.pop_dirty_games() == set()
 
 
 async def test_create_game(players, game_service):
@@ -21,7 +22,7 @@ async def test_create_game(players, game_service):
         password=None
     )
     assert game is not None
-    assert game in game_service.dirty_games
+    assert game in game_service.pop_dirty_games()
     assert isinstance(game, CustomGame)
 
     game_service.remove_game(game)
@@ -49,7 +50,7 @@ async def test_create_game_ladder1v1(players, game_service):
         name="Test Ladder",
     )
     assert game is not None
-    assert game in game_service.dirty_games
+    assert game in game_service.pop_dirty_games()
     assert isinstance(game, LadderGame)
     assert game.game_mode == "ladder1v1"
 
@@ -64,6 +65,6 @@ async def test_create_game_other_gamemode(players, game_service):
         password=None
     )
     assert game is not None
-    assert game in game_service.dirty_games
+    assert game in game_service.pop_dirty_games()
     assert isinstance(game, Game)
     assert game.game_mode == "labwars"

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -104,12 +104,12 @@ async def test_mark_dirty(player_factory, player_service):
 
     # Marking the same player as dirty multiple times should not matter
     player_service.mark_dirty(player)
-    assert player_service.dirty_players == {player}
+    assert player_service._dirty_players == {player}
     player_service.mark_dirty(player)
-    assert player_service.dirty_players == {player}
+    assert player_service._dirty_players == {player}
 
-    player_service.clear_dirty()
-    assert player_service.dirty_players == set()
+    assert player_service.pop_dirty_players() == {player}
+    assert player_service._dirty_players == set()
 
 
 async def test_update_data(player_service):


### PR DESCRIPTION
I refactored the broadcasting logic to its own service which now also posts the broadcast messages to rabbitmq. I stuck with posting them to the same exchange as the `gameResults` for now, but I'd be interested to hear other peoples opinions on whether that makes sense or it should get its own exchange. The 3 part routing key is a little weird since there will never be any success states other than "success" and the CRUD operation will always be "update" and there is no real clear way to specify that the message is a broadcast.

I also decided to aggregate all of the game info into a single message just like it is sent during login. Maybe we should take the opportunity to differentiate between `"game_info"` messages that represent a single game and `"game_info"` messages that have a `"games"` sub-list. Maybe call it `"game_list_info"`, or just get rid of the single game version entirely. I think getting rid of the single game version makes a lot of sense as it would maintain consistency with how the other broadcasted info messages look.

Closes #771