### PR TITLE
Change map pool selection

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -130,7 +130,8 @@ class ConfigurationStore:
         self.LADDER_SEARCH_EXPANSION_STEP = 0.05
         self.LADDER_TOP_PLAYER_SEARCH_EXPANSION_MAX = 0.3
         self.LADDER_TOP_PLAYER_SEARCH_EXPANSION_STEP = 0.15
-        # The maximum amount of time in seconds) to wait between pops.
+        self.MAP_POOL_RATING_SELECTION = "mean"  # can also be "min" or "max"
+        # The maximum amount of time in seconds to wait between pops.
         self.QUEUE_POP_TIME_MAX = 90
         # The number of possible matches we would like to have when the queue
         # pops. The queue pop time will be adjusted based on the current rate of

--- a/server/config.py
+++ b/server/config.py
@@ -5,6 +5,7 @@ Server config variables
 import asyncio
 import logging
 import os
+import statistics
 from typing import Callable
 
 import trueskill
@@ -26,6 +27,11 @@ FFA_TEAM = 1
 # see: http://forums.faforever.com/viewtopic.php?f=45&t=11698#p119599
 # Optimum values for ladder here, using them for global as well.
 trueskill.setup(mu=1500, sigma=500, beta=240, tau=10, draw_probability=0.10)
+MAP_POOL_RATING_SELECTION_FUNCTIONS = {
+    "mean": statistics.mean,
+    "min": min,
+    "max": max,
+}
 
 
 @with_logger
@@ -130,8 +136,10 @@ class ConfigurationStore:
         self.LADDER_SEARCH_EXPANSION_STEP = 0.05
         self.LADDER_TOP_PLAYER_SEARCH_EXPANSION_MAX = 0.3
         self.LADDER_TOP_PLAYER_SEARCH_EXPANSION_STEP = 0.15
-        self.MAP_POOL_RATING_SELECTION = "mean"  # can also be "min" or "max"
-        # The maximum amount of time in seconds to wait between pops.
+        # The method for choosing map pool rating
+        # Can be "mean", "min", or "max"
+        self.MAP_POOL_RATING_SELECTION = "mean"
+        # The maximum amount of time in seconds to wait between pops
         self.QUEUE_POP_TIME_MAX = 90
         # The number of possible matches we would like to have when the queue
         # pops. The queue pop time will be adjusted based on the current rate of

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -514,7 +514,7 @@ class LadderService(Service):
             def get_displayed_rating(player: Player) -> float:
                 return player.ratings[queue.rating_type].displayed()
 
-            rating = min(
+            rating = statistics.mean(
                 get_displayed_rating(player) for player in all_players
             )
             pool = queue.get_map_pool_for_rating(rating)

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -510,9 +510,12 @@ class LadderService(Service):
                 queue.id,
                 limit=config.LADDER_ANTI_REPETITION_LIMIT
             )
+
+            def get_displayed_rating(player: Player) -> float:
+                return player.ratings[queue.rating_type].displayed()
+
             rating = min(
-                player.ratings[queue.rating_type].displayed()
-                for player in all_players
+                get_displayed_rating(player) for player in all_players
             )
             pool = queue.get_map_pool_for_rating(rating)
             if not pool:
@@ -532,11 +535,8 @@ class LadderService(Service):
             game.map_file_path = map_path
             game.set_name_unchecked(game_name(team1, team2))
 
-            def get_player_mean(player: Player) -> float:
-                return player.ratings[queue.rating_type].mean
-
-            team1 = sorted(team1, key=get_player_mean)
-            team2 = sorted(team2, key=get_player_mean)
+            team1 = sorted(team1, key=get_displayed_rating)
+            team2 = sorted(team2, key=get_displayed_rating)
 
             # Shuffle the teams such that direct opponents remain the same
             zipped_teams = list(zip(team1, team2))

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -14,7 +14,7 @@ import humanize
 from sqlalchemy import and_, func, select, text, true
 
 from server import metrics
-from server.config import config
+from server.config import MAP_POOL_RATING_SELECTION_FUNCTIONS, config
 from server.core import Service
 from server.db import FAFDatabase
 from server.db.models import (
@@ -515,12 +515,11 @@ class LadderService(Service):
                 return player.ratings[queue.rating_type].displayed()
 
             ratings = (get_displayed_rating(player) for player in all_players)
-            if config.MAP_POOL_RATING_SELECTION == "min":
-                rating = min(ratings)
-            elif config.MAP_POOL_RATING_SELECTION == "max":
-                rating = max(ratings)
-            else:
-                rating = statistics.mean(ratings)
+            func = MAP_POOL_RATING_SELECTION_FUNCTIONS.get(
+                config.MAP_POOL_RATING_SELECTION,
+                statistics.mean
+            )
+            rating = func(ratings)
 
             pool = queue.get_map_pool_for_rating(rating)
             if not pool:

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -514,9 +514,14 @@ class LadderService(Service):
             def get_displayed_rating(player: Player) -> float:
                 return player.ratings[queue.rating_type].displayed()
 
-            rating = statistics.mean(
-                get_displayed_rating(player) for player in all_players
-            )
+            ratings = (get_displayed_rating(player) for player in all_players)
+            if config.MAP_POOL_RATING_SELECTION == "min":
+                rating = min(ratings)
+            elif config.MAP_POOL_RATING_SELECTION == "max":
+                rating = max(ratings)
+            else:
+                rating = statistics.mean(ratings)
+
             pool = queue.get_map_pool_for_rating(rating)
             if not pool:
                 raise RuntimeError(f"No map pool available for rating {rating}!")


### PR DESCRIPTION
Changes the map pool selection from lowest rating to average rating as per request of the matchmaking team.
Also fixes a minor bug I noticed where the slot pairs are only made based on mean rating which can lead to unexpected results for players with high deviation.

I feel like it would be good to have unit tests for this behavior, but I am not sure how to access the relevant variables to check their contents after the method has run.