### PR TITLE
Make RabbitMQ exchanges durable

### DIFF
--- a/server/message_queue_service.py
+++ b/server/message_queue_service.py
@@ -87,7 +87,7 @@ class MessageQueueService(Service):
         self._logger.debug("Connected to RabbitMQ %r", self._connection)
 
     async def declare_exchange(
-        self, exchange_name: str, exchange_type: ExchangeType = ExchangeType.TOPIC
+        self, exchange_name: str, exchange_type: ExchangeType = ExchangeType.TOPIC, durable: bool = True
     ) -> None:
         await self.initialize()
         if not self._is_ready:
@@ -96,13 +96,13 @@ class MessageQueueService(Service):
             )
             return
 
-        await self._declare_exchange(exchange_name, exchange_type)
+        await self._declare_exchange(exchange_name, exchange_type, durable)
 
     async def _declare_exchange(
-        self, exchange_name: str, exchange_type: ExchangeType
+        self, exchange_name: str, exchange_type: ExchangeType, durable: bool = True
     ) -> None:
         new_exchange = await self._channel.declare_exchange(
-            exchange_name, exchange_type
+            exchange_name, exchange_type, durable
         )
 
         self._exchanges[exchange_name] = new_exchange

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -391,7 +391,8 @@ async def connect_mq_consumer(server, channel, routing_key):
     """
     exchange = await channel.declare_exchange(
         config.MQ_EXCHANGE_NAME,
-        aio_pika.ExchangeType.TOPIC
+        aio_pika.ExchangeType.TOPIC,
+        durable=True
     )
     queue = await channel.declare_queue("", exclusive=True)
     await queue.bind(exchange, routing_key=routing_key)

--- a/tests/integration_tests/test_message_queue_service.py
+++ b/tests/integration_tests/test_message_queue_service.py
@@ -22,7 +22,7 @@ class Consumer:
         )
         channel = await self.connection.channel()
         exchange = await channel.declare_exchange(
-            "test_exchange", aio_pika.ExchangeType.TOPIC
+            "test_exchange", aio_pika.ExchangeType.TOPIC, durable=True
         )
         self.queue = await channel.declare_queue("test_queue", exclusive=True)
 


### PR DESCRIPTION
Fixes #853
As long as we do not have any session-related data,
all exchanges and queues should be durable to avoid
data loss on server restart.