### PR TITLE
Fix GeoIP cronjob schedule

### DIFF
--- a/server/geoip_service.py
+++ b/server/geoip_service.py
@@ -50,7 +50,7 @@ class GeoIpService(Service):
         # Run every Wednesday because GeoLite2 is updated every first Tuesday
         # of the month.
         self._update_cron = aiocron.crontab(
-            "0 0 0 * * 3", func=self.check_update_geoip_db
+            "0 0 * * 3", func=self.check_update_geoip_db
         )
         self._check_file_timer = Timer(
             60 * 10, self.check_geoip_db_file_updated, start=True


### PR DESCRIPTION
The sixth column is for seconds, so the extra zero caused the cronjob to run everyday at three seconds after midnight instead of every wednesday at midnight