### PR TITLE
Tune matchmaker minority bonus

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -111,7 +111,8 @@ class ConfigurationStore:
         self.MAXIMUM_TIME_BONUS = 0.2
         self.NEWBIE_TIME_BONUS = 0.25
         self.MAXIMUM_NEWBIE_TIME_BONUS = 3.0
-        self.MINORITY_BONUS = 0.7
+        self.MINORITY_BONUS = 1
+        self.MINORITY_BONUS_RATING_RANGE = 1250
 
         self.TWILIO_ACCOUNT_SID = ""
         self.TWILIO_TOKEN = ""

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -287,7 +287,8 @@ class TeamMatchMaker(Matchmaker):
                 search_newbie_bonus = search.failed_matching_attempts * config.NEWBIE_TIME_BONUS * num_newbies / team_size
                 newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS * num_newbies / team_size)
 
-                minority_bonus += ((search.average_rating - rating_peak) * 0.001) ** 4 * normalize_size * config.MINORITY_BONUS
+                minority_bonus += ((search.average_rating - rating_peak) / config.MINORITY_BONUS_RATING_RANGE) ** 4\
+                                  * normalize_size * config.MINORITY_BONUS
 
         minority_bonus = min(minority_bonus, config.MINORITY_BONUS)
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)

--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -287,8 +287,8 @@ class TeamMatchMaker(Matchmaker):
                 search_newbie_bonus = search.failed_matching_attempts * config.NEWBIE_TIME_BONUS * num_newbies / team_size
                 newbie_bonus += min(search_newbie_bonus, config.MAXIMUM_NEWBIE_TIME_BONUS * num_newbies / team_size)
 
-                minority_bonus += ((search.average_rating - rating_peak) / config.MINORITY_BONUS_RATING_RANGE) ** 4\
-                                  * normalize_size * config.MINORITY_BONUS
+                minority_bonus += (((search.average_rating - rating_peak) / config.MINORITY_BONUS_RATING_RANGE) ** 4 *
+                                   normalize_size * config.MINORITY_BONUS)
 
         minority_bonus = min(minority_bonus, config.MINORITY_BONUS)
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)


### PR DESCRIPTION
Feedback from Blodir showed that we need to increase the rating range over which the minority bonus gets applied to not saturate it too early. To compensate we need to increase it a little again.