### PR TITLE
Remove search boundaries

### DIFF
--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -257,9 +257,6 @@ class MatchmakerQueue:
         self._is_running = False
 
     def to_dict(self):
-        """
-        Return a fuzzy representation of the searches currently in the queue
-        """
         return {
             "queue_name": self.name,
             "queue_pop_time": datetime.fromtimestamp(
@@ -267,8 +264,6 @@ class MatchmakerQueue:
             ).isoformat(),
             "queue_pop_time_delta": self.timer.next_queue_pop - time.time(),
             "num_players": self.num_players,
-            "boundary_80s": [search.boundary_80 for search in self._queue.keys()],
-            "boundary_75s": [search.boundary_75 for search in self._queue.keys()],
             # TODO: Remove, the client should query the API for this
             "team_size": self.team_size,
         }

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -1,6 +1,5 @@
 import asyncio
 import itertools
-import math
 import statistics
 import time
 from typing import Any, Callable, List, Optional, Tuple
@@ -99,25 +98,6 @@ class Search:
     @property
     def raw_ratings(self):
         return [player.ratings[self.rating_type] for player in self.players]
-
-    def _nearby_rating_range(self, delta):
-        """
-        Returns 'boundary' mu values for player matching. Adjust delta for
-        different game qualities.
-        """
-        mu, _ = self.ratings[0]  # Takes the rating of the first player, only works for 1v1
-        rounded_mu = int(math.ceil(mu / 10) * 10)  # Round to 10
-        return rounded_mu - delta, rounded_mu + delta
-
-    @property
-    def boundary_80(self):
-        """ Achieves roughly 80% quality. """
-        return self._nearby_rating_range(200)
-
-    @property
-    def boundary_75(self):
-        """ Achieves roughly 75% quality. FIXME - why is it MORE restrictive??? """
-        return self._nearby_rating_range(100)
 
     @property
     def failed_matching_attempts(self) -> int:

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -419,8 +419,6 @@ async def test_matchmaker_info_message(lobby_server, mocker):
         assert queue["queue_pop_time_delta"] == math.ceil(
             config.QUEUE_POP_TIME_MAX / 2
         )
-        assert queue["boundary_80s"] == []
-        assert queue["boundary_75s"] == []
 
 
 @fast_forward(10)
@@ -453,8 +451,6 @@ async def test_command_matchmaker_info(lobby_server, mocker):
         assert queue["queue_pop_time_delta"] == math.ceil(
             config.QUEUE_POP_TIME_MAX / 2
         )
-        assert queue["boundary_80s"] == []
-        assert queue["boundary_75s"] == []
 
 
 @fast_forward(10)
@@ -481,10 +477,10 @@ async def test_matchmaker_info_message_on_cancel(lobby_server):
             queue_message = next(
                 q for q in msg["queues"] if q["queue_name"] == "ladder1v1"
             )
-            if not queue_message["boundary_80s"]:
+            if not queue_message["num_players"]:
                 continue
 
-            assert len(queue_message["boundary_80s"]) == 1
+            assert queue_message["num_players"] == 1
 
             return
 
@@ -499,7 +495,7 @@ async def test_matchmaker_info_message_on_cancel(lobby_server):
     msg = await read_until_command(proto, "matchmaker_info")
 
     queue_message = next(q for q in msg["queues"] if q["queue_name"] == "ladder1v1")
-    assert len(queue_message["boundary_80s"]) == 0
+    assert queue_message["num_players"] == 0
 
 
 @fast_forward(10)

--- a/tests/integration_tests/test_teammatchmaker.py
+++ b/tests/integration_tests/test_teammatchmaker.py
@@ -74,13 +74,6 @@ async def test_info_message(lobby_server):
     msg = await read_until_command(proto, "matchmaker_info")
 
     assert msg["queues"]
-    for queue in msg["queues"]:
-        boundaries = queue["boundary_80s"]
-
-        if queue["queue_name"] == "tmm2v2":
-            assert boundaries == [[300, 700]]
-        else:
-            assert boundaries == []
 
 
 @fast_forward(10)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -488,7 +488,7 @@ async def test_abort(mocker, lobbyconnection):
 async def test_send_game_list(mocker, database, lobbyconnection, game_stats_service):
     games = mocker.patch.object(lobbyconnection, "game_service")  # type: GameService
     game1, game2 = mock.create_autospec(Game(42, database, mock.Mock(), game_stats_service)), \
-                   mock.create_autospec(Game(22, database, mock.Mock(), game_stats_service))
+        mock.create_autospec(Game(22, database, mock.Mock(), game_stats_service))
 
     games.open_games = [game1, game2]
     lobbyconnection.send = CoroutineMock()
@@ -959,13 +959,13 @@ async def test_command_game_matchmaking_not_party_owner(
 
     lobbyconnection.ladder_service.cancel_search.assert_called_once()
 
-    
+
 async def test_command_match_ready(lobbyconnection):
     await lobbyconnection.on_message_received({
         "command": "match_ready"
     })
 
-    
+
 async def test_command_matchmaker_info(
     lobbyconnection,
     ladder_service,
@@ -1008,9 +1008,7 @@ async def test_command_matchmaker_info(
                 "queue_pop_time": "2019-07-01T16:53:20+00:00",
                 "queue_pop_time_delta": 1.0,
                 "team_size": 1,
-                "num_players": 6,
-                "boundary_80s": [(1800, 2200), (300, 700), (800, 1200)],
-                "boundary_75s": [(1900, 2100), (400, 600), (900, 1100)]
+                "num_players": 6
             }
         ]
     })

