### PR TITLE
Fix game quality calculations

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -90,11 +90,11 @@ class ConfigurationStore:
         self.MAXIMUM_RATING_IMBALANCE = 400
         # stdev of the ratings of all participating players
         self.MAXIMUM_RATING_DEVIATION = 750
-        # Quality bonus for each failed matching attempt per player
-        self.TIME_BONUS = 0.01
-        self.MAXIMUM_TIME_BONUS = 0.2
-        self.NEWBIE_TIME_BONUS = 0.1
-        self.MAXIMUM_NEWBIE_TIME_BONUS = 0.4
+        # Quality bonus for each failed matching attempt per full team
+        self.TIME_BONUS = 0.02
+        self.MAXIMUM_TIME_BONUS = 0.4
+        self.NEWBIE_TIME_BONUS = 0.2
+        self.MAXIMUM_NEWBIE_TIME_BONUS = 0.8
 
         self.TWILIO_ACCOUNT_SID = ""
         self.TWILIO_TOKEN = ""

--- a/server/config.py
+++ b/server/config.py
@@ -89,7 +89,7 @@ class ConfigurationStore:
         # Difference of cumulated rating of the teams
         self.MAXIMUM_RATING_IMBALANCE = 500
         # stdev of the ratings of all participating players
-        self.MAXIMUM_RATING_DEVIATION = 900
+        self.MAXIMUM_RATING_DEVIATION = 750
         # Quality bonus for each failed matching attempt per full team
         self.TIME_BONUS = 0.02
         self.MAXIMUM_TIME_BONUS = 0.4

--- a/server/config.py
+++ b/server/config.py
@@ -87,14 +87,14 @@ class ConfigurationStore:
         # Values for the custom (i.e. not trueskill) game quality metric used by the matchmaker
         self.MINIMUM_GAME_QUALITY = 0.4
         # Difference of cumulated rating of the teams
-        self.MAXIMUM_RATING_IMBALANCE = 400
+        self.MAXIMUM_RATING_IMBALANCE = 500
         # stdev of the ratings of all participating players
-        self.MAXIMUM_RATING_DEVIATION = 750
+        self.MAXIMUM_RATING_DEVIATION = 900
         # Quality bonus for each failed matching attempt per full team
         self.TIME_BONUS = 0.02
         self.MAXIMUM_TIME_BONUS = 0.4
         self.NEWBIE_TIME_BONUS = 0.2
-        self.MAXIMUM_NEWBIE_TIME_BONUS = 0.8
+        self.MAXIMUM_NEWBIE_TIME_BONUS = 1.6
 
         self.TWILIO_ACCOUNT_SID = ""
         self.TWILIO_TOKEN = ""

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -279,11 +279,14 @@ class TeamMatchMaker(Matchmaker):
                 newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS)
 
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)
-        fairness = max((config.MAXIMUM_RATING_IMBALANCE - rating_disparity) / config.MAXIMUM_RATING_IMBALANCE, 0)
+        fairness = 1 - (rating_disparity / config.MAXIMUM_RATING_IMBALANCE)
         deviation = statistics.pstdev(ratings)
-        uniformity = max((config.MAXIMUM_RATING_DEVIATION - deviation) / config.MAXIMUM_RATING_DEVIATION, 0)
+        uniformity = 1 - (deviation / config.MAXIMUM_RATING_DEVIATION)
 
-        quality = fairness * uniformity + newbie_bonus + time_bonus
+        quality = fairness * uniformity
+        if fairness < 0 and uniformity < 0:
+            quality *= -1
+        quality += newbie_bonus + time_bonus
         self._logger.debug(
             "bonuses: %s rating disparity: %s -> fairness: %f deviation: %f -> uniformity: %f -> game quality: %f",
             newbie_bonus + time_bonus, rating_disparity, fairness, deviation, uniformity, quality)

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -276,8 +276,9 @@ class TeamMatchMaker(Matchmaker):
                 # Time bonus accumulation for a game should not depend on team size or whether the participants are premade or not.
                 search_time_bonus = search.failed_matching_attempts * config.TIME_BONUS * len(search.players) / team_size
                 time_bonus += min(search_time_bonus, config.MAXIMUM_TIME_BONUS * len(search.players) / team_size)
-                search_newbie_bonus = search.failed_matching_attempts * config.NEWBIE_TIME_BONUS * search.num_newbies() / team_size
-                newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS * search.num_newbies() / team_size)
+                num_newbies = search.num_newbies()
+                search_newbie_bonus = search.failed_matching_attempts * config.NEWBIE_TIME_BONUS * num_newbies / team_size
+                newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS * num_newbies / team_size)
 
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)
         fairness = 1 - (rating_disparity / config.MAXIMUM_RATING_IMBALANCE)

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -71,6 +71,9 @@ class Search:
 
         return False
 
