### PR TITLE
Check for lobby scope in token during login

### DIFF
--- a/server/oauth_service.py
+++ b/server/oauth_service.py
@@ -87,7 +87,10 @@ class OAuthService(Service, name="oauth_service"):
             )
 
             if "lobby" not in decoded["scp"]:
-                raise AuthenticationError("Token does not have permission to login to the lobby server", "token")
+                raise AuthenticationError(
+                    "Token does not have permission to login to the lobby server",
+                    "token"
+                )
 
             return int(decoded["sub"])
         except (InvalidTokenError, KeyError, ValueError):

--- a/server/oauth_service.py
+++ b/server/oauth_service.py
@@ -85,6 +85,10 @@ class OAuthService(Service, name="oauth_service"):
                 algorithms="RS256",
                 options={"verify_aud": False}
             )
+
+            if "lobby" not in decoded["scp"]:
+                raise AuthenticationError("Token does not have permission to login to the lobby server", "token")
+
             return int(decoded["sub"])
         except (InvalidTokenError, KeyError, ValueError):
             raise AuthenticationError("Token signature was invalid", "token")


### PR DESCRIPTION
This asserts that the oauth token contains the lobby scope before allowing a player to login. This allows for players to be banned from just the game service. All oauth tokens from the clients currently have the lobby scope