--- a/tests/unit_tests/test_matchmaker_queue.py
+++ b/tests/unit_tests/test_matchmaker_queue.py
@@ -28,20 +28,20 @@ def player_factory(player_factory):
 @pytest.fixture
 def matchmaker_players(player_factory):
     return player_factory("Dostya", player_id=1, ladder_rating=(2300, 64)), \
-           player_factory("Brackman", player_id=2, ladder_rating=(1200, 72)), \
-           player_factory("Zoidberg", player_id=3, ladder_rating=(1300, 175)), \
-           player_factory("QAI", player_id=4, ladder_rating=(2350, 125)), \
-           player_factory("Rhiza", player_id=5, ladder_rating=(1200, 175)), \
-           player_factory("Newbie", player_id=6, ladder_rating=(1200, 175), ladder_games=config.NEWBIE_MIN_GAMES - 1)
+        player_factory("Brackman", player_id=2, ladder_rating=(1200, 72)), \
+        player_factory("Zoidberg", player_id=3, ladder_rating=(1300, 175)), \
+        player_factory("QAI", player_id=4, ladder_rating=(2350, 125)), \
+        player_factory("Rhiza", player_id=5, ladder_rating=(1200, 175)), \
+        player_factory("Newbie", player_id=6, ladder_rating=(1200, 175), ladder_games=config.NEWBIE_MIN_GAMES - 1)
 
 
 @pytest.fixture
 def matchmaker_players_all_match(player_factory):
     return player_factory("Dostya", player_id=1, ladder_rating=(1500, 50)), \
-           player_factory("Brackman", player_id=2, ladder_rating=(1500, 50)), \
-           player_factory("Zoidberg", player_id=3, ladder_rating=(1500, 50)), \
-           player_factory("QAI", player_id=4, ladder_rating=(1500, 50)), \
-           player_factory("Rhiza", player_id=5, ladder_rating=(1500, 50))
+        player_factory("Brackman", player_id=2, ladder_rating=(1500, 50)), \
+        player_factory("Zoidberg", player_id=3, ladder_rating=(1500, 50)), \
+        player_factory("QAI", player_id=4, ladder_rating=(1500, 50)), \
+        player_factory("Rhiza", player_id=5, ladder_rating=(1500, 50))
 
 
 def test_get_game_options_empty(queue_factory):
@@ -163,15 +163,6 @@ def test_search_no_match_wrong_type(matchmaker_players):
     p1, _, _, _, _, _ = matchmaker_players
     s1 = Search([p1])
     assert not s1.matches_with(42)
-
-
-def test_search_boundaries(matchmaker_players):
-    p1 = matchmaker_players[0]
-    s1 = Search([p1])
-    assert p1.ratings[RatingType.LADDER_1V1][0] > s1.boundary_80[0]
-    assert p1.ratings[RatingType.LADDER_1V1][0] < s1.boundary_80[1]
-    assert p1.ratings[RatingType.LADDER_1V1][0] > s1.boundary_75[0]
-    assert p1.ratings[RatingType.LADDER_1V1][0] < s1.boundary_75[1]
 
 
 def test_search_expansion_controlled_by_failed_matching_attempts(matchmaker_players, mocker):
@@ -343,8 +334,8 @@ def test_queue_multiple_map_pools(
 @pytest.mark.asyncio
 async def test_queue_many(matchmaker_queue, player_factory):
     p1, p2, p3 = player_factory("Dostya", ladder_rating=(2200, 150)), \
-                 player_factory("Brackman", ladder_rating=(1500, 150)), \
-                 player_factory("Zoidberg", ladder_rating=(1500, 125))
+        player_factory("Brackman", ladder_rating=(1500, 150)), \
+        player_factory("Zoidberg", ladder_rating=(1500, 125))
 
     s1 = Search([p1])
     s2 = Search([p2])
@@ -366,8 +357,8 @@ async def test_queue_many(matchmaker_queue, player_factory):
 @pytest.mark.asyncio
 async def test_queue_race(matchmaker_queue, player_factory):
     p1, p2, p3 = player_factory("Dostya", ladder_rating=(2300, 150)), \
-                 player_factory("Brackman", ladder_rating=(2200, 150)), \
-                 player_factory("Zoidberg", ladder_rating=(2300, 125))
+        player_factory("Brackman", ladder_rating=(2200, 150)), \
+        player_factory("Zoidberg", ladder_rating=(2300, 125))
 
     async def find_matches():
         await asyncio.sleep(0.01)


### PR DESCRIPTION
I guess they were used by the python client for the "A person in your rating range is searching for a game. Click here to join them." message. However, the ranges are unreliable, because it just gives a hardcoded range and the trueskill quality also depends on the deviation. Also we alter the acceptable quality for every unsucessful queue pop. For team queues we use a different system entirely.
The java client doesn't use them for anything at the moment.