### PR TITLE
Issue/#866 matchmaker timeout

### DIFF
--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -463,17 +463,19 @@ class LadderService(Service):
                 game_options=game_options
             )
 
-            def game_options(player: Player) -> GameLaunchOptions:
+            def make_game_options(player: Player) -> GameLaunchOptions:
                 return options._replace(
                     team=game.get_player_option(player.id, "Team"),
                     faction=player.faction,
                     map_position=game.get_player_option(player.id, "StartSpot")
                 )
 
-            await host.lobby_connection.launch_game(
-                game, is_host=True, options=game_options(host)
-            )
             try:
+                host.lobby_connection.write_launch_game(
+                    game,
+                    is_host=True,
+                    options=make_game_options(host)
+                )
                 await game.wait_hosted(60)
             finally:
                 # TODO: Once the client supports `match_cancelled`, don't
@@ -482,13 +484,13 @@ class LadderService(Service):
                 # think it is searching for ladder, even though the server has
                 # already removed it from the queue.
 
-                await asyncio.gather(*[
-                    guest.lobby_connection.launch_game(
-                        game, is_host=False, options=game_options(guest)
-                    )
-                    for guest in all_guests
-                    if guest.lobby_connection is not None
-                ])
+                for guest in all_guests:
+                    if guest.lobby_connection is not None:
+                        guest.lobby_connection.write_launch_game(
+                            game,
+                            is_host=False,
+                            options=make_game_options(guest)
+                        )
             await game.wait_launched(60 + 10 * len(all_guests))
             self._logger.debug("Ladder game launched successfully %s", game)
         except Exception as e:

--- a/server/ladder_service.py
+++ b/server/ladder_service.py
@@ -503,7 +503,8 @@ class LadderService(Service):
             if game:
                 await game.on_game_end()
 
-            msg = {"command": "match_cancelled"}
+            game_id = game.id if game else None
+            msg = {"command": "match_cancelled", "game_id": game_id}
             for player in all_players:
                 if player.state == PlayerState.STARTING_AUTOMATCH:
                     player.state = PlayerState.IDLE

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -303,7 +303,7 @@ async def test_game_matchmaking_disconnect(lobby_server):
 
     msg = await read_until_command(proto2, "match_cancelled", timeout=120)
 
