### PR TITLE
Cap minority bonus

### DIFF
--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -289,6 +289,7 @@ class TeamMatchMaker(Matchmaker):
 
                 minority_bonus += ((search.average_rating - rating_peak) * 0.001) ** 4 * normalize_size * config.MINORITY_BONUS
 
+        minority_bonus = min(minority_bonus, config.MINORITY_BONUS)
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)
         unfairness = rating_disparity / config.MAXIMUM_RATING_IMBALANCE
         deviation = statistics.pstdev(ratings)

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -228,7 +228,7 @@ def test_maximum_game_quality_for_even_teams(player):
     team_b = CombinedSearch(*[search] * 4)
     game = TeamMatchMaker().assign_game_quality((team_a, team_b), 4, 1000)
 
-    assert game.quality >= 1.0
+    assert 1.0 <= game.quality <= 1.0 + config.MINORITY_BONUS
 
 
 def test_low_game_quality_for_high_rating_disparity(player_factory):


### PR DESCRIPTION
The recent fix to the minority bonus created a new problem. When there are many high rated people in the queue this bonus actually allows games of too low quality like this one:
![grafik](https://user-images.githubusercontent.com/52536103/208790382-e9f804a6-d943-4a0a-b523-d1152e29f0d7.png)
This is because the bonus is uncapped and grows with the power of 4. This was originally intended to shape the curve in the 0..1 range, but becomes a problem at extreme ratings.
A cap on the bonus allows to prevent this while not changing the bonus for moderately high rated people.