### PR TITLE
Issue/#769 nightly test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache hypothesis examples
+        uses: actions/cache@v2
+        with:
+          path: .hypothesis
+          key: .hypothesis
+
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
       - master
       - develop
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   FAF_DB_VERSION: v112
@@ -92,9 +94,16 @@ jobs:
           pip install pipenv
           pipenv sync --dev
 
-      - run: pipenv run tests --cov-report=xml -m ""
+      - name: Run tests
+        if: ${{ github.event_name != 'schedule' }}
+        run: pipenv run tests --cov-report=xml -m ""
+
+      - name: Run hypothesis tests with many examples
+        if: ${{ github.event_name == 'schedule' }}
+        run: pipenv run tests -m "hypothesis" --hypothesis-profile nightly
 
       - name: Report coverage
+        if: ${{ github.event_name != 'schedule' }}
         uses: codecov/codecov-action@v1
         with:
           files: coverage.xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from typing import Iterable
 from unittest import mock
 
 import asynctest
+import hypothesis
 import pytest
 from asynctest import CoroutineMock
 
@@ -42,6 +43,11 @@ from server.stats.game_stats_service import GameStatsService
 from tests.utils import MockDatabase
 
 logging.getLogger().setLevel(TRACE)
+hypothesis.settings.register_profile(
+    "nightly",
+    max_examples=10_000,
+    print_blob=True
+)
 
 
 def pytest_addoption(parser):

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -615,6 +615,7 @@ async def test_ratings_initialized_based_on_global_persisted(
             "state": "start",
             "mod": "tmm2v2"
         })
+        await read_until_command(proto, "player_info")
 
     msg1, msg2, msg3, msg4 = await asyncio.gather(*[
         client_response(proto) for proto in protos

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -238,7 +238,7 @@ async def test_start_game_with_teams(
         unique=True
     )
 )
-@settings(deadline=300)
+@settings(deadline=None)
 @autocontext("ladder_and_game_service_context", "monkeypatch_context")
 async def test_start_game_start_spots(
     ladder_and_game_service,


### PR DESCRIPTION
Run hypothesis tests with 10,000 examples once per day. Caches the hypothesis example database so that falsifying examples found on one test run will be tried on subsequent runs. 

This means the nightly test run should essentially be gathering examples of edge cases that will then be tried on normal PR's, making the normal PR runs more effective.

Closes #769 