### PR TITLE
Optimize rating initialization

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -861,17 +861,22 @@ class Game():
         self._process_pending_army_stats()
 
     def is_visible_to_player(self, player: Player) -> bool:
+        """
+        Determine if a player should see this game in their games list.
+
+        Note: This is a *hot* function, it can have significant impacts on
+        performance.
+        """
         if self.host is None:
             return False
 
         if player == self.host or player in self._connections:
             return True
 
-        mean, dev = player.ratings[self.rating_type]
-        displayed_rating = mean - 3 * dev
         if (
             self.enforce_rating_range
-            and displayed_rating not in self.displayed_rating_range
+            and player.get_displayed_rating(self.rating_type)
+            not in self.displayed_rating_range
         ):
             return False
 

--- a/server/players.py
+++ b/server/players.py
@@ -88,6 +88,10 @@ class Player:
         else:
             self._faction = Faction.from_value(value)
 
+    def get_displayed_rating(self, rating_type: str) -> float:
+        mean, dev = self.ratings[rating_type]
+        return mean - 3 * dev
+
     def power(self) -> int:
         """An artifact of the old permission system. The client still uses this
         number to determine if a player gets a special category in the user list


### PR DESCRIPTION
I had a look at the server profile generated after the last update, and it looks like the rating initialization was being called an excessive amount. This is mostly because it gets invoked both when generating `game_info` as well as `player_info` messages. 

In the `game_info` messages it would be called even if the rating data wasn't actually needed, just because it had been easier to write that ways. Now, it checks whether rating enforcement is enabled first and only queries the rating if it is. I also added some caching to the rating computation itself so that the queries generated by the `player_info` message creation will now short circuit the majority of the time.