### PR TITLE
Fix severe matchmaking bug

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -100,7 +100,7 @@ class ConfigurationStore:
         self.MAXIMUM_TIME_BONUS = 0.2
         self.NEWBIE_TIME_BONUS = 0.25
         self.MAXIMUM_NEWBIE_TIME_BONUS = 3.0
-        self.MINORITY_BONUS = 1.0
+        self.MINORITY_BONUS = 0.7
 
         self.TWILIO_ACCOUNT_SID = ""
         self.TWILIO_TOKEN = ""

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -287,7 +287,7 @@ class TeamMatchMaker(Matchmaker):
                 search_newbie_bonus = search.failed_matching_attempts * config.NEWBIE_TIME_BONUS * num_newbies / team_size
                 newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS * num_newbies / team_size)
 
-                minority_bonus = ((search.average_rating - rating_peak) * 0.001) ** 4 * normalize_size * config.MINORITY_BONUS
+                minority_bonus += ((search.average_rating - rating_peak) * 0.001) ** 4 * normalize_size * config.MINORITY_BONUS
 
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)
         unfairness = rating_disparity / config.MAXIMUM_RATING_IMBALANCE


### PR DESCRIPTION
The minority bonus only got added for one of the parties in a match instead of all. As a result high rated people (and low rated people) had a harder time finding games because of the generally stricter matchmaker settings.
Fixing this showed that the bonus was now a bit overtuned, so I reduced it.