### PR TITLE
Issue/#893 player hash implementation

### DIFF
--- a/server/games/typedefs.py
+++ b/server/games/typedefs.py
@@ -176,7 +176,13 @@ class EndedGameInfo(NamedTuple):
                 {
                     "outcome": team_summary.outcome.name,
                     "player_ids": list(team_summary.player_ids),
-                    "army_results": [result._asdict() for result in team_summary.army_results],
+                    "army_results": [
+                        result._asdict()
+                        for result in sorted(
+                            team_summary.army_results,
+                            key=lambda x: x.player_id
+                        )
+                    ],
                 }
                 for team_summary in self.team_summaries
             ],

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -365,7 +365,10 @@ class CombinedSearch(Search):
             s.cancel()
 
     def __str__(self):
-        return f"CombinedSearch({','.join(str(s) for s in self.searches)})"
+        return f"CombinedSearch({', '.join(str(s) for s in self.searches)})"
+
+    def __repr__(self):
+        return f"CombinedSearch({', '.join(str(s) for s in self.searches)})"
 
     def get_original_searches(self) -> list[Search]:
         """

--- a/server/players.py
+++ b/server/players.py
@@ -171,9 +171,3 @@ class Player:
         return (f"Player(login={self.login}, session={self.session}, "
                 f"id={self.id}, ratings={dict(self.ratings)}, "
                 f"clan={self.clan}, game_count={dict(self.game_count)})")
-
-    def __hash__(self) -> int:
-        return hash(self.id)
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, type(self)) and self.id == other.id

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -420,16 +420,6 @@ async def test_anti_map_repetition(lobby_server):
             proto1.close(),
             proto2.close()
         )
-        # TODO: The real problem here is that sometimes it takes a while for the
-        # on_connection_lost logic to be triggered for all services. In the mean
-        # time the player logs in with a second connection, but inherits the
-        # old party object (because of the __hash__, and __eq__ implementation)
-        # which references the old Player object that's still in the PLAYING
-        # state which prevents the new player from queuing.
-
-        # Really, the old party object should be ignored and a new party should
-        # be created.
-        await asyncio.sleep(3)
 
 
 @fast_forward(10)

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -15,7 +15,7 @@ from server.db.models import (
 )
 from tests.utils import fast_forward
 
-from .conftest import connect_and_sign_in, read_until, read_until_command
+from .conftest import connect_and_sign_in, read_until_command
 from .test_game import (
     client_response,
     idle_response,

--- a/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_bucket_teams.py
@@ -24,6 +24,7 @@ def player_factory(player_factory):
         deviation: int = 500,
         ladder_games: int = config.NEWBIE_MIN_GAMES + 1,
         name=None,
+        **kwargs
     ):
         """Make a player with the given ratings"""
         player = player_factory(
@@ -31,6 +32,7 @@ def player_factory(player_factory):
             ladder_games=ladder_games,
             login=name,
             lobby_connection_spec=None,
+            **kwargs
         )
         return player
 
@@ -203,7 +205,10 @@ def do_test_make_teams(teams, team_size, total_unmatched, unmatched_sizes):
 
 
 def test_distribute_pairs_1(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(4)]
+    players = [
+        player_factory(1500, 500, name=f"p{i+1}", player_id=i+1)
+        for i in range(4)
+    ]
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4 = players
 
@@ -214,18 +219,24 @@ def test_distribute_pairs_1(player_factory):
 
 
 def test_distribute_pairs_2(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(8)]
+    players = [
+        player_factory(1500, 500, name=f"p{i+1}", player_id=i+1)
+        for i in range(8)
+    ]
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4, p5, p6, p7, p8 = players
 
     grouped = [
         search.players for search in algorithm.bucket_teams._distribute(searches, 2)
     ]
-    assert grouped == [[p1, p4], [p2, p3], [p5, p8], [p6, p7]]
+    assert grouped == [[p1, p7], [p2, p8], [p3, p5], [p4, p6]]
 
 
 def test_distribute_triples(player_factory):
-    players = [player_factory(1500, 500, name=f"p{i+1}") for i in range(6)]
+    players = [
+        player_factory(1500, 500, name=f"p{i+1}", player_id=i+1)
+        for i in range(6)
+    ]
     searches = [(Search([player]), 0) for player in players]
     p1, p2, p3, p4, p5, p6 = players
 
@@ -233,7 +244,7 @@ def test_distribute_triples(player_factory):
         search.players for search in algorithm.bucket_teams._distribute(searches, 3)
     ]
 
-    assert grouped == [[p1, p3, p6], [p2, p4, p5]]
+    assert grouped == [[p1, p3, p6], [p2, p5, p4]]
 
 
 def test_BucketTeamMatchmaker_1v1(player_factory):

--- a/tests/unit_tests/test_party_service.py
+++ b/tests/unit_tests/test_party_service.py
@@ -34,7 +34,7 @@ def get_members(party: PlayerParty):
     return set(member.player for member in party)
 
 
-async def test_get_party(party_service, player_factory):
+def test_get_party(party_service, player_factory):
     player = player_factory(player_id=1)
     party = party_service.get_party(player)
 
@@ -43,7 +43,19 @@ async def test_get_party(party_service, player_factory):
     assert party.owner is player
 
 
-async def test_invite_player_to_party(party_service, player_factory):
+def test_get_party_same_id(party_service, player_factory):
+    player1 = player_factory(player_id=1, state=PlayerState.IDLE)
+    player2 = player_factory(player_id=1, state=PlayerState.HOSTING)
+    party1 = party_service.get_party(player1)
+    party2 = party_service.get_party(player2)
+
+    assert party1.players[0] == player1
+    assert party1.players[0].state == PlayerState.IDLE
+    assert party2.players[0] == player2
+    assert party2.players[0].state == PlayerState.HOSTING
+
+
+def test_invite_player_to_party(party_service, player_factory):
     sender = player_factory(player_id=1)
     receiver = player_factory(player_id=2)
 
@@ -231,7 +243,7 @@ async def test_leave_party_then_join_another(party_service, player_factory):
     party_service.invite_player_to_party(player1, player3)
 
 
-async def test_set_factions(party_service, player_factory):
+def test_set_factions(party_service, player_factory):
     sender = player_factory(player_id=1)
     receiver = player_factory(player_id=2)
 
@@ -244,7 +256,7 @@ async def test_set_factions(party_service, player_factory):
     assert party_member.factions == [Faction.uef, Faction.seraphim]
 
 
-async def test_set_factions_creates_party(party_service, player_factory):
+def test_set_factions_creates_party(party_service, player_factory):
     # TODO: Is this really the behavior we want?
     player = player_factory(player_id=1)
 
@@ -252,7 +264,7 @@ async def test_set_factions_creates_party(party_service, player_factory):
     assert player in party_service.player_parties
 
 
-async def test_player_disconnected(party_service, player_factory):
+def test_player_disconnected(party_service, player_factory):
     sender = player_factory(player_id=1, lobby_connection_spec="auto")
     receiver = player_factory(player_id=2)
 

--- a/tests/unit_tests/test_players.py
+++ b/tests/unit_tests/test_players.py
@@ -45,11 +45,12 @@ def test_faction():
     assert p.faction == Faction.aeon
 
 
-def test_equality_by_id():
-    p = Player("Sheeo", 42)
-    p2 = Player("RandomSheeo", 42)
-    assert p == p2
-    assert p.__hash__() == p2.__hash__()
+def test_object_equality():
+    p1 = Player("Arthur", 42)
+    p2 = Player("Arthur", 42)
+    assert p1 == p1
+    assert p1 != p2
+    assert hash(p1) == hash(p1)
 
 
 def test_weak_references():


### PR DESCRIPTION
Removes the custom implementation of the `__hash__` and `__eq__` which seem to have done nothing but cause bugs. The only thing we lose is that `set`'s of Players will no longer be sorted by player id when iterated over. Seems like sets (unlike dicts) still do not preserve insertion order, so I had to change one `to_dict` method to sort the set items by player id.

Closes #893 