### PR TITLE
Issue/#773 refactor database wrapper to use sqlalchemy engine instead of aiomysql 

### DIFF
--- a/server.py
+++ b/server.py
@@ -54,13 +54,12 @@ async def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
-    database = server.db.FAFDatabase(loop)
+    database = server.db.FAFDatabase()
     await database.connect(
         host=config.DB_SERVER,
         port=int(config.DB_PORT),
         user=config.DB_LOGIN,
         password=config.DB_PASSWORD,
-        maxsize=10,
         db=config.DB_NAME,
     )
 

--- a/server.py
+++ b/server.py
@@ -54,13 +54,12 @@ async def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
-    database = server.db.FAFDatabase()
-    await database.connect(
+    database = server.db.FAFDatabase(
         host=config.DB_SERVER,
         port=int(config.DB_PORT),
         user=config.DB_LOGIN,
         password=config.DB_PASSWORD,
-        db=config.DB_NAME,
+        db=config.DB_NAME
     )
 
     # Set up services

--- a/server/db/__init__.py
+++ b/server/db/__init__.py
@@ -4,7 +4,6 @@ Database interaction
 
 import asyncio
 import logging
-from typing import Optional
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
@@ -15,22 +14,17 @@ from sqlalchemy.util import EMPTY_DICT
 logger = logging.getLogger(__name__)
 
 
-class FAFDatabase:
-    def __init__(self):
-        self.engine: Optional[AsyncEngine] = None
 
-    async def connect(
+class FAFDatabase:
+    def __init__(
         self,
-        host="localhost",
-        port=3306,
-        user="root",
-        password="",
-        db="faf_test",
+        host: str = "localhost",
+        port: int = 3306,
+        user: str = "root",
+        password: str = "",
+        db: str = "faf_test",
         **kwargs
     ):
-        if self.engine is not None:
-            raise ValueError("DB is already connected!")
-
         kwargs["future"] = True
         sync_engine = create_engine(
             f"mysql+aiomysql://{user}:{password}@{host}:{port}/{db}",
@@ -40,13 +34,10 @@ class FAFDatabase:
         self.engine = AsyncEngine(sync_engine)
 
     def acquire(self):
-        assert self.engine is not None, "must call `connect` before `acquire`!"
         return self.engine.begin()
 
     async def close(self):
-        assert self.engine is not None, "must call `connect` before `close`!"
         await self.engine.dispose()
-        self.engine = None
 
 
 class AsyncEngine(_AsyncEngine):

--- a/server/db/__init__.py
+++ b/server/db/__init__.py
@@ -4,17 +4,20 @@ Database interaction
 
 import asyncio
 import logging
+from typing import Optional
 
-from aiomysql.sa import create_engine
-from pymysql.err import OperationalError
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncConnection as _AsyncConnection
+from sqlalchemy.ext.asyncio import AsyncEngine as _AsyncEngine
+from sqlalchemy.util import EMPTY_DICT
 
 logger = logging.getLogger(__name__)
 
 
 class FAFDatabase:
-    def __init__(self, loop):
-        self._loop = loop
-        self.engine = None
+    def __init__(self):
+        self.engine: Optional[AsyncEngine] = None
 
     async def connect(
         self,
@@ -23,53 +26,110 @@ class FAFDatabase:
         user="root",
         password="",
         db="faf_test",
-        minsize=1,
-        maxsize=1
+        **kwargs
     ):
         if self.engine is not None:
             raise ValueError("DB is already connected!")
-        self.engine = await create_engine(
-            host=host,
-            port=port,
-            user=user,
-            password=password,
-            db=db,
-            autocommit=True,
-            loop=self._loop,
-            minsize=minsize,
-            maxsize=maxsize,
+
+        kwargs["future"] = True
+        sync_engine = create_engine(
+            f"mysql+aiomysql://{user}:{password}@{host}:{port}/{db}",
+            **kwargs
         )
 
+        self.engine = AsyncEngine(sync_engine)
+
     def acquire(self):
-        return self.engine.acquire()
+        assert self.engine is not None, "must call `connect` before `acquire`!"
+        return self.engine.begin()
 
     async def close(self):
-        if self.engine is None:
-            return
-
-        self.engine.close()
-        await self.engine.wait_closed()
+        assert self.engine is not None, "must call `connect` before `close`!"
+        await self.engine.dispose()
         self.engine = None
 
 
-async def deadlock_retry_execute(conn, *args, max_attempts=3):
-    for attempt in range(max_attempts - 1):
-        try:
-            return await conn.execute(*args)
-        except OperationalError as e:
-            error_text = str(e)
-            if any(msg in error_text for msg in (
-                "Deadlock found",
-                "Lock wait timeout exceeded"
-            )):
-                logger.warning(
-                    "Encountered deadlock during SQL execution. Attempts: %d",
-                    attempt + 1
-                )
-                # Exponential backoff
-                await asyncio.sleep(0.3 * 2 ** attempt)
-            else:
-                raise
+class AsyncEngine(_AsyncEngine):
+    """
+    For overriding the connection class used to execute statements.
 
-    # On the final attempt we don't do any error handling
-    return await conn.execute(*args)
+    This could also be done by changing engine._connection_cls, however this
+    is undocumented and probably more fragile so we subclass instead.
+    """
+
+    def connect(self):
+        return AsyncConnection(self)
+
+
+class AsyncConnection(_AsyncConnection):
+    async def execute(
+        self,
+        statement,
+        parameters=None,
+        execution_options=EMPTY_DICT,
+    ):
+        """
+        Wrap strings in the text type automatically
+        """
+        if isinstance(statement, str):
+            statement = text(statement)
+
+        return await super().execute(
+            statement,
+            parameters=parameters,
+            execution_options=execution_options
+        )
+
+    async def stream(
+        self,
+        statement,
+        parameters=None,
+        execution_options=EMPTY_DICT,
+    ):
+        """
+        Wrap strings in the text type automatically
+        """
+        if isinstance(statement, str):
+            statement = text(statement)
+
+        return await super().stream(
+            statement,
+            parameters=parameters,
+            execution_options=execution_options
+        )
+
+    async def deadlock_retry_execute(
+        self,
+        statement,
+        parameters=None,
+        execution_options=EMPTY_DICT,
+        max_attempts=3
+    ):
+        for attempt in range(max_attempts - 1):
+            try:
+                return await self.execute(
+                    statement,
+                    parameters=parameters,
+                    execution_options=execution_options
+                )
+            except OperationalError as e:
+                error_text = str(e)
+                if any(msg in error_text for msg in (
+                    "Deadlock found",
+                    "Lock wait timeout exceeded"
+                )):
+                    logger.warning(
+                        "Encountered deadlock during SQL execution. Attempts: %d",
+                        attempt + 1
+                    )
+                    # Exponential backoff
+                    await asyncio.sleep(0.3 * 2 ** attempt)
+                else:
+                    raise
+
+        # On the final attempt we don't do any error handling
+        return await self.execute(
+            statement,
+            parameters=parameters,
+            execution_options=execution_options
+        )

--- a/server/db/__init__.py
+++ b/server/db/__init__.py
@@ -72,12 +72,14 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
+        **kwargs
     ):
         with stat_db_errors():
             return await self._execute(
                 statement,
                 parameters=parameters,
-                execution_options=execution_options
+                execution_options=execution_options,
+                **kwargs
             )
 
     async def _execute(
@@ -85,12 +87,17 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
+        **kwargs
     ):
         """
-        Wrap strings in the text type automatically
+        Wrap strings in the text type automatically and allows bindparams to be
+        passed via kwargs.
         """
         if isinstance(statement, str):
             statement = text(statement)
+
+        if kwargs and parameters is None:
+            parameters = kwargs
 
         return await super().execute(
             statement,
@@ -103,12 +110,14 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
+        **kwargs
     ):
         with stat_db_errors():
             return await self._stream(
                 statement,
                 parameters=parameters,
-                execution_options=execution_options
+                execution_options=execution_options,
+                **kwargs
             )
 
     async def _stream(
@@ -116,12 +125,17 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
+        **kwargs
     ):
         """
-        Wrap strings in the text type automatically
+        Wrap strings in the text type automatically and allows bindparams to be
+        passed via kwargs.
         """
         if isinstance(statement, str):
             statement = text(statement)
+
+        if kwargs and parameters is None:
+            parameters = kwargs
 
         return await super().stream(
             statement,
@@ -134,14 +148,16 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
-        max_attempts=3
+        max_attempts=3,
+        **kwargs
     ):
         with stat_db_errors():
             return await self._deadlock_retry_execute(
                 statement,
                 parameters=parameters,
                 execution_options=execution_options,
-                max_attempts=max_attempts
+                max_attempts=max_attempts,
+                **kwargs
             )
 
     async def _deadlock_retry_execute(
@@ -149,14 +165,16 @@ class AsyncConnection(_AsyncConnection):
         statement,
         parameters=None,
         execution_options=EMPTY_DICT,
-        max_attempts=3
+        max_attempts=3,
+        **kwargs
     ):
         for attempt in range(max_attempts - 1):
             try:
                 return await self._execute(
                     statement,
                     parameters=parameters,
-                    execution_options=execution_options
+                    execution_options=execution_options,
+                    **kwargs
                 )
             except OperationalError as e:
                 error_text = str(e)
@@ -177,5 +195,6 @@ class AsyncConnection(_AsyncConnection):
         return await self._execute(
             statement,
             parameters=parameters,
-            execution_options=execution_options
+            execution_options=execution_options,
+            **kwargs
         )

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -1,5 +1,4 @@
 from sqlalchemy import (
-    JSON,
     TIME,
     TIMESTAMP,
     Boolean,
@@ -15,8 +14,7 @@ from sqlalchemy import (
     Text
 )
 
-from ..games.game_results import GameOutcome
-from ..games.typedefs import Victory
+from .typedefs import GameOutcome, Victory
 
 metadata = MetaData()
 
@@ -265,7 +263,7 @@ map_pool_map_version = Table(
     Column("map_pool_id",    Integer,       ForeignKey("map_pool.id"),      nullable=False),
     Column("map_version_id", Integer,       ForeignKey("map_version.id")),
     Column("weight",         Integer,       nullable=False),
-    Column("map_params",     JSON),
+    Column("map_params",     Text),
     Column("create_time",    TIMESTAMP,     nullable=False),
     Column("update_time",    TIMESTAMP,     nullable=False)
 )
@@ -294,7 +292,7 @@ matchmaker_queue = Table(
     Column("leaderboard_id",    Integer,        ForeignKey("leaderboard.id"),       nullable=False),
     Column("name_key",          String(255),    nullable=False),
     Column("team_size",         Integer,        nullable=False),
-    Column("params",            JSON),
+    Column("params",            Text),
     Column("enabled",           Boolean,        nullable=False),
     Column("create_time",   TIMESTAMP,      nullable=False),
     Column("update_time",   TIMESTAMP,      nullable=False)

--- a/server/db/typedefs.py
+++ b/server/db/typedefs.py
@@ -1,0 +1,20 @@
+# To prevent import issues, enums used by models should be defined in the db
+# package
+
+from enum import Enum, unique
+
+
+@unique
+class Victory(Enum):
+    DEMORALIZATION = 0
+    DOMINATION = 1
+    ERADICATION = 2
+    SANDBOX = 3
+
+
+@unique
+class GameOutcome(Enum):
+    VICTORY = "VICTORY"
+    DEFEAT = "DEFEAT"
+    DRAW = "DRAW"
+    UNKNOWN = "UNKNOWN"

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -44,8 +44,8 @@ class GameService(Service):
         message_queue_service: MessageQueueService
     ):
         self._db = database
-        self._dirty_games = set()
-        self._dirty_queues = set()
+        self._dirty_games: Set[Game] = set()
+        self._dirty_queues: Set[MatchmakerQueue] = set()
         self.player_service = player_service
         self.game_stats_service = game_stats_service
         self._rating_service = rating_service
@@ -55,8 +55,8 @@ class GameService(Service):
         # Populated below in really_update_static_ish_data.
         self.featured_mods = dict()
 
-        # A set of mod ids that are allowed in ranked games (everyone loves caching)
-        self.ranked_mods = set()
+        # A set of mod ids that are allowed in ranked games
+        self.ranked_mods: Set[str] = set()
 
         # The set of active games
         self._games: Dict[int, Game] = dict()
@@ -111,7 +111,7 @@ class GameService(Service):
             result = await conn.execute("SELECT uid FROM table_mod WHERE ranked = 1")
 
             # Turn resultset into a list of uids
-            self.ranked_mods = set(map(lambda x: x[0], result))
+            self.ranked_mods = {row.uid for row in result}
 
     def mark_dirty(self, obj: Union[Game, MatchmakerQueue]):
         if isinstance(obj, Game):

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -264,7 +264,7 @@ class GameConnection(GpgNetServerProtocol):
             async with self._db.acquire() as conn:
                 rows = await conn.execute(
                     "SELECT `uid`, `name` from `table_mod` WHERE `uid` in :ids",
-                    {"ids": tuple(uids)}
+                    ids=tuple(uids)
                 )
                 for row in rows:
                     self.game.mods[row.uid] = row.name
@@ -500,7 +500,7 @@ class GameConnection(GpgNetServerProtocol):
                         "v.mod_id = s.mod_id "
                         "SET s.times_played = s.times_played + 1 "
                         "WHERE v.uid in :ids",
-                        {"ids": tuple(uids)}
+                        ids=tuple(uids)
                     )
         elif state == "Ended":
             await self.on_connection_lost()

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -724,7 +724,8 @@ class Game():
             # so, and grab the map id at the same time.
             result = await conn.execute(
                 "SELECT id, ranked FROM map_version "
-                "WHERE lower(filename) = lower(:f)", {"f": self.map_file_path}
+                "WHERE lower(filename) = lower(:filename)",
+                filename=self.map_file_path
             )
             row = result.fetchone()
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -5,12 +5,11 @@ import time
 from collections import defaultdict
 from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
 
-import pymysql
 from sqlalchemy import and_, bindparam
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.sql.functions import now as sql_now
 
 from server.config import FFA_TEAM
-from server.db import deadlock_retry_execute
 from server.db.models import (
     game_player_stats,
     game_stats,
@@ -567,7 +566,7 @@ class Game():
                 scoreTime=sql_now(),
                 result=bindparam("result"),
             )
-            await deadlock_retry_execute(conn, update_statement, rows)
+            await conn.deadlock_retry_execute(update_statement, rows)
 
     def get_basic_info(self) -> BasicGameInfo:
         return BasicGameInfo(
@@ -725,14 +724,14 @@ class Game():
             # so, and grab the map id at the same time.
             result = await conn.execute(
                 "SELECT id, ranked FROM map_version "
-                "WHERE lower(filename) = lower(%s)", (self.map_file_path, )
+                "WHERE lower(filename) = lower(:f)", {"f": self.map_file_path}
             )
-            row = await result.fetchone()
+            row = result.fetchone()
 
         is_generated = (self.map_file_path and "neroxis_map_generator" in self.map_file_path)
 
         if row:
-            self.map_id = row["id"]
+            self.map_id = row.id
 
         if (
             self.validity is ValidityState.VALID
@@ -811,7 +810,7 @@ class Game():
         try:
             async with self._db.acquire() as conn:
                 await conn.execute(game_player_stats.insert().values(query_args))
-        except pymysql.MySQLError:
+        except DBAPIError:
             self._logger.exception(
                 "Failed to update game_player_stats. Query args %s:", query_args
             )

--- a/server/games/typedefs.py
+++ b/server/games/typedefs.py
@@ -1,6 +1,7 @@
 from enum import Enum, unique
 from typing import Any, Dict, List, NamedTuple, Optional, Set
 
+from server.db.typedefs import Victory
 from server.games.game_results import ArmyResult, GameOutcome
 from server.players import Player
 
@@ -25,14 +26,6 @@ class GameConnectionState(Enum):
 class InitMode(Enum):
     NORMAL_LOBBY = 0
     AUTO_LOBBY = 1
-
-
-@unique
-class Victory(Enum):
-    DEMORALIZATION = 0
-    DOMINATION = 1
-    ERADICATION = 2
-    SANDBOX = 3
 
 
 @unique
@@ -215,3 +208,19 @@ class FA(object):
 
     ENABLED = _FAEnabled()
     DISABLED = _FADisabled()
+
+
+__all__ = (
+    "BasicGameInfo",
+    "EndedGameInfo",
+    "FA",
+    "FeaturedModType",
+    "GameConnectionState",
+    "GameState",
+    "GameType",
+    "InitMode",
+    "TeamRatingSummary",
+    "ValidityState",
+    "Victory",
+    "VisibilityState",
+)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -211,7 +211,7 @@ class LobbyConnection:
         raise ClientError("FAF no longer supports direct registration. Please use the website to register.", recoverable=True)
 
     async def command_coop_list(self, message):
-        """ Request for coop map list"""
+        """Request for coop map list"""
         async with self._db.acquire() as conn:
             result = await conn.stream(select([coop_map]))
 
@@ -407,16 +407,25 @@ class LobbyConnection:
 
         now = datetime.utcnow()
         if ban_reason is not None and now < ban_expiry:
-            self._logger.debug("Rejected login from banned user: %s, %s, %s",
-                               player_id, username, self.session)
+            self._logger.debug(
+                "Rejected login from banned user: %s, %s, %s",
+                player_id, username, self.session
+            )
             raise BanError(ban_expiry, ban_reason)
 
         # New accounts are prevented from playing if they didn't link to steam
 
         if config.FORCE_STEAM_LINK and not steamid and create_time.timestamp() > config.FORCE_STEAM_LINK_AFTER_DATE:
-            self._logger.debug("Rejected login from new user: %s, %s, %s", player_id, username, self.session)
+            self._logger.debug(
+                "Rejected login from new user: %s, %s, %s",
+                player_id, username, self.session
+            )
             raise ClientError(
-                'Unfortunately, you must currently link your account to Steam in order to play Forged Alliance Forever. You can do so on <a href="{steamlink_url}">{steamlink_url}</a>.'.format(steamlink_url=config.WWW_URL + "/account/link"),
+                "Unfortunately, you must currently link your account to Steam "
+                "in order to play Forged Alliance Forever. You can do so on "
+                '<a href="{steamlink_url}">{steamlink_url}</a>.'.format(
+                    steamlink_url=config.WWW_URL + "/account/link"
+                ),
                 recoverable=False)
 
         return player_id, real_username, steamid
@@ -1253,6 +1262,8 @@ class LobbyConnection:
             ban_expiry = row.expires_at
             ban_reason = row.reason
             if now < ban_expiry:
-                self._logger.debug("Aborting connection of banned user: %s, %s, %s",
-                                   self.player.id, self.player.login, self.session)
+                self._logger.debug(
+                    "Aborting connection of banned user: %s, %s, %s",
+                    self.player.id, self.player.login, self.session
+                )
                 raise BanError(ban_expiry, ban_reason)

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -759,7 +759,7 @@ class LobbyConnection:
 
         if action == "list_avatar":
             async with self._db.acquire() as conn:
-                rows = await conn.execute(
+                result = await conn.execute(
                     select([
                         avatars_list.c.url,
                         avatars_list.c.tooltip
@@ -772,14 +772,11 @@ class LobbyConnection:
                     )
                 )
 
-                if not rows:
-                    return
-
                 await self.send({
                     "command": "avatar",
                     "avatarlist": [
                         {"url": row.url, "tooltip": row.tooltip}
-                        for row in rows
+                        for row in result
                     ]
                 })
 

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -711,8 +711,10 @@ class LobbyConnection:
 
         try:
             await conn.execute(
-                "UPDATE anope.anope_db_NickCore SET pass = :p WHERE display = :d",
-                {"p": irc_pass, "d": login}
+                "UPDATE anope.anope_db_NickCore "
+                "SET pass = :passwd WHERE display = :display",
+                passwd=irc_pass,
+                display=login
             )
         except (OperationalError, ProgrammingError):
             self._logger.error("Failure updating NickServ password for %s", login)
@@ -1080,7 +1082,8 @@ class LobbyConnection:
                 result = await conn.execute(
                     "SELECT uid, name, version, author, ui, date, downloads, "
                     "likes, played, description, filename, icon, likers FROM "
-                    "`table_mod` WHERE uid = :id LIMIT 1", {"id": uid}
+                    "`table_mod` WHERE uid = :uid LIMIT 1",
+                    uid=uid
                 )
 
                 row = result.fetchone()
@@ -1110,7 +1113,8 @@ class LobbyConnection:
                         "UPDATE mod_stats s "
                         "JOIN mod_version v ON v.mod_id = s.mod_id "
                         "SET s.likes = s.likes + 1, likers=:l WHERE v.uid=:id",
-                        {"l": json.dumps(likers), "id": uid}
+                        l=json.dumps(likers),
+                        id=uid
                     )
                     await self.send(out)
 

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -95,6 +95,12 @@ connection_on_message_received = Histogram(
     "Seconds spent in 'connection.on_message_received'",
 )
 
+db_exceptions = Counter(
+    "db_exceptions_total",
+    "Total number of database exceptions when executing queries",
+    ["class", "code"]
+)
+
 
 # =====
 # Games

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -105,7 +105,10 @@ class PlayerService(Service):
             result = await conn.execute(sql)
             row = result.fetchone()
             if not row:
-                self._logger.warning("Did not find data for player with id %i", player.id)
+                self._logger.warning(
+                    "Did not find data for player with id %i",
+                    player.id
+                )
                 return
 
             row = row._mapping

--- a/server/rating_service/rating_service.py
+++ b/server/rating_service/rating_service.py
@@ -326,7 +326,7 @@ class RatingService(Service):
             for player_id in new_ratings.keys()
         ]
 
-        for player_id, new_rating, old_rating in ratings:
+        for player_id, old_rating, new_rating in ratings:
             self._logger.debug(
                 "New %s rating for player with id %s: %s -> %s",
                 rating_type,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ async def test_data(request):
     await db.close()
 
 
-async def global_database(request):
+async def global_database(request) -> FAFDatabase:
     def opt(val):
         return request.config.getoption(val)
     host, user, pw, name, port = (
@@ -143,17 +143,14 @@ async def global_database(request):
         opt("--mysql_database"),
         opt("--mysql_port")
     )
-    db = FAFDatabase()
 
-    await db.connect(
+    return FAFDatabase(
         host=host,
         user=user,
-        password=pw or None,
+        password=pw or "",
         port=port,
         db=name
     )
-
-    return db
 
 
 @pytest.fixture(scope="session")
@@ -170,15 +167,14 @@ def database_context():
             opt("--mysql_database"),
             opt("--mysql_port")
         )
-        db = MockDatabase()
-
-        await db.connect(
+        db = MockDatabase(
             host=host,
             user=user,
-            password=pw or None,
+            password=pw or "",
             port=port,
             db=name
         )
+        await db.connect()
 
         yield db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ async def test_data(request):
     db = await global_database(request)
     with open("tests/data/test-data.sql") as f:
         async with db.acquire() as conn:
-            await conn.execute(f.read())
+            await conn.execute(f.read().replace(":", r"\:"))
 
     await db.close()
 
@@ -143,7 +143,7 @@ async def global_database(request):
         opt("--mysql_database"),
         opt("--mysql_port")
     )
-    db = FAFDatabase(asyncio.get_running_loop())
+    db = FAFDatabase()
 
     await db.connect(
         host=host,
@@ -170,7 +170,7 @@ def database_context():
             opt("--mysql_database"),
             opt("--mysql_port")
         )
-        db = MockDatabase(asyncio.get_running_loop())
+        db = MockDatabase()
 
         await db.connect(
             host=host,

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -19,6 +19,7 @@ DELETE FROM map_version_reviews_summary;
 DELETE FROM map_version;
 DELETE FROM `map`;
 DELETE FROM coop_map;
+DELETE FROM coop_leaderboard;
 DELETE FROM mod_version_review;
 DELETE FROM mod_version_reviews_summary;
 DELETE FROM mod_version;

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -325,6 +325,7 @@ insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_param
   (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
   (4, NULL, 1, '{"type": "neroxis", "size": 768, "spawns": 2, "version": "0.0.0"}'),
   -- Bad Generated Map Parameters should not be included in pool
+  (4, NULL, 1, '{"type": "neroxis"...'),
   (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
   (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),
   (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 3, "version": "0.0.0"}'),

--- a/tests/integration_tests/test_coop.py
+++ b/tests/integration_tests/test_coop.py
@@ -94,7 +94,7 @@ async def test_single_player_game_recorded(lobby_server, database):
                 coop_leaderboard.c.gameuid == game_id
             )
         )
-        row = await result.fetchone()
+        row = result.fetchone()
         assert row is not None
         assert row.secondary == 0
         assert row.time == datetime.time(0, 11, 50)

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -602,7 +602,7 @@ async def test_ladder_game_draw_bug(lobby_server, database):
                 game_player_stats.c.gameId == game_id
             )
         )
-        async for row in result:
+        for row in result:
             assert row.result == GameOutcome.DEFEAT
             assert row.score == 0
 

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -133,7 +133,7 @@ async def test_game_matchmaking_start(lobby_server, database):
             game_player_stats.c.team,
             game_player_stats.c.place,
         ]).where(game_player_stats.c.gameId == msg["uid"]))
-        rows = await result.fetchall()
+        rows = result.fetchall()
         assert len(rows) == 2
         for row in rows:
             assert row["faction"] == 1
@@ -146,8 +146,8 @@ async def test_game_matchmaking_start(lobby_server, database):
         ]).select_from(
             matchmaker_queue_game.outerjoin(matchmaker_queue)
         ).where(matchmaker_queue_game.c.game_stats_id == msg["uid"]))
