### PR TITLE
Issue/#703 update game info when player disconnects

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -906,7 +906,7 @@ class Game():
             "mapname": self.map_folder_name,
             "map_file_path": self.map_file_path,
             "host": self.host.login if self.host else "",
-            "num_players": len(self.players),
+            "num_players": len(connected_players),
             "max_players": self.max_players,
             "launched_at": self.launched_at,
             "rating_type": self.rating_type,

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -584,7 +584,7 @@ async def test_ladder_game_not_joinable(lobby_server):
     }
 
 
-@fast_forward(30)
+@fast_forward(60)
 async def test_gamestate_ended_clears_references(
     lobby_server,
     game_service,
@@ -665,7 +665,7 @@ async def test_gamestate_ended_clears_references(
         test_proto,
         "game_info",
         state="closed",
-        num_players=2
+        num_players=0
     )
     await asyncio.sleep(0.1)
     gc.collect()

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -307,7 +307,7 @@ async def test_game_ended_broadcasts_rating_update(lobby_server, channel):
     new_persisted_ratings = await get_player_ratings(host_proto, "test", "Rhiza")
 
     rhiza_message = {
-        "player_id": 3, # Rhiza
+        "player_id": 3,  # Rhiza
         "rating_type": "global",
         "new_rating_mean": new_persisted_ratings["Rhiza"][0],
         "new_rating_deviation": new_persisted_ratings["Rhiza"][1],
@@ -317,7 +317,7 @@ async def test_game_ended_broadcasts_rating_update(lobby_server, channel):
     }
 
     test_message = {
-        "player_id": 1, # test
+        "player_id": 1,  # test
         "rating_type": "global",
         "new_rating_mean": new_persisted_ratings["test"][0],
         "new_rating_deviation": new_persisted_ratings["test"][1],
@@ -681,7 +681,10 @@ async def test_gamestate_ended_clears_references(
 
 @pytest.mark.rabbitmq
 @fast_forward(30)
-async def test_galactic_war_1v1_game_ended_broadcasts_army_results(lobby_server, channel):
+async def test_galactic_war_1v1_game_ended_broadcasts_army_results(
+    lobby_server,
+    channel
+):
     mq_proto_all = await connect_mq_consumer(
         lobby_server,
         channel,

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -301,7 +301,7 @@ async def test_player_team_is_none(game, players, mock_game_connection):
     mock_game_connection.state = GameConnectionState.CONNECTED_TO_HOST
     game.add_game_connection(mock_game_connection)
     game.set_player_option(players.hosting.id, "Army", 0)
-    assert game.players == {players.hosting}
+    assert game.players == [players.hosting]
     assert game.get_player_option(players.hosting.id, "Team") is None
     assert game.get_player_option(players.hosting.id, "Army") == 0
     assert game.teams == {None}
@@ -314,7 +314,7 @@ async def test_set_player_option(game, players, mock_game_connection):
     mock_game_connection.state = GameConnectionState.CONNECTED_TO_HOST
     game.add_game_connection(mock_game_connection)
     game.set_player_option(players.hosting.id, "Team", 1)
-    assert game.players == {players.hosting}
+    assert game.players == [players.hosting]
     assert game.get_player_option(players.hosting.id, "Team") == 1
     assert game.teams == {1}
     game.set_player_option(players.hosting.id, "StartSpot", 1)
@@ -333,7 +333,7 @@ async def test_add_game_connection(game: Game, players, mock_game_connection):
     # Players should not be considered as 'in lobby' until the host has sent
     # "PlayerOption" configuration for them
     assert game.to_dict()["num_players"] == 0
-    assert game.players == set()
+    assert game.players == []
     game.set_player_option(players.hosting.id, "Team", 1)
     assert players.hosting in game.players
 
@@ -349,19 +349,19 @@ async def test_add_game_connection_twice(game: Game, players, mock_game_connecti
     # Connect the host
     game.add_game_connection(mock_game_connection)
     game.set_player_option(players.hosting.id, "Team", 1)
-    assert game.players == {players.hosting}
+    assert game.players == [players.hosting]
     # Join a new player
     join_conn = add_connected_player(game, players.joining)
-    assert game.players == {players.hosting, players.joining}
+    assert game.players == [players.hosting, players.joining]
     # Player leaves
     await game.remove_game_connection(join_conn)
-    assert game.players == {players.hosting}
+    assert game.players == [players.hosting]
     # Player joins again
     game.add_game_connection(join_conn)
     assert game.to_dict()["num_players"] == 1
-    assert game.players == {players.hosting}
+    assert game.players == [players.hosting]
     game.set_player_option(players.joining.id, "Team", 1)
-    assert game.players == {players.hosting, players.joining}
+    assert game.players == [players.hosting, players.joining]
     assert game.to_dict()["num_players"] == 2
 
 
@@ -479,10 +479,10 @@ async def test_game_launch_freezes_players(game: Game, players):
     await game.launch()
 
     assert game.state is GameState.LIVE
-    assert game.players == {players.hosting, players.joining}
+    assert game.players == [players.hosting, players.joining]
 
     await game.remove_game_connection(host_conn)
-    assert game.players == {players.hosting, players.joining}
+    assert game.players == [players.hosting, players.joining]
 
 
 async def test_game_teams_represents_active_teams(game: Game, players):
@@ -840,7 +840,7 @@ async def test_players_exclude_observers(
     game.add_game_connection(gc)
     await game.launch()
 
-    assert game.players == frozenset(players)
+    assert game.players == players
 
 
 async def test_game_outcomes(game: Game, database, players):


### PR DESCRIPTION
Changes the `game_info` message to use connected players instead of players frozen at game launch. This should allow the client to tell when a player has left the game even before the game has completely ended.

Closes #703