### PR TITLE
Issue/#931 Violation tracking fix

### DIFF
--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -2,7 +2,6 @@ import asyncio
 import math
 import re
 from collections import deque
-from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import select
@@ -24,8 +23,7 @@ from .test_game import (
     queue_players_for_matchmaking,
     queue_temp_players_for_matchmaking,
     read_until_launched,
-    send_player_options,
-    start_search
+    send_player_options
 )
 
 
@@ -568,105 +566,3 @@ async def test_search_info_messages(lobby_server):
 
     with pytest.raises(asyncio.TimeoutError):
         await read_until_command(proto, "search_info", timeout=5)
-
-
-@fast_forward(360)
-async def test_failed_start_ban_guest(mocker, lobby_server):
-    mock_now = mocker.patch(
-        "server.ladder_service.violation_service.datetime_now",
-        return_value=datetime(2022, 2, 5, tzinfo=timezone.utc)
-    )
-    _, host, guest_id, guest = await queue_players_for_matchmaking(lobby_server)
-
-    # The player that queued last will be the host
-    async def launch_game_and_timeout_guest():
-        await read_until_command(host, "game_launch")
-        await open_fa(host)
-        await read_until_command(host, "game_info")
-
-        await read_until_command(guest, "game_launch")
-        await read_until_command(guest, "match_cancelled", timeout=120)
-        await read_until_command(host, "match_cancelled")
-        await host.send_message({
-            "command": "GameState",
-            "target": "game",
-            "args": ["Ended"]
-        })
-
-    await launch_game_and_timeout_guest()
-
-    # Second time searching there is no ban
-    await start_search(host)
-    await start_search(guest)
-    await launch_game_and_timeout_guest()
-
-    # Third time searching there is a short ban
-    await guest.send_message({
-        "command": "game_matchmaking",
-        "state": "start",
-        "queue_name": "ladder1v1"
-    })
-
-    msg = await read_until_command(guest, "search_timeout")
-    assert msg == {
-        "command": "search_timeout",
-        "timeouts": [{
-            "player": guest_id,
-            "expires_at": "2022-02-05T00:10:00+00:00"
-        }]
-    }
-
-    mock_now.return_value = datetime(2022, 2, 5, 0, 10, tzinfo=timezone.utc)
-    await asyncio.sleep(1)
-
-    # Third successful search
-    await start_search(host)
-    await start_search(guest)
-    await launch_game_and_timeout_guest()
-
-    # Fourth time searching there is a long ban
-    await guest.send_message({
-        "command": "game_matchmaking",
-        "state": "start",
-        "queue_name": "ladder1v1"
-    })
-
-    msg = await read_until_command(guest, "search_timeout")
-    assert msg == {
-        "command": "search_timeout",
-        "timeouts": [{
-            "player": guest_id,
-            "expires_at": "2022-02-05T00:40:00+00:00"
-        }]
-    }
-
-    mock_now.return_value = datetime(2022, 2, 5, 0, 40, tzinfo=timezone.utc)
-    await asyncio.sleep(1)
-
-    # Fourth successful search
-    await start_search(host)
-    await start_search(guest)
-    await launch_game_and_timeout_guest()
-
-    # Fifth time searching there is a long ban
-    await guest.send_message({
-        "command": "game_matchmaking",
-        "state": "start",
-        "queue_name": "ladder1v1"
-    })
-
-    msg = await read_until_command(guest, "search_timeout")
-    assert msg == {
-        "command": "search_timeout",
-        "timeouts": [{
-            "player": guest_id,
-            "expires_at": "2022-02-05T01:10:00+00:00"
-        }]
-    }
-
-    msg = await read_until_command(guest, "notice")
-    assert msg == {
-        "command": "notice",
-        "style": "info",
-        "text": "Player ladder2 is timed out for 30 minutes"
-    }

