### PR TITLE
Allow map size of the generator params to be non power of 2

### DIFF
--- a/server/types.py
+++ b/server/types.py
@@ -57,7 +57,7 @@ class NeroxisGeneratedMap(NamedTuple):
         if map_size_pixels <= 0:
             raise Exception("Map size is zero or negative")
 
-        if map_size_pixels // 64 != 0:
+        if map_size_pixels % 64 != 0:
             raise Exception("Map size is not a multiple of 64")
 
         spawns = int(params["spawns"])

--- a/server/types.py
+++ b/server/types.py
@@ -57,8 +57,8 @@ class NeroxisGeneratedMap(NamedTuple):
         if map_size_pixels <= 0:
             raise Exception("Map size is zero or negative")
 
-        if map_size_pixels & (map_size_pixels - 1) != 0:
-            raise Exception("Map size is not a power of 2")
+        if map_size_pixels // 64 != 0:
+            raise Exception("Map size is not a multiple of 64")
 
         spawns = int(params["spawns"])
         if spawns % 2 != 0:

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -323,6 +323,7 @@ insert into map_pool_map_version (map_pool_id, map_version_id, weight, map_param
   (2, 11, 1, NULL), (2, 14, 1, NULL), (2, 15, 1, NULL), (2, 16, 1, NULL), (2, 17, 1, NULL),
   (3, 1, 1, NULL), (3, 2, 1, NULL), (3, 3, 1, NULL),
   (4, NULL, 1, '{"type": "neroxis", "size": 512, "spawns": 2, "version": "0.0.0"}'),
+  (4, NULL, 1, '{"type": "neroxis", "size": 768, "spawns": 2, "version": "0.0.0"}'),
   -- Bad Generated Map Parameters should not be included in pool
   (4, NULL, 1, '{"type": "neroxis", "size": 513, "spawns": 2, "version": "0.0.0"}'),
   (4, NULL, 1, '{"type": "neroxis", "size": 0, "spawns": 2, "version": "0.0.0"}'),

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -70,7 +70,7 @@ async def test_game_launch_message_map_generator(lobby_server):
 
     assert msg1["mapname"] == msg2["mapname"]
     assert re.match(
-        "neroxis_map_generator_0.0.0_[0-9a-z]{13}_aiea",
+        "neroxis_map_generator_0.0.0_[0-9a-z]{13}_[0-9a-z]{4}",
         msg1["mapname"]
     )
 

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -74,12 +74,18 @@ async def test_load_from_database(ladder_service, queue_factory):
 
         queue = ladder_service.queues["neroxis1v1"]
         assert queue.name == "neroxis1v1"
-        assert len(queue.map_pools) == 1
+        assert len(queue.map_pools) == 2
         assert list(queue.map_pools[4][0].maps.values()) == [
             NeroxisGeneratedMap.of({
                 "version": "0.0.0",
                 "spawns": 2,
                 "size": 512,
+                "type": "neroxis"
+            }),
+            NeroxisGeneratedMap.of({
+                "version": "0.0.0",
+                "spawns": 2,
+                "size": 768,
                 "type": "neroxis"
             }),
         ]

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -74,7 +74,7 @@ async def test_load_from_database(ladder_service, queue_factory):
 
         queue = ladder_service.queues["neroxis1v1"]
         assert queue.name == "neroxis1v1"
-        assert len(queue.map_pools) == 2
+        assert len(queue.map_pools) == 1
         assert list(queue.map_pools[4][0].maps.values()) == [
             NeroxisGeneratedMap.of({
                 "version": "0.0.0",


### PR DESCRIPTION
Only enforce that the param size needs to be a multiple of 64 as specified by the map name encoding of the generator