### PR TITLE
Refine matchmaker metrics

### DIFF
--- a/server/game_service.py
+++ b/server/game_service.py
@@ -9,6 +9,7 @@ import aiocron
 from sqlalchemy import select
 
 from server.config import config
+
 from . import metrics
 from .core import Service
 from .db import FAFDatabase

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -203,7 +203,7 @@ class GameService(Service):
 
         for state in GameState:
             for rating_type in rating_type_counter.keys():
-                metrics.active_games_by_rating_type.labels(rating_type).set(
+                metrics.active_games_by_rating_type.labels(rating_type, state.name).set(
                     rating_type_counter[(rating_type, state)]
                 )
 

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -9,7 +9,6 @@ import aiocron
 from sqlalchemy import select
 
 from server.config import config
-
 from . import metrics
 from .core import Service
 from .db import FAFDatabase
@@ -191,6 +190,20 @@ class GameService(Service):
             for mode in modes + ["other"]:
                 metrics.active_games.labels(mode, state.name).set(
                     game_counter[(mode, state)]
+                )
+
+        rating_type_counter = Counter(
+            (
+                game.rating_type,
+                game.state
+            )
+            for game in self._games.values()
+        )
+
+        for state in GameState:
+            for rating_type in rating_type_counter.keys():
+                metrics.active_games_by_rating_type.labels(rating_type).set(
+                    rating_type_counter[(rating_type, state)]
                 )
 
     @property

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -6,14 +6,13 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Optional
 
 import server.metrics as metrics
-
-from ..asyncio_extensions import SpinLock, synchronized
-from ..decorators import with_logger
-from ..players import PlayerState
 from .algorithm.team_matchmaker import TeamMatchMaker
 from .map_pool import MapPool
 from .pop_timer import PopTimer
 from .search import Match, Search
+from ..asyncio_extensions import SpinLock, synchronized
+from ..decorators import with_logger
+from ..players import PlayerState
 
 MatchFoundCallback = Callable[[Search, Search, "MatchmakerQueue"], Any]
 
@@ -189,11 +188,11 @@ class MatchmakerQueue:
             self._report_party_sizes(search2)
 
             rating_imbalance = abs(search1.cumulative_rating - search2.cumulative_rating)
-            metrics.match_rating_imbalance.labels(self.name).set(rating_imbalance)
+            metrics.match_rating_imbalance.labels(self.name).observe(rating_imbalance)
 
             ratings = search1.displayed_ratings + search2.displayed_ratings
             rating_variety = max(ratings) - min(ratings)
-            metrics.match_rating_variety.labels(self.name).set(rating_variety)
+            metrics.match_rating_variety.labels(self.name).observe(rating_variety)
 
             metrics.match_quality.labels(self.name).observe(
                 search1.quality_with(search2)

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -6,13 +6,14 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Optional
 
 import server.metrics as metrics
+
+from ..asyncio_extensions import SpinLock, synchronized
+from ..decorators import with_logger
+from ..players import PlayerState
 from .algorithm.team_matchmaker import TeamMatchMaker
 from .map_pool import MapPool
 from .pop_timer import PopTimer
 from .search import Match, Search
-from ..asyncio_extensions import SpinLock, synchronized
-from ..decorators import with_logger
-from ..players import PlayerState
 
 MatchFoundCallback = Callable[[Search, Search, "MatchmakerQueue"], Any]
 

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -36,16 +36,18 @@ match_quality = Histogram(
     buckets=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0],
 )
 
-match_rating_imbalance = Gauge(
+match_rating_imbalance = Histogram(
     "server_matchmaker_matches_imbalance",
     "Rating difference between the two teams",
     ["queue"],
+    buckets=[50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000],
 )
 
-match_rating_variety = Gauge(
+match_rating_variety = Histogram(
     "server_matchmaker_matches_rating_variety",
     "Maximum rating difference between two players in the game",
     ["queue"],
+    buckets=[100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000],
 )
 
 unmatched_searches = Gauge(
@@ -141,6 +143,14 @@ active_games = Gauge(
     "Includes games in lobby, games currently running, and games that ended "
     "but are still in the game_service.",
     ["game_mode", "game_state"],
+)
+
+active_games_by_rating_type = Gauge(
+    "server_game_active_games_by_rating_type_total",
+    "Number of currently active games by rating type. "
+    "Includes games in lobby, games currently running, and games that ended "
+    "but are still in the game_service.",
+    ["rating_type", "game_state"],
 )
 
 rated_games = Counter(


### PR DESCRIPTION
We need histograms instead of gauges to be able to properly display the match quality in Grafana. The number of currently active matchmaker games is also nice to have.