### PR TITLE
Reduce desired matches for pop timer

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -120,7 +120,7 @@ class ConfigurationStore:
         # The number of possible matches we would like to have when the queue
         # pops. The queue pop time will be adjusted based on the current rate of
         # players queuing to try and hit this number.
-        self.QUEUE_POP_DESIRED_MATCHES = 4
+        self.QUEUE_POP_DESIRED_MATCHES = 2.5
         # How many previous queue sizes to consider
         self.QUEUE_POP_TIME_MOVING_AVG_SIZE = 5
 


### PR DESCRIPTION
Looking at the logs has showed that currently the timer reduction gets almost never triggered. Reducing the desired matches to 2.5 should allow queue times to reduce to about two minutes during busy weekend hours.