### PR TITLE
Check for clean disconnects and raise DisconnectedError

### DIFF
--- a/server/protocol/simple_json.py
+++ b/server/protocol/simple_json.py
@@ -1,6 +1,6 @@
 import json
 
-from .protocol import Protocol, json_encoder
+from .protocol import DisconnectedError, Protocol, json_encoder
 
 
 class SimpleJsonProtocol(Protocol):
@@ -10,4 +10,6 @@ class SimpleJsonProtocol(Protocol):
 
     async def read_message(self) -> dict:
         line = await self.reader.readline()
+        if not line:
+            raise DisconnectedError()
         return json.loads(line.strip())

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -11,7 +11,7 @@ import server.metrics as metrics
 from .core import Service
 from .decorators import with_logger
 from .lobbyconnection import LobbyConnection
-from .protocol import Protocol, QDataStreamProtocol
+from .protocol import DisconnectedError, Protocol, QDataStreamProtocol
 from .types import Address
 
 
@@ -96,11 +96,13 @@ class ServerContext:
                 message = await protocol.read_message()
                 with metrics.connection_on_message_received.time():
                     await connection.on_message_received(message)
-        except (ConnectionError, TimeoutError, asyncio.CancelledError):
+        except (
+            ConnectionError,
+            DisconnectedError,
+            TimeoutError,
+            asyncio.CancelledError,
+        ):
             pass
-        except asyncio.IncompleteReadError as ex:
-            if not stream_reader.at_eof():
-                self._logger.exception(ex)
         except Exception as ex:
             self._logger.exception(ex)
         finally:


### PR DESCRIPTION
The SimpleJson protocol would throw JSONDecodeError's whenever a client disconnected because it would pass `""` to json.loads.