### PR TITLE
Set game_id_counter to 0 if no games

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -82,7 +82,8 @@ class GameService(Service):
             # doing LAST_UPDATE_ID to get the id number, and then doing an UPDATE when the actual
             # data to go into the row becomes available: we now only do a single insert for each
             # game, and don't end up with 800,000 junk rows in the database.
-            self.game_id_counter = await conn.scalar("SELECT COALESCE(MAX(id),0) FROM game_stats")
+            sql = "SELECT MAX(id) FROM game_stats"
+            self.game_id_counter = await conn.scalar(sql) or 0
 
     async def update_data(self):
         """

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -82,7 +82,7 @@ class GameService(Service):
             # doing LAST_UPDATE_ID to get the id number, and then doing an UPDATE when the actual
             # data to go into the row becomes available: we now only do a single insert for each
             # game, and don't end up with 800,000 junk rows in the database.
-            self.game_id_counter = await conn.scalar("SELECT MAX(id) FROM game_stats")
+            self.game_id_counter = await conn.scalar("SELECT COALESCE(MAX(id),0) FROM game_stats")
 
     async def update_data(self):
         """

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -1,3 +1,4 @@
+from server.db.models import game_stats
 from server.games import CustomGame, Game, LadderGame, VisibilityState
 from server.players import PlayerState
 
@@ -5,6 +6,16 @@ from server.players import PlayerState
 async def test_initialization(game_service):
     assert len(game_service._dirty_games) == 0
     assert game_service.pop_dirty_games() == set()
+
+
+async def test_initialize_game_counter_empty(game_service, database):
+    async with database.acquire() as conn:
+        await conn.execute("SET FOREIGN_KEY_CHECKS=0")
+        await conn.execute(game_stats.delete())
+
+    await game_service.initialise_game_counter()
+
+    assert game_service.game_id_counter == 0
 
 
 async def test_create_game(players, game_service):


### PR DESCRIPTION
If the game_stats table is empty, the creation of new games will fail. Picking the max(id) of game_stats is null,
but incrementing null by 1 throws an error.