-    assert msg == {"command": "match_cancelled"}
+    assert msg == {"command": "match_cancelled", "game_id": 41956}
 
 
 @fast_forward(130)

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -206,8 +206,14 @@ async def test_start_game_timeout(
 
     LadderGame.timeout_game.assert_called_once()
     LadderGame.on_game_end.assert_called()
-    p1.lobby_connection.write.assert_called_once_with({"command": "match_cancelled"})
-    p2.lobby_connection.write.assert_called_once_with({"command": "match_cancelled"})
+    p1.lobby_connection.write.assert_called_once_with({
+        "command": "match_cancelled",
+        "game_id": 41956
+    })
+    p2.lobby_connection.write.assert_called_once_with({
+        "command": "match_cancelled",
+        "game_id": 41956
+    })
     assert p1.lobby_connection.launch_game.called
     # TODO: Once client supports `match_cancelled` change this to `assert not`
     # and uncomment the following lines.

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -142,18 +142,14 @@ async def test_start_game_1v1(
     monkeypatch.setattr(LadderGame, "wait_hosted", mock.AsyncMock())
     monkeypatch.setattr(LadderGame, "wait_launched", mock.AsyncMock())
     monkeypatch.setattr(LadderGame, "timeout_game", mock.AsyncMock())
-    for player in (player1, player2):
-        player.lobby_connection.launch_game = mock.AsyncMock(
-            spec=LobbyConnection.launch_game
-        )
 
     await ladder_service.start_game([player1], [player2], queue)
 
     game = game_service[game_service.game_id_counter]
 
-    assert player1.lobby_connection.launch_game.called
+    assert player1.lobby_connection.write_launch_game.called
     # TODO: Once client supports `match_cancelled` change this to `assert not`
-    assert player2.lobby_connection.launch_game.called
+    assert player2.lobby_connection.write_launch_game.called
     assert isinstance(game, LadderGame)
     assert game.rating_type == queue.rating_type
     assert game.max_players == 2
@@ -214,12 +210,50 @@ async def test_start_game_timeout(
         "command": "match_cancelled",
         "game_id": 41956
     })
-    assert p1.lobby_connection.launch_game.called
+    assert p1.lobby_connection.write_launch_game.called
     # TODO: Once client supports `match_cancelled` change this to `assert not`
     # and uncomment the following lines.
-    assert p2.lobby_connection.launch_game.called
+    assert p2.lobby_connection.write_launch_game.called
     # assert p1.state is PlayerState.IDLE
     # assert p2.state is PlayerState.IDLE
+
+
+@fast_forward(200)
+async def test_start_game_timeout_on_send(
+    ladder_service: LadderService,
+    player_factory,
+    monkeypatch
+):
+    queue = ladder_service.queues["ladder1v1"]
+    p1 = player_factory("Dostya", player_id=1, lobby_connection_spec="auto")
+    p2 = player_factory("Rhiza", player_id=2, lobby_connection_spec="auto")
+
+    monkeypatch.setattr(LadderGame, "timeout_game", mock.AsyncMock())
+    monkeypatch.setattr(LadderGame, "on_game_end", mock.AsyncMock())
+
+    async def wait_forever(*args, **kwargs):
+        await asyncio.sleep(1000)
+    # Even though launch_game isn't called by start_game, these mocks are
+    # important for the test in case someone refactors the code to call it.
+    p1.lobby_connection.launch_game.side_effect = wait_forever
+    p2.lobby_connection.launch_game.side_effect = wait_forever
+
+    await asyncio.wait_for(
+        ladder_service.start_game([p1], [p2], queue),
+        timeout=150
+    )
+
+    LadderGame.timeout_game.assert_called_once()
+    LadderGame.on_game_end.assert_called()
+    p1.lobby_connection.write.assert_called_once_with({
+        "command": "match_cancelled",
+        "game_id": 41956
+    })
+    p2.lobby_connection.write.assert_called_once_with({
+        "command": "match_cancelled",
+        "game_id": 41956
+    })
+    assert p1.lobby_connection.write_launch_game.called
 
 
 @given(
@@ -244,10 +278,6 @@ async def test_start_game_with_teams(
     monkeypatch.setattr(LadderGame, "wait_hosted", mock.AsyncMock())
     monkeypatch.setattr(LadderGame, "wait_launched", mock.AsyncMock())
     monkeypatch.setattr(LadderGame, "timeout_game", mock.AsyncMock())
-    for player in (player1, player2, player3, player4):
-        player.lobby_connection.launch_game = mock.AsyncMock(
-            spec=LobbyConnection.launch_game
-        )
 
     await ladder_service.start_game(
         [player1, player3],
@@ -257,10 +287,10 @@ async def test_start_game_with_teams(
 
     game = game_service[game_service.game_id_counter]
 
-    assert player1.lobby_connection.launch_game.called
-    assert player2.lobby_connection.launch_game.called
-    assert player3.lobby_connection.launch_game.called
-    assert player4.lobby_connection.launch_game.called
+    assert player1.lobby_connection.write_launch_game.called
+    assert player2.lobby_connection.write_launch_game.called
+    assert player3.lobby_connection.write_launch_game.called
+    assert player4.lobby_connection.write_launch_game.called
     assert isinstance(game, LadderGame)
     assert game.rating_type == queue.rating_type
     assert game.max_players == 4


### PR DESCRIPTION
- Add `game_id` to `match_cancelled` message so the client can choose to ignore it if the message doesn't apply to the current game
- Prevent `start_game` from stalling on hung connections. The timeouts should always be followed now.

@Sheikah any preference on what to call the `game_id` field? I think `game_id` makes sense but in `game_info` it's called `uid`.

Mitigates some of #866 but doesn't fix it completely.