+    def num_newbies(self) -> int:
+        return sum(self.is_newbie(player) for player in self.players)
+
     def has_top_player(self) -> bool:
         max_rating = max(map(lambda rating_tuple: rating_tuple[0], self.ratings))
         return max_rating >= config.TOP_PLAYER_MIN_RATING

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -216,7 +216,7 @@ def test_ignore_impossible_team_splits(player_factory):
 def test_game_quality(team_a, team_b):
     game = TeamMatchMaker().assign_game_quality((team_a, team_b))
 
-    assert 0.0 <= game.quality <= 1.0
+    assert game.quality <= 1.0
 
 
 @given(player=st_players())
@@ -235,7 +235,7 @@ def test_low_game_quality_for_high_rating_disparity(player_factory):
     team_b = CombinedSearch(*[s[4], s[5], s[6], s[7]])
     game = TeamMatchMaker().assign_game_quality((team_a, team_b))
 
-    assert game.quality == 0.0
+    assert game.quality < 0.0
 
 
 def test_low_game_quality_for_unfair_teams(player_factory):
@@ -244,7 +244,7 @@ def test_low_game_quality_for_unfair_teams(player_factory):
     team_b = CombinedSearch(*[s[4], s[5], s[6], s[7]])
     game = TeamMatchMaker().assign_game_quality((team_a, team_b))
 
-    assert game.quality == 0.0
+    assert game.quality < 0.0
 
 
 @given(st_searches_list(max_players=1, min_size=6, max_size=6))

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -281,9 +281,13 @@ def test_game_quality_max_time_bonus(s):
 
     num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
-    # player number / team size * time bonus
-    assert quality_before + 6 / 3 * config.MAXIMUM_TIME_BONUS + num_newbies / 3 * config.MAXIMUM_NEWBIE_TIME_BONUS \
-           == pytest.approx(quality_after)
+    assert (
+            quality_before
+            # player number / team size * time bonus
+            + 6 / 3 * config.MAXIMUM_TIME_BONUS
+            + num_newbies / 3 * config.MAXIMUM_NEWBIE_TIME_BONUS
+            == pytest.approx(quality_after)
+    )
 
 
 @pytest.mark.slow

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -261,9 +261,13 @@ def test_game_quality_time_bonus(s):
 
     num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
-    # player number / team size * time bonus
-    assert quality_before + 6 / 3 * config.TIME_BONUS + num_newbies / 3 * config.NEWBIE_TIME_BONUS \
-           == pytest.approx(quality_after)
+    assert (
+        quality_before
+        # player number / team size * time bonus
+        + 6 / 3 * config.TIME_BONUS
+        + num_newbies / 3 * config.NEWBIE_TIME_BONUS
+        == pytest.approx(quality_after)
+    )
 
 
 @given(st_searches_list(max_players=1, min_size=6, max_size=6))
@@ -282,11 +286,11 @@ def test_game_quality_max_time_bonus(s):
     num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
     assert (
-            quality_before
-            # player number / team size * time bonus
-            + 6 / 3 * config.MAXIMUM_TIME_BONUS
-            + num_newbies / 3 * config.MAXIMUM_NEWBIE_TIME_BONUS
-            == pytest.approx(quality_after)
+        quality_before
+        # player number / team size * time bonus
+        + 6 / 3 * config.MAXIMUM_TIME_BONUS
+        + num_newbies / 3 * config.MAXIMUM_NEWBIE_TIME_BONUS
+        == pytest.approx(quality_after)
     )
 
 

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -113,7 +113,7 @@ def test_team_matchmaker_algorithm_2(player_factory):
 
 
 @pytest.mark.slow
-@settings(suppress_health_check=[HealthCheck.filter_too_much])
+@settings(suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow])
 @given(st_searches_list_with_player_size(min_size=2, max_players=4, max_size=8))
 def test_make_even_teams(searches_with_player_size):
     searches = searches_with_player_size[0]

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -86,7 +86,7 @@ def test_team_matchmaker_algorithm(player_factory):
     assert set(matches[1][1].get_original_searches()) == {c2, s[0], s[3]}
     assert set(unmatched) == {s[7]}
     for match in matches:
-        assert matchmaker.assign_game_quality(match).quality > config.MINIMUM_GAME_QUALITY
+        assert matchmaker.assign_game_quality(match, 4).quality > config.MINIMUM_GAME_QUALITY
 
 
 def test_team_matchmaker_algorithm_2(player_factory):
@@ -109,7 +109,7 @@ def test_team_matchmaker_algorithm_2(player_factory):
     assert set(matches[0][1].get_original_searches()) == {c2, c3}
     assert set(unmatched) == {s[0], s[1], s[2], s[3], s[5], s[6], s[7], c1}
     for match in matches:
