### PR TITLE
Issue/#824 support for GameOptions in matchmaker queues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  FAF_DB_VERSION: v119
+  FAF_DB_VERSION: v121
   FLYWAY_VERSION: 7.5.4
 
 jobs:

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -291,6 +291,7 @@ matchmaker_queue = Table(
     Column("leaderboard_id",    Integer,        ForeignKey("leaderboard.id"),       nullable=False),
     Column("name_key",          String(255),    nullable=False),
     Column("team_size",         Integer,        nullable=False),
+    Column("params",            JSON),
     Column("enabled",           Boolean,        nullable=False),
     Column("create_time",   TIMESTAMP,      nullable=False),
     Column("update_time",   TIMESTAMP,      nullable=False)

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (
+    JSON,
     TIME,
     TIMESTAMP,
     Boolean,
@@ -261,7 +262,7 @@ map_pool_map_version = Table(
     Column("map_pool_id",    Integer,       ForeignKey("map_pool.id"),      nullable=False),
     Column("map_version_id", Integer,       ForeignKey("map_version.id")),
     Column("weight",         Integer,       nullable=False),
-    Column("map_params",     Text),
+    Column("map_params",     JSON),
     Column("create_time",    TIMESTAMP,     nullable=False),
     Column("update_time",    TIMESTAMP,     nullable=False)
 )

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -3,7 +3,6 @@ Manages interactions between players and matchmakers
 """
 
 import asyncio
-import json
 import random
 import re
 from collections import defaultdict
@@ -133,10 +132,12 @@ class LadderService(Service):
                 )
             elif row.map_params is not None:
                 try:
-                    params = json.loads(row.map_params)
+                    params = row.map_params
                     map_type = params["type"]
                     if map_type == "neroxis":
-                        map_list.append(NeroxisGeneratedMap.of(params, row.weight))
+                        map_list.append(
+                            NeroxisGeneratedMap.of(params, row.weight)
+                        )
                     else:
                         self._logger.warning(
                             "Unsupported map type %s in pool %s",

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -446,6 +446,10 @@ class LadderService(Service):
                 game.set_player_option(player.id, "Army", slot)
                 game.set_player_option(player.id, "Color", slot)
 
+            game_options = queue.get_game_options()
+            if game_options:
+                game.gameOptions.update(game_options)
+
             mapname = re.match("maps/(.+).zip", map_path).group(1)
             # FIXME: Database filenames contain the maps/ prefix and .zip suffix.
             # Really in the future, just send a better description
@@ -455,6 +459,7 @@ class LadderService(Service):
             options = GameLaunchOptions(
                 mapname=mapname,
                 expected_players=len(all_players),
+                game_options=game_options
             )
 
             def game_options(player: Player) -> GameLaunchOptions:

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -86,12 +86,7 @@ class MatchmakerQueue:
             return map_pool
 
     def get_game_options(self) -> Dict[str, Any]:
-        game_options = self.params.get("GameOptions")
-
-        if game_options is None:
-            return {}
-
-        return game_options
+        return self.params.get("GameOptions") or None
 
     def initialize(self):
         asyncio.create_task(self.queue_pop_timer())

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -49,6 +49,7 @@ class MatchmakerQueue:
         featured_mod: str,
         rating_type: str,
         team_size: int = 1,
+        params: Optional[Dict[str, Any]] = None,
         map_pools: Iterable[Tuple[MapPool, Optional[int], Optional[int]]] = (),
     ):
         self.game_service = game_service
@@ -57,6 +58,7 @@ class MatchmakerQueue:
         self.featured_mod = featured_mod
         self.rating_type = rating_type
         self.team_size = team_size
+        self.params = params or {}
         self.map_pools = {info[0].id: info for info in map_pools}
 
         self._queue: Dict[Search, None] = OrderedDict()
@@ -82,6 +84,14 @@ class MatchmakerQueue:
             if max_rating is not None and rating > max_rating:
                 continue
             return map_pool
+
+    def get_game_options(self) -> Dict[str, Any]:
+        game_options = self.params.get("GameOptions")
+
+        if game_options is None:
+            return {}
+
+        return game_options
 
     def initialize(self):
         asyncio.create_task(self.queue_pop_timer())

--- a/server/types.py
+++ b/server/types.py
@@ -4,7 +4,7 @@ General type definitions
 
 import base64
 import random
-from typing import NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 
 class Address(NamedTuple):
@@ -27,6 +27,7 @@ class GameLaunchOptions(NamedTuple):
     faction: Optional[int] = None
     expected_players: Optional[int] = None
     map_position: Optional[int] = None
+    game_options: Optional[Dict[str, Any]] = None
 
 
 class Map(NamedTuple):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,7 +358,8 @@ def queue_factory():
         name="Test Queue",
         mod="ladder1v1",
         team_size=1,
-        rating_type=RatingType.GLOBAL
+        rating_type=RatingType.GLOBAL,
+        **kwargs
     ):
         nonlocal queue_id
         queue_id += 1
@@ -370,6 +371,7 @@ def queue_factory():
             featured_mod=mod,
             rating_type=rating_type,
             team_size=team_size,
+            **kwargs
         )
     return make
 

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -280,11 +280,13 @@ insert into game_player_stats (gameId, playerId, AI, faction, color, team, place
   (41943, 51, 0, 0, 0, 2, 0, 1500, 500, NOW(), 1400),
   (41944, 51, 0, 0, 0, 2, 0, 1500, 500, NOW(), 1600);
 
-insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, enabled) values
-  (1, "ladder1v1", 6, 2, "matchmaker.ladder1v1", 1, true),
-  (2, "tmm2v2", 1, 3, "matchmaker.tmm2v2", 2, true),
-  (3, "disabled", 1, 1, "matchmaker.disabled", 4, false),
-  (4, "neroxis1v1", 1, 2, "matchmaker.neroxis", 1, true);
+insert into matchmaker_queue (id, technical_name, featured_mod_id, leaderboard_id, name_key, team_size, params, enabled) values
+  (1, "ladder1v1", 6, 2, "matchmaker.ladder1v1", 1, NULL, true),
+  (2, "tmm2v2", 1, 3, "matchmaker.tmm2v2", 2, NULL, true),
+  (3, "disabled", 1, 1, "matchmaker.disabled", 4, NULL, false),
+  (4, "neroxis1v1", 1, 2, "matchmaker.neroxis", 1, NULL, true),
+  (5, "gameoptions", 1, 1, "matchmaker.gameoptions", 3, '{"GameOptions":{"Share":"ShareUntilDeath","UnitCap":500}}', true),
+  (6, "gameoptions_malformed", 1, 1, "matchmaker.gameoptions_malformed", 3, '{"GameOptions"...', true);
 
 insert into matchmaker_queue_game (matchmaker_queue_id, game_stats_id) values
   (1, 1),
@@ -332,7 +334,9 @@ insert into matchmaker_queue_map_pool (matchmaker_queue_id, map_pool_id, min_rat
   (1, 2, 800, NULL),
   (1, 3, 1000, NULL),
   (2, 3, NULL, NULL),
-  (4, 4, NULL, NULL);
+  (4, 4, NULL, NULL),
+  (5, 1, NULL, NULL),
+  (6, 1, NULL, NULL);
 
 insert into friends_and_foes (user_id, subject_id, `status`) values
   (1, 400, 'FOE'),

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -262,13 +262,14 @@ async def jwks_server(jwk_kid):
 
 
 @pytest.fixture
-async def tmp_user(database):
+def tmp_user(database):
     user_ids = defaultdict(lambda: 1)
     password_plain = "foo"
     password = hashlib.sha256(password_plain.encode()).hexdigest()
 
     async def make_user(name="TempUser"):
         user_id = user_ids[name]
+        user_ids[name] += 1
         login_name = f"{name}{user_id}"
         async with database.acquire() as conn:
             await conn.execute(login.insert().values(
@@ -276,7 +277,6 @@ async def tmp_user(database):
                 email=f"{login_name}@example.com",
                 password=password,
             ))
-        user_ids[name] += 1
         return login_name, password_plain
 
     return make_user

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -45,14 +45,20 @@ async def test_game_launch_message(lobby_server):
 
 @fast_forward(70)
 async def test_game_launch_message_map_generator(lobby_server):
-    proto1, proto2 = await queue_players_for_matchmaking(lobby_server, queue_name="neroxis1v1")
+    proto1, proto2 = await queue_players_for_matchmaking(
+        lobby_server,
+        queue_name="neroxis1v1"
+    )
 
     msg1 = await read_until_command(proto1, "game_launch")
     await open_fa(proto1)
     msg2 = await read_until_command(proto2, "game_launch")
 
     assert msg1["mapname"] == msg2["mapname"]
-    assert re.match("neroxis_map_generator_0.0.0_[0-9a-z]{13}_aiea", msg1["mapname"])
+    assert re.match(
+        "neroxis_map_generator_0.0.0_[0-9a-z]{13}_aiea",
+        msg1["mapname"]
+    )
 
 
 @fast_forward(15)

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -409,6 +409,7 @@ async def test_command_matchmaker_info(lobby_server, mocker):
     await proto.send_message({"command": "matchmaker_info"})
     msg = await read_until_command(proto, "matchmaker_info")
     assert "queues" in msg
+    assert len(msg["queues"]) == 4
     for queue in msg["queues"]:
         assert "queue_name" in queue
         assert "team_size" in queue

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -52,7 +52,7 @@ async def test_load_from_database(ladder_service, queue_factory):
 
         queue = ladder_service.queues["ladder1v1"]
         assert queue.name == "ladder1v1"
-        assert queue.get_game_options() == {}
+        assert queue.get_game_options() is None
         assert len(queue.map_pools) == 3
         assert list(queue.map_pools[1][0].maps.values()) == [
             Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
@@ -152,6 +152,34 @@ async def test_start_game_1v1(
     assert isinstance(game, LadderGame)
     assert game.rating_type == queue.rating_type
     assert game.max_players == 2
+
+    LadderGame.wait_launched.assert_called_once()
+
+
+async def test_start_game_with_game_options(
+    ladder_service,
+    game_service,
+    monkeypatch,
+    player_factory
+):
+    queue = ladder_service.queues["gameoptions"]
+    p1 = player_factory("Dostya", player_id=1, lobby_connection_spec="auto")
+    p2 = player_factory("Rhiza", player_id=2, lobby_connection_spec="auto")
+
+    monkeypatch.setattr(LadderGame, "wait_hosted", CoroutineMock())
+    monkeypatch.setattr(LadderGame, "wait_launched", CoroutineMock())
+    monkeypatch.setattr(LadderGame, "timeout_game", CoroutineMock())
+
+    # We're cheating a little bit here for simplicity of the test. The queue
+    # is actually set up to be 3v3 but `start_game` doesn't care.
+    await ladder_service.start_game([p1], [p2], queue)
+
+    game = game_service[game_service.game_id_counter]
+
+    assert game.rating_type == queue.rating_type
+    assert game.max_players == 2
+    assert game.gameOptions["Share"] == "ShareUntilDeath"
+    assert game.gameOptions["UnitCap"] == 500
 
     LadderGame.wait_launched.assert_called_once()
 

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -48,10 +48,11 @@ async def test_load_from_database(ladder_service, queue_factory):
     for _ in range(3):
         await ladder_service.update_data()
 
-        assert len(ladder_service.queues) == 3
+        assert len(ladder_service.queues) == 4
 
         queue = ladder_service.queues["ladder1v1"]
         assert queue.name == "ladder1v1"
+        assert queue.get_game_options() == {}
         assert len(queue.map_pools) == 3
         assert list(queue.map_pools[1][0].maps.values()) == [
             Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
@@ -82,6 +83,12 @@ async def test_load_from_database(ladder_service, queue_factory):
                 "type": "neroxis"
             }),
         ]
+
+        queue = ladder_service.queues["gameoptions"]
+        assert queue.get_game_options() == {
+            "Share": "ShareUntilDeath",
+            "UnitCap": 500
+        }
 
 
 @fast_forward(5)

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -44,6 +44,20 @@ def matchmaker_players_all_match(player_factory):
            player_factory("Rhiza", player_id=5, ladder_rating=(1500, 50))
 
 
+def test_get_game_options_empty(queue_factory):
+    queue1 = queue_factory(params={})
+    queue2 = queue_factory(params={"GameOptions": {}})
+
+    assert queue1.get_game_options() is None
+    assert queue2.get_game_options() is None
+
+
+def test_get_game_options(queue_factory):
+    queue = queue_factory(params={"GameOptions": {"Share": "ShareUntilDeath"}})
+
+    assert queue.get_game_options() == {"Share": "ShareUntilDeath"}
+
+
 def test_newbie_detection(matchmaker_players):
     pro, joe, _, _, _, newbie = matchmaker_players
     pro_search = Search([pro])


### PR DESCRIPTION
Loads additional params from the database and parses out game options to send in the game_launch message. My goal is for the `params` column to closely resemble the `gameInfo` table in the lua code. So something like this:

```json
{
    "GameOptions": {
        "FogOfWar": "explored",
        "UnitCap": 1000,
        "Share": "FullShare",
    },
    "GameMods": {}
}
```

But it could always be expanded in the future.

Requires https://github.com/FAForever/db/pull/285
Closes #824 