### PR TITLE
Add dummy implementation for client command `match_ready` (#607)

### DIFF
--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -991,6 +991,13 @@ class LobbyConnection:
         )
         await self.launch_game(game, is_host=True)
 
+    async def command_match_ready(self, message):
+        """
+        Replace with full implementation when implemented in client, see:
+        https://github.com/FAForever/downlords-faf-client/issues/1783
+        """
+        pass
+
     async def launch_game(
         self,
         game,

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -963,6 +963,7 @@ async def test_command_match_ready(lobbyconnection):
         "command": "match_ready"
     })
 
+    
 async def test_command_matchmaker_info(
     lobbyconnection,
     ladder_service,

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -957,7 +957,7 @@ async def test_command_game_matchmaking_not_party_owner(
 
     lobbyconnection.ladder_service.cancel_search.assert_called_once()
 
-async def test_command_match_ready(
+async def test_command_match_ready(lobbyconnection):
     await lobbyconnection.on_message_received({
         "command": "match_ready"
     })

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -957,6 +957,10 @@ async def test_command_game_matchmaking_not_party_owner(
 
     lobbyconnection.ladder_service.cancel_search.assert_called_once()
 
+async def test_command_match_ready(
+    await lobbyconnection.on_message_received({
+        "command": "match_ready"
+    })
 
 async def test_command_matchmaker_info(
     lobbyconnection,

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -957,6 +957,7 @@ async def test_command_game_matchmaking_not_party_owner(
 
     lobbyconnection.ladder_service.cancel_search.assert_called_once()
 
+    
 async def test_command_match_ready(lobbyconnection):
     await lobbyconnection.on_message_received({
         "command": "match_ready"


### PR DESCRIPTION
Moves #607 forward (see https://github.com/FAForever/downlords-faf-client/issues/1783#issuecomment-894844963).

Sadly untested because if currently don't have a local environment for running the python server, so i would be glad if somebody else could test that. Sorry.