-        assert matchmaker.assign_game_quality(match).quality > config.MINIMUM_GAME_QUALITY
+        assert matchmaker.assign_game_quality(match, 4).quality > config.MINIMUM_GAME_QUALITY
 
 
 @pytest.mark.slow
@@ -214,7 +214,7 @@ def test_ignore_impossible_team_splits(player_factory):
 
 @given(team_a=st_searches(4), team_b=st_searches(4))
 def test_game_quality(team_a, team_b):
-    game = TeamMatchMaker().assign_game_quality((team_a, team_b))
+    game = TeamMatchMaker().assign_game_quality((team_a, team_b), 4)
 
     assert game.quality <= 1.0
 
@@ -224,7 +224,7 @@ def test_maximum_game_quality_for_even_teams(player):
     search = Search([player])
     team_a = CombinedSearch(*[search] * 4)
     team_b = CombinedSearch(*[search] * 4)
-    game = TeamMatchMaker().assign_game_quality((team_a, team_b))
+    game = TeamMatchMaker().assign_game_quality((team_a, team_b), 4)
 
     assert game.quality == 1.0
 
@@ -233,7 +233,7 @@ def test_low_game_quality_for_high_rating_disparity(player_factory):
     s = make_searches([100, 100, 4000, 4000, 4000, 4000, 100, 100], player_factory)
     team_a = CombinedSearch(*[s[0], s[1], s[2], s[3]])
     team_b = CombinedSearch(*[s[4], s[5], s[6], s[7]])
-    game = TeamMatchMaker().assign_game_quality((team_a, team_b))
+    game = TeamMatchMaker().assign_game_quality((team_a, team_b), 4)
 
     assert game.quality < 0.0
 
@@ -242,7 +242,7 @@ def test_low_game_quality_for_unfair_teams(player_factory):
     s = make_searches([100, 100, 100, 100, 4000, 4000, 4000, 4000], player_factory)
     team_a = CombinedSearch(*[s[0], s[1], s[2], s[3]])
     team_b = CombinedSearch(*[s[4], s[5], s[6], s[7]])
-    game = TeamMatchMaker().assign_game_quality((team_a, team_b))
+    game = TeamMatchMaker().assign_game_quality((team_a, team_b), 4)
 
     assert game.quality < 0.0
 
@@ -253,16 +253,37 @@ def test_game_quality_time_bonus(s):
     team_a = CombinedSearch(*[s.pop(), s.pop(), s.pop()])
     c1 = CombinedSearch(*[s.pop(), s.pop()])
     team_b = CombinedSearch(*[c1, s.pop()])
-    quality_before = matchmaker.assign_game_quality((team_a, team_b)).quality
+    quality_before = matchmaker.assign_game_quality((team_a, team_b), 3).quality
 
     team_a.register_failed_matching_attempt()
     team_b.register_failed_matching_attempt()
-    quality_after = matchmaker.assign_game_quality((team_a, team_b)).quality
+    quality_after = matchmaker.assign_game_quality((team_a, team_b), 3).quality
 
-    num_newbies = sum(search.has_newbie() for search in team_a.get_original_searches())
-    num_newbies += sum(search.has_newbie() for search in team_b.get_original_searches())
+    num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
-    assert quality_before + 6 * config.TIME_BONUS + num_newbies * config.NEWBIE_TIME_BONUS == pytest.approx(quality_after)
+    # player number / team size * time bonus
+    assert quality_before + 6 / 3 * config.TIME_BONUS + num_newbies / 3 * config.NEWBIE_TIME_BONUS \
+           == pytest.approx(quality_after)
+
+
+@given(st_searches_list(max_players=1, min_size=6, max_size=6))
+def test_game_quality_max_time_bonus(s):
+    matchmaker = TeamMatchMaker()
+    team_a = CombinedSearch(*[s.pop(), s.pop(), s.pop()])
+    c1 = CombinedSearch(*[s.pop(), s.pop()])
+    team_b = CombinedSearch(*[c1, s.pop()])
+    quality_before = matchmaker.assign_game_quality((team_a, team_b), 3).quality
+
+    for _ in range(30):
+        team_a.register_failed_matching_attempt()
+        team_b.register_failed_matching_attempt()
+    quality_after = matchmaker.assign_game_quality((team_a, team_b), 3).quality
+
+    num_newbies = team_a.num_newbies() + team_b.num_newbies()
+
+    # player number / team size * time bonus
+    assert quality_before + 6 / 3 * config.MAXIMUM_TIME_BONUS + num_newbies / 3 * config.MAXIMUM_NEWBIE_TIME_BONUS \
+           == pytest.approx(quality_after)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Normalizes the time bonus accumulation. So now a full game will accumulate the same time boni regardless of team size or premade parties. This increases mainly the 4v4 game quality, because it is not so dominated anymore by the time boni.
Also allows the game quality to be negative. This discourages really bad matches.