### PR TITLE
Change game quality calculations

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -89,12 +89,12 @@ class ConfigurationStore:
         # Difference of cumulated rating of the teams
         self.MAXIMUM_RATING_IMBALANCE = 500
         # stdev of the ratings of all participating players
-        self.MAXIMUM_RATING_DEVIATION = 750
+        self.MAXIMUM_RATING_DEVIATION = 500
         # Quality bonus for each failed matching attempt per full team
         self.TIME_BONUS = 0.02
-        self.MAXIMUM_TIME_BONUS = 0.4
-        self.NEWBIE_TIME_BONUS = 0.2
-        self.MAXIMUM_NEWBIE_TIME_BONUS = 1.6
+        self.MAXIMUM_TIME_BONUS = 0.2
+        self.NEWBIE_TIME_BONUS = 0.9
+        self.MAXIMUM_NEWBIE_TIME_BONUS = 2.7
 
         self.TWILIO_ACCOUNT_SID = ""
         self.TWILIO_TOKEN = ""

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -286,7 +286,8 @@ class TeamMatchMaker(Matchmaker):
         deviation = statistics.pstdev(ratings)
         rating_variety = deviation / config.MAXIMUM_RATING_DEVIATION
 
-        # Visually this creates a cone in the unfairness-rating_variety plane that slowly raises with the time boni.
+        # Visually this creates a cone in the unfairness-rating_variety plane
+        # that slowly raises with the time bonuses.
         quality = 1 - sqrt(unfairness ** 2 + rating_variety ** 2) + time_bonus
         if not any(team.has_top_player() for team in match):
             quality += newbie_bonus

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -132,7 +132,7 @@ insert into leaderboard_rating (login_id, mean, deviation, total_games, leaderbo
   (102, 1500, 500, 0, 1),
   (102, 1500, 500, 0, 2),
   (105, 1400, 150, 20, 3),
-  (106, 1500, 75, 20, 3)
+  (106, 900, 75, 20, 3)
 ;
 
 -- legacy table for global rating

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -80,10 +80,10 @@ def test_team_matchmaker_algorithm(player_factory):
 
     matches, unmatched = matchmaker.find(s, 4)
 
-    assert set(matches[0][0].get_original_searches()) == {c1, s[2], s[5]}
-    assert set(matches[0][1].get_original_searches()) == {c3, s[1], s[6]}
-    assert set(matches[1][0].get_original_searches()) == {c4, s[4]}
-    assert set(matches[1][1].get_original_searches()) == {c2, s[0], s[3]}
+    assert set(matches[1][0].get_original_searches()) == {c1, s[2], s[5]}
+    assert set(matches[1][1].get_original_searches()) == {c3, s[1], s[6]}
+    assert set(matches[0][0].get_original_searches()) == {c4, s[4]}
+    assert set(matches[0][1].get_original_searches()) == {c2, s[0], s[3]}
     assert set(unmatched) == {s[7]}
     for match in matches:
         assert matchmaker.assign_game_quality(match, 4).quality > config.MINIMUM_GAME_QUALITY
@@ -259,7 +259,10 @@ def test_game_quality_time_bonus(s):
     team_b.register_failed_matching_attempt()
     quality_after = matchmaker.assign_game_quality((team_a, team_b), 3).quality
 
-    num_newbies = team_a.num_newbies() + team_b.num_newbies()
+    if team_a.has_top_player() or team_b.has_top_player():
+        num_newbies = 0
+    else:
+        num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
     assert (
         quality_before
@@ -283,7 +286,10 @@ def test_game_quality_max_time_bonus(s):
         team_b.register_failed_matching_attempt()
     quality_after = matchmaker.assign_game_quality((team_a, team_b), 3).quality
 
-    num_newbies = team_a.num_newbies() + team_b.num_newbies()
+    if team_a.has_top_player() or team_b.has_top_player():
+        num_newbies = 0
+    else:
+        num_newbies = team_a.num_newbies() + team_b.num_newbies()
 
     assert (
         quality_before


### PR DESCRIPTION
Here we go again...

When looking at some real games I noticed two problems with the current implementation:
- If the uniformity and the fairness are both very bad (close to 0) and at least one is negative, we get a better score (slightly below 0) than if one is negative and the other one is really good (close to 1). Then we get a score that is way more negative.
- We don't care so much if the rating disparity is exactly zero, but we want to discourage games where uniformity or fairness are way off.

We can fix the first one by not multiplying but adding uniformity and fairness. That way one getting worse will always worsen the game quality.
For the second one we can simply square the penalty for deviating from the ideal values. This makes small errors smaller and increases big errors.
With these changes I have to tune the config values again, I will update this PR when I made some more tests.