### PR TITLE
Configure server contexts through yaml config

### DIFF
--- a/server.py
+++ b/server.py
@@ -115,9 +115,9 @@ async def main():
     }
     for cfg in config.LISTEN:
         try:
-            host = cfg.get("address", "")
-            port = cfg.get("port", 0)
-            proto_class_name = cfg.get("protocol", QDataStreamProtocol.__name__)
+            host = cfg["ADDRESS"]
+            port = cfg["PORT"]
+            proto_class_name = cfg["PROTOCOL"]
             proto_class = PROTO_CLASSES[proto_class_name]
 
             await instance.listen(

--- a/server.py
+++ b/server.py
@@ -124,17 +124,13 @@ async def main():
                 address=(host, port),
                 protocol_class=proto_class
             )
-        except Exception:
-            logger.exception(
-                "Failed to start server instance with config: %s",
-                cfg
-            )
-            done.set_result(-1)
+        except Exception as e:
+            raise RuntimeError(f"Error with server instance config: {cfg}") from e
 
     if not instance.contexts:
-        logger.warning(
-            "The server was not configured to listen on any ports! No one will "
-            "be able to connect."
+        raise RuntimeError(
+            "The server was not configured to listen on any ports! Check the "
+            "config file and try again."
         )
 
     server.metrics.info.info({

--- a/server.py
+++ b/server.py
@@ -123,7 +123,7 @@ async def main():
         time.perf_counter() - startup_time
     )
 
-    await done
+    exit_code = await done
 
     shutdown_time = time.perf_counter()
 
@@ -133,6 +133,8 @@ async def main():
 
     # Close DB connections
     await database.close()
+
+    return exit_code
 
 
 if __name__ == "__main__":
@@ -162,7 +164,7 @@ if __name__ == "__main__":
         import uvloop
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-    asyncio.run(main())
+    exit_code = asyncio.run(main())
 
     stop_time = time.perf_counter()
     logger.info(
@@ -175,3 +177,8 @@ if __name__ == "__main__":
             "Server shut down in %0.2f seconds",
             stop_time - shutdown_time
         )
+
+    if exit_code:
+        logger.error("Server shut down with exit code: %s", exit_code)
+
+    exit(exit_code)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -274,9 +274,10 @@ class ServerInstance(object):
         )
         for result, ctx in zip(results, self.contexts):
             if isinstance(result, BaseException):
-                self._logger.error(
+                self._logger.exception(
                     "Unexpected error when stopping context %s",
-                    ctx
+                    ctx,
+                    exc_info=result
                 )
 
         results = await asyncio.gather(

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -261,9 +261,9 @@ class ServerInstance(object):
             list(self.services.values()),
             protocol_class
         )
-        self.contexts.add(ctx)
-
         await ctx.listen(*address)
+
+        self.contexts.add(ctx)
 
         return ctx
 

--- a/server/config.py
+++ b/server/config.py
@@ -37,14 +37,14 @@ class ConfigurationStore:
         self.CONFIGURATION_REFRESH_TIME = 300
         self.LISTEN = [
             {
-                "address": "",
-                "port": 8001,
-                "protocol": "QDataStreamProtocol",
+                "ADDRESS": "",
+                "PORT": 8001,
+                "PROTOCOL": "QDataStreamProtocol",
             },
             {
-                "address": "",
-                "port": 8002,
-                "protocol": "SimpleJsonProtocol"
+                "ADDRESS": "",
+                "PORT": 8002,
+                "PROTOCOL": "SimpleJsonProtocol"
             }
         ]
         self.LOG_LEVEL = "DEBUG"

--- a/server/config.py
+++ b/server/config.py
@@ -35,6 +35,18 @@ class ConfigurationStore:
         Change default values here.
         """
         self.CONFIGURATION_REFRESH_TIME = 300
+        self.LISTEN = [
+            {
+                "address": "",
+                "port": 8001,
+                "protocol": "QDataStreamProtocol",
+            },
+            {
+                "address": "",
+                "port": 8002,
+                "protocol": "SimpleJsonProtocol"
+            }
+        ]
         self.LOG_LEVEL = "DEBUG"
         # Whether or not to use uvloop as a drop-in replacement for asyncio's
         # default event loop

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -173,7 +173,7 @@ class ServerContext:
             yield
         except exceptions:
             if hasattr(func, "__self__"):
-                desc = f"{func.__self__.__class__}.{func.__name__}"
+                desc = f"{func.__self__.__class__.__name__}.{func.__name__}"
             else:
                 desc = func.__name__
             self._logger.warning(

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -46,7 +46,7 @@ class ServerContext:
         return f"ServerContext({self.name})"
 
     async def listen(self, host, port):
-        self._logger.debug("%s: listen(%s, %s)", self.name, host, port)
+        self._logger.debug("%s: listen(%r, %r)", self.name, host, port)
 
         self._server = await asyncio.start_server(
             self.client_connected,
@@ -57,6 +57,8 @@ class ServerContext:
 
         for sock in self.sockets:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            host, port, *_ = sock.getsockname()
+            self._logger.info("%s: listening on %s:%s", self.name, host, port)
 
         return self._server
 
@@ -88,9 +90,9 @@ class ServerContext:
         self._logger.debug("%s: All connections closed", self.name)
 
     async def stop(self):
+        self._logger.debug("%s: stop()", self.name)
         self._server.close()
         await self._server.wait_closed()
-        self._logger.debug("%s: stop()", self.name)
 
     def __contains__(self, connection):
         return connection in self.connections

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -95,9 +95,6 @@ class ServerContext:
             self._server.close()
             await self._server.wait_closed()
 
-    def __contains__(self, connection):
-        return connection in self.connections
-
     def write_broadcast(self, message, validate_fn=lambda _: True):
         self.write_broadcast_raw(
             self.protocol_class.encode_message(message),

--- a/server/servercontext.py
+++ b/server/servercontext.py
@@ -91,8 +91,9 @@ class ServerContext:
 
     async def stop(self):
         self._logger.debug("%s: stop()", self.name)
-        self._server.close()
-        await self._server.wait_closed()
+        if self._server:
+            self._server.close()
+            await self._server.wait_closed()
 
     def __contains__(self, connection):
         return connection in self.connections

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -969,7 +969,7 @@ async def test_galactic_war_1v1_game_ended_broadcasts_army_results(
             "args": ["Ended"]
         })
 
-    message = await asyncio.wait_for(mq_proto_all.read_message(), timeout=5)
+    message = await asyncio.wait_for(mq_proto_all.read_message(), timeout=10)
 
     assert message == {
         "game_id": 41956,
@@ -1009,7 +1009,7 @@ async def test_galactic_war_1v1_game_ended_broadcasts_army_results(
 
     with pytest.raises(asyncio.TimeoutError):
         # We expect only one message to be broadcast
-        await asyncio.wait_for(mq_proto_all.read_message(), timeout=5)
+        await asyncio.wait_for(mq_proto_all.read_message(), timeout=10)
 
 
 @pytest.mark.rabbitmq
@@ -1107,7 +1107,7 @@ async def test_galactic_war_2v1_game_ended_broadcasts_army_results(lobby_server,
             "args": ["Ended"]
         })
 
-    message = await asyncio.wait_for(mq_proto_all.read_message(), timeout=5)
+    message = await asyncio.wait_for(mq_proto_all.read_message(), timeout=10)
 
     assert message == {
         "commander_kills": {},
@@ -1153,4 +1153,4 @@ async def test_galactic_war_2v1_game_ended_broadcasts_army_results(lobby_server,
 
     with pytest.raises(asyncio.TimeoutError):
         # We expect only one message to be broadcast
-        await asyncio.wait_for(mq_proto_all.read_message(), timeout=5)
+        await asyncio.wait_for(mq_proto_all.read_message(), timeout=10)

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -99,6 +99,7 @@ async def test_game_launch_message_game_options(lobby_server, tmp_user):
         }
 
 
+@pytest.mark.flaky
 @fast_forward(15)
 async def test_game_matchmaking_start(lobby_server, database):
     host_id, host, guest_id, guest = await queue_players_for_matchmaking(lobby_server)

--- a/tests/unit_tests/test_servercontext.py
+++ b/tests/unit_tests/test_servercontext.py
@@ -1,0 +1,62 @@
+from unittest import mock
+
+import pytest
+
+from server import LobbyConnection, ServerContext
+from server.protocol import Protocol
+
+
+@pytest.fixture
+def context():
+    return ServerContext("TestServer", mock.Mock, [])
+
+
+def test_repr(context):
+    text = repr(context)
+
+    assert context.__class__.__name__ in text
+    assert "TestServer" in text
+
+
+async def test_stop_unstarted(context):
+    context = ServerContext("TestServer", mock.Mock, [])
+
+    await context.stop()
+
+
+def test_write_broadcast_raw_error(context, caplog):
+    conn = mock.create_autospec(LobbyConnection)
+    proto = mock.create_autospec(Protocol)
+    proto.write_raw.side_effect = RuntimeError("test")
+
+    context.connections[conn] = proto
+
+    with caplog.at_level("ERROR"):
+        context.write_broadcast_raw(b"foo")
+
+    assert "TestServer: Encountered error in broadcast" in caplog.text
+
+
+def test_suppress_and_log_regular_function(context, caplog):
+    def on_connection_lost():
+        raise RuntimeError("test")
+
+    with caplog.at_level("WARNING"):
+        with context.suppress_and_log(on_connection_lost, Exception):
+            on_connection_lost()
+
+    assert "Unexpected exception in on_connection_lost" in caplog.text
+
+
+def test_suppress_and_log_bound_method(context, caplog):
+    class SomeClass:
+        def on_connection_lost(self):
+            raise RuntimeError("test")
+
+    obj = SomeClass()
+
+    with caplog.at_level("WARNING"):
+        with context.suppress_and_log(obj.on_connection_lost, Exception):
+            obj.on_connection_lost()
+
+    assert "Unexpected exception in SomeClass.on_connection_lost" in caplog.text


### PR DESCRIPTION
This enables us to set up the lobby ports using the yaml config file. It's not entirely dynamic in that changing the config will still require a server restart to take effect (mostly because it was going to be a little complicated to implement and I felt like it wasn't worth it). This will let us turn off the legacy QDataStream socket whenever we feel like it's time without needing to make a code change.

I also have some plans for a subsequent PR to add a 'v2' port that will be enabled in dev/test configs but not in prod, so we can start deploying some breaking protocol changes running side by side with the stable version to develop against.