### PR TITLE
Issue/#796 use kick to prevent client reconnect loop

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -617,7 +617,8 @@ class LobbyConnection:
                     old_player.lobby_connection.write_warning(
                         "You have been signed out because you signed in "
                         "elsewhere.",
-                        fatal=True
+                        fatal=True,
+                        style="kick"
                     )
 
         await self.player_service.fetch_player_data(self.player)
@@ -1181,13 +1182,18 @@ class LobbyConnection:
         if fatal:
             await self.abort(message)
 
-    def write_warning(self, message: str, fatal: bool = False):
+    def write_warning(
+        self,
+        message: str,
+        fatal: bool = False,
+        style: Optional[str] = None
+    ):
         """
         Like `send_warning`, but does not await the data to be sent.
         """
         self.write({
             "command": "notice",
-            "style": "info" if not fatal else "error",
+            "style": style or ("info" if not fatal else "error"),
             "text": message
         })
         if fatal:

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -221,7 +221,7 @@ async def test_server_double_login(lobby_server):
     msg = await read_until_command(proto, "notice")
     assert msg == {
         "command": "notice",
-        "style": "error",
+        "style": "kick",
         "text": "You have been signed out because you signed in elsewhere."
     }
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -211,7 +211,8 @@ async def test_double_login(lobbyconnection, mock_players, player_factory):
 
     old_player.lobby_connection.write_warning.assert_called_with(
         "You have been signed out because you signed in elsewhere.",
-        fatal=True
+        fatal=True,
+        style="kick"
     )
     # This should only be reset in abort, which is mocked for this test
     assert old_player.lobby_connection.player is not None


### PR DESCRIPTION
This way the client doesn't need to check the message text to determine whether or not it should try to reconnect.

Closes #796 