-        row = await result.fetchone()
-        assert row["technical_name"] == "ladder1v1"
+        row = result.fetchone()
+        assert row.technical_name == "ladder1v1"
 
 
 @fast_forward(15)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -524,6 +524,25 @@ async def get_player_selected_avatars(conn, player_id):
 
 
 @fast_forward(30)
+async def test_avatar_list_empty(lobby_server):
+    _, _, proto = await connect_and_sign_in(
+        ("test", "test_password"),
+        lobby_server
+    )
+    await read_until_command(proto, "game_info")
+
+    await proto.send_message({
+        "command": "avatar", "action": "list_avatar"
+    })
+    msg = await read_until_command(proto, "avatar")
+
+    assert msg == {
+        "command": "avatar",
+        "avatarlist": []
+    }
+
+
+@fast_forward(30)
 async def test_avatar_select(lobby_server, database):
     # This user has multiple avatars in the test data
     player_id, _, proto = await connect_and_sign_in(

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -554,8 +554,8 @@ async def test_avatar_select(lobby_server, database):
     async with database.acquire() as conn:
         result = await get_player_selected_avatars(conn, player_id)
         assert result.rowcount == 1
-        row = await result.fetchone()
-        assert row[avatars_list.c.url] == avatar["url"]
+        row = result.fetchone()
+        assert row.url == avatar["url"]
 
     await proto.send_message({
         "command": "avatar",
@@ -568,8 +568,8 @@ async def test_avatar_select(lobby_server, database):
     async with database.acquire() as conn:
         result = await get_player_selected_avatars(conn, player_id)
         assert result.rowcount == 1
-        row = await result.fetchone()
-        assert row[avatars_list.c.url] == avatar["url"]
+        row = result.fetchone()
+        assert row.url == avatar["url"]
 
 
 @fast_forward(30)

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -676,7 +676,7 @@ async def test_ratings_initialized_based_on_global_persisted(
     )
 
     async with database.acquire() as conn:
-        res = await conn.execute(
+        result = await conn.execute(
             select([leaderboard_rating]).select_from(
                 leaderboard.join(leaderboard_rating)
             ).where(and_(
@@ -684,10 +684,10 @@ async def test_ratings_initialized_based_on_global_persisted(
                 leaderboard_rating.c.login_id == test_id
             ))
         )
-        row = await res.fetchone()
+        row = result.fetchone()
         assert row.mean > 2000
 
-        res = await conn.execute(
+        result = await conn.execute(
             select([leaderboard_rating_journal]).select_from(
                 leaderboard
                 .join(leaderboard_rating_journal)
@@ -697,7 +697,7 @@ async def test_ratings_initialized_based_on_global_persisted(
                 game_player_stats.c.playerId == test_id
             ))
         )
-        rows = await res.fetchall()
+        rows = result.fetchall()
         assert len(rows) == 1
         assert rows[0].rating_mean_before == 2000
         assert rows[0].rating_deviation_before == 250

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -49,11 +49,11 @@ def custom_game(database, game_service, game_stats_service):
 
 async def game_player_scores(database, game):
     async with database.acquire() as conn:
-        results = await conn.execute(
-            "SELECT playerId, score FROM game_player_stats WHERE gameid = %s",
-            game.id
+        result = await conn.execute(
+            "SELECT playerId, score FROM game_player_stats WHERE gameid = :id",
+            {"id": game.id}
         )
-        return set(f.as_tuple() for f in await results.fetchall())
+        return set(tuple(f) for f in result.fetchall())
 
 
 async def test_initialization(game: Game):

--- a/tests/unit_tests/test_game_rating.py
+++ b/tests/unit_tests/test_game_rating.py
@@ -767,12 +767,13 @@ async def test_rating_errors_persisted(custom_game, player_factory):
     await rating_service._join_rating_queue()
 
     async with rating_service._db.acquire() as conn:
-        rows = await conn.execute(
-            "SELECT `validity` FROM `game_stats` " "WHERE `id`=%s", (custom_game.id,)
+        result = await conn.execute(
+            "SELECT `validity` FROM `game_stats` WHERE `id`=:id",
+            {"id": custom_game.id}
         )
-    row = await rows.fetchone()
+    row = result.fetchone()
 
-    assert row[0] == ValidityState.UNKNOWN_RESULT.value
+    assert row.validity == ValidityState.UNKNOWN_RESULT.value
 
 
 async def test_rate_game_treats_double_defeat_as_draw(custom_game, player_factory):

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -637,8 +637,8 @@ async def test_handle_action_OperationComplete_duplicate(
             game_stats.insert().values(
                 id=coop_game.id,
                 startTime=datetime.utcnow(),
-                gameName='Another test game',
-                gameType='0',
+                gameName="Another test game",
+                gameType="0",
                 gameMod=6,
                 host=1,
                 mapId=1,

--- a/tests/unit_tests/test_rating_service.py
+++ b/tests/unit_tests/test_rating_service.py
@@ -174,7 +174,7 @@ async def get_all_ratings(db: FAFDatabase, player_id: int):
 
     async with db.acquire() as conn:
         result = await conn.execute(rating_sql)
-        rows = await result.fetchall()
+        rows = result.fetchall()
 
     return rows
 
@@ -257,8 +257,8 @@ async def test_rating_persistence(semiinitialized_service):
                 game_player_stats.c.playerId == player_id,
             )
         )
-        results = await conn.execute(sql)
-        gps_row = await results.fetchone()
+        result = await conn.execute(sql)
+        gps_row = result.fetchone()
 
         sql = select([leaderboard_rating.c.mean]).where(
             and_(
@@ -266,15 +266,15 @@ async def test_rating_persistence(semiinitialized_service):
                 leaderboard_rating.c.leaderboard_id == rating_type_id,
             )
         )
-        results = await conn.execute(sql)
-        rating_row = await results.fetchone()
+        result = await conn.execute(sql)
+        rating_row = result.fetchone()
 
         sql = select([leaderboard_rating_journal.c.rating_mean_after]).where(
             leaderboard_rating_journal.c.game_player_stats_id
             == gps_row[game_player_stats.c.id]
         )
-        results = await conn.execute(sql)
-        journal_row = await results.fetchone()
+        result = await conn.execute(sql)
+        journal_row = result.fetchone()
 
     assert gps_row[game_player_stats.c.after_mean] == after_mean
     assert rating_row[leaderboard_rating.c.mean] == after_mean


### PR DESCRIPTION
It works mostly the same but is more up to date and will hopefully play nicer with python 3.9. As a result of some of the API differences, I had to refactor some of the uses of the `Row` object. I ran into a cyclic dependency issue when importing `db.models` from `GameService`. Somehow this causes a cycle `models -> game -> CoopGame -> models`, and I'm not entirely sure why I don't see that problem when importing the models anywhere else, but I refactored the typedefs to be their own module that can be imported from anywhere in the server without causing cycles. I also refactored random code style stuff as I found it.

Closes #773 

Might also close #657