--- a/tests/integration_tests/test_matchmaker_violations.py
+++ b/tests/integration_tests/test_matchmaker_violations.py
@@ -1,0 +1,109 @@
+import asyncio
+from datetime import datetime, timezone
+
+from tests.utils import fast_forward
+
+from .conftest import read_until_command
+from .test_game import open_fa, queue_players_for_matchmaking, start_search
+
+
+@fast_forward(360)
+async def test_violation_for_guest_timeout(mocker, lobby_server):
+    mock_now = mocker.patch(
+        "server.ladder_service.violation_service.datetime_now",
+        return_value=datetime(2022, 2, 5, tzinfo=timezone.utc)
+    )
+    _, host, guest_id, guest = await queue_players_for_matchmaking(lobby_server)
+
+    # The player that queued last will be the host
+    async def launch_game_and_timeout_guest():
+        await read_until_command(host, "game_launch")
+        await open_fa(host)
+        await read_until_command(host, "game_info")
+
+        await read_until_command(guest, "game_launch")
+        await read_until_command(guest, "match_cancelled", timeout=120)
+        await read_until_command(host, "match_cancelled")
+        await host.send_message({
+            "command": "GameState",
+            "target": "game",
+            "args": ["Ended"]
+        })
+
+    await launch_game_and_timeout_guest()
+
+    # Second time searching there is no ban
+    await start_search(host)
+    await start_search(guest)
+    await launch_game_and_timeout_guest()
+
+    # Third time searching there is a short ban
+    await guest.send_message({
+        "command": "game_matchmaking",
+        "state": "start",
+        "queue_name": "ladder1v1"
+    })
+
+    msg = await read_until_command(guest, "search_timeout")
+    assert msg == {
+        "command": "search_timeout",
+        "timeouts": [{
+            "player": guest_id,
+            "expires_at": "2022-02-05T00:10:00+00:00"
+        }]
+    }
+
+    mock_now.return_value = datetime(2022, 2, 5, 0, 10, tzinfo=timezone.utc)
+    await asyncio.sleep(1)
+
+    # Third successful search
+    await start_search(host)
+    await start_search(guest)
+    await launch_game_and_timeout_guest()
+
+    # Fourth time searching there is a long ban
+    await guest.send_message({
+        "command": "game_matchmaking",
+        "state": "start",
+        "queue_name": "ladder1v1"
+    })
+
+    msg = await read_until_command(guest, "search_timeout")
+    assert msg == {
+        "command": "search_timeout",
+        "timeouts": [{
+            "player": guest_id,
+            "expires_at": "2022-02-05T00:40:00+00:00"
+        }]
+    }
+
+    mock_now.return_value = datetime(2022, 2, 5, 0, 40, tzinfo=timezone.utc)
+    await asyncio.sleep(1)
+
+    # Fourth successful search
+    await start_search(host)
+    await start_search(guest)
+    await launch_game_and_timeout_guest()
+
+    # Fifth time searching there is a long ban
+    await guest.send_message({
+        "command": "game_matchmaking",
+        "state": "start",
+        "queue_name": "ladder1v1"
+    })
+
+    msg = await read_until_command(guest, "search_timeout")
+    assert msg == {
+        "command": "search_timeout",
+        "timeouts": [{
+            "player": guest_id,
+            "expires_at": "2022-02-05T01:10:00+00:00"
+        }]
+    }
+
+    msg = await read_until_command(guest, "notice")
+    assert msg == {
+        "command": "notice",
+        "style": "info",
+        "text": "Player ladder2 is timed out for 30 minutes"
+    }

--- a/tests/unit_tests/test_violation_service.py
+++ b/tests/unit_tests/test_violation_service.py
@@ -60,12 +60,13 @@ def test_violation_clear_expired(
     v1 = Violation(time=NOW - timedelta(hours=1))
     v2 = Violation(time=NOW)
 
-    violation_service.violations[p1] = v1
-    violation_service.violations[p2] = v2
+    violation_service.set_violation(p1, v1)
+    violation_service.set_violation(p2, v2)
 
     violation_service.clear_expired()
 
-    assert violation_service.violations == {p2: v2}
+    assert violation_service.get_violation(p1) is None
+    assert violation_service.get_violation(p2) == v2
 
 
 def test_register_violation(
@@ -89,7 +90,21 @@ def test_get_violations_clears_expired(
     player_factory
 ):
     p1 = player_factory("Test3", player_id=1)
+    v1 = Violation(time=NOW - timedelta(hours=1))
 
-    violation_service.violations[p1] = Violation(time=NOW - timedelta(hours=1))
+    violation_service.set_violation(p1, v1)
     violation_service.get_violations([p1])
-    assert violation_service.violations == {}
+    assert violation_service.get_violation(p1) is None
+
+
+def test_violation_tracked_by_player_id(
+    violation_service: ViolationService,
+    player_factory
+):
+    p1 = player_factory("Test", player_id=1)
+    p2 = player_factory("Test_Renamed", player_id=1)
+
+    v1 = Violation(time=NOW - timedelta(hours=1))
+
+    violation_service.set_violation(p1, v1)
+    assert violation_service.get_violation(p2) == v1


### PR DESCRIPTION
The issue isn't with parties but with relogs. Since I refactored the `Player` objects to no longer hash by id because it was causing confusing and incorrect behavior in other parts of the code, using `Player`s as keys directly made the violation service think you were a different player after you relogged. Tracking by player id explicitly should fix this.

Closes #931