### PR TITLE
Kubernetes integration and graceful shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ Options:
 import asyncio
 import logging
 import os
-import platform
 import signal
 import sys
 import time
@@ -22,6 +21,7 @@ from docopt import docopt
 from prometheus_client import start_http_server
 
 import server
+from server import info
 from server.config import config
 from server.control import ControlServer
 from server.game_service import GameService
@@ -44,14 +44,12 @@ def log_signal(func):
 async def main():
     global startup_time, shutdown_time
 
-    version = os.environ.get("VERSION") or "dev"
-    python_version = platform.python_version()
-
     logger.info(
-        "Lobby %s (Python %s) on %s",
-        version,
-        python_version,
-        sys.platform
+        "Lobby %s (Python %s) on %s named %s",
+        info.VERSION,
+        info.PYTHON_VERSION,
+        sys.platform,
+        info.CONTAINER_NAME,
     )
 
     if config.ENABLE_METRICS:
@@ -151,8 +149,8 @@ async def main():
         )
 
     server.metrics.info.info({
-        "version": version,
-        "python_version": python_version,
+        "version": info.VERSION,
+        "python_version": info.PYTHON_VERSION,
         "start_time": datetime.utcnow().strftime("%m-%d %H:%M"),
         "game_uid": str(game_service.game_id_counter)
     })

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from functools import wraps
 
 import humanize
 from docopt import docopt
+from prometheus_client import start_http_server
 
 import server
 from server.config import config
@@ -52,6 +53,10 @@ async def main():
         python_version,
         sys.platform
     )
+
+    if config.ENABLE_METRICS:
+        logger.info("Using prometheus on port: %i", config.METRICS_PORT)
+        start_http_server(config.METRICS_PORT)
 
     loop = asyncio.get_running_loop()
     done = loop.create_future()
@@ -217,7 +222,7 @@ if __name__ == "__main__":
     stop_time = time.perf_counter()
     logger.info(
         "Total server uptime: %s",
-        humanize.naturaldelta(stop_time - startup_time)
+        humanize.precisedelta(stop_time - startup_time)
     )
 
     if shutdown_time is not None:

--- a/main.py
+++ b/main.py
@@ -98,18 +98,15 @@ async def main():
     config.register_callback("PROFILING_DURATION", profiler.refresh)
     config.register_callback("PROFILING_INTERVAL", profiler.refresh)
 
-    await instance.start_services()
+    ctrl_server = await server.run_control_server(instance)
 
-    ctrl_server = await server.run_control_server(player_service, game_service)
+    await instance.start_services()
 
     async def restart_control_server():
         nonlocal ctrl_server
 
         await ctrl_server.shutdown()
-        ctrl_server = await server.run_control_server(
-            player_service,
-            game_service
-        )
+        ctrl_server = await server.run_control_server(instance)
     config.register_callback("CONTROL_SERVER_PORT", restart_control_server)
 
     PROTO_CLASSES = {

--- a/main.py
+++ b/main.py
@@ -150,7 +150,10 @@ async def main():
     shutdown_time = time.perf_counter()
 
     # Cleanup
+    await instance.graceful_shutdown()
+    await instance.drain()
     await instance.shutdown()
+
     await ctrl_server.shutdown()
 
     # Close DB connections

--- a/minikube-example.yaml
+++ b/minikube-example.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: faf-lobby
+  labels:
+    app: faf-lobby
+spec:
+  type: NodePort
+  selector:
+    app: faf-lobby
+  ports:
+  - port: 8001
+    name: qstream
+  - port: 8002
+    name: simplejson
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: faf-lobby
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: faf-lobby
+  template:
+    metadata:
+      labels:
+        app: faf-lobby
+    spec:
+      terminationGracePeriodSeconds: 310
+      containers:
+      - name: faf-python-server
+        image: faf-python-server:graceful
+        imagePullPolicy: Never
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: health
+          initialDelaySeconds: 4
+          periodSeconds: 1
+        ports:
+        - containerPort: 4000
+          name: control
+        - containerPort: 2000
+          name: health
+        - containerPort: 8001
+          name: qstream
+        - containerPort: 8002
+          name: simplejson
+        env:
+          - name: CONFIGURATION_FILE
+            value: /config/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: minikube-dev-config
+          items:
+            - key: config.yaml
+              path: config.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minikube-dev-config
+data:
+  config.yaml: |
+    LOG_LEVEL: TRACE
+    USE_POLICY_SERVER: false
+    QUEUE_POP_TIME_MAX: 30
+    SHUTDOWN_GRACE_PERIOD: 300
+    SHUTDOWN_KICK_IDLE_PLAYERS: true
+
+    DB_SERVER: host.minikube.internal
+    MQ_SERVER: host.minikube.internal

--- a/minikube-example.yaml
+++ b/minikube-example.yaml
@@ -51,6 +51,10 @@ spec:
         env:
           - name: CONFIGURATION_FILE
             value: /config/config.yaml
+          - name: CONTAINER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         volumeMounts:
         - name: config
           mountPath: /config

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -99,7 +99,6 @@ from .asyncio_extensions import map_suppress, synchronizedmethod
 from .broadcast_service import BroadcastService
 from .config import TRACE, config
 from .configuration_service import ConfigurationService
-from .control import run_control_server
 from .core import Service, create_services
 from .db import FAFDatabase
 from .game_service import GameService
@@ -139,10 +138,8 @@ __all__ = (
     "RatingService",
     "ServerInstance",
     "ViolationService",
-    "control",
     "game_service",
     "protocol",
-    "run_control_server",
 )
 
 logger = logging.getLogger("server")

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -90,8 +90,6 @@ import logging
 import time
 from typing import Optional
 
-from prometheus_client import start_http_server
-
 import server.metrics as metrics
 
 from .asyncio_extensions import map_suppress, synchronizedmethod
@@ -142,10 +140,6 @@ __all__ = (
 )
 
 logger = logging.getLogger("server")
-
-if config.ENABLE_METRICS:
-    logger.info("Using prometheus on port: %i", config.METRICS_PORT)
-    start_http_server(config.METRICS_PORT)
 
 
 class ServerInstance(object):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -273,12 +273,27 @@ class ServerInstance(object):
 
         return ctx
 
+    async def graceful_shutdown(self):
+        """
+        Start a graceful shut down of the server.
+
+        1. Notify all services of graceful shutdown
+        """
+        self._logger.info("Initiating graceful shutdown")
+
+        await map_suppress(
+            lambda service: service.graceful_shutdown(),
+            self.services.values(),
+            logger=self._logger,
+            msg="when starting graceful shutdown of service "
+        )
+
     async def shutdown(self):
         """
         Immediately shutdown the server.
 
         1. Stop accepting new connections
-        2. Stop all services and notify players of shutdown
+        2. Stop all services
         3. Close all existing connections
         """
         await self._stop_contexts()
@@ -287,6 +302,12 @@ class ServerInstance(object):
 
         self.contexts.clear()
         self.started = False
+
+    async def drain(self):
+        """
+        Wait for all connections to close.
+        """
+        pass
 
     async def _shutdown_services(self):
         await map_suppress(

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -307,7 +307,12 @@ class ServerInstance(object):
         """
         Wait for all connections to close.
         """
-        pass
+        await asyncio.wait_for(
+            asyncio.gather(
+                *(ctx.drain_connections() for ctx in self.contexts)
+            ),
+            timeout=config.SHUTDOWN_GRACE_PERIOD
+        )
 
     async def _shutdown_services(self):
         await map_suppress(

--- a/server/broadcast_service.py
+++ b/server/broadcast_service.py
@@ -116,3 +116,15 @@ class BroadcastService(Service):
 
     def broadcast_ping(self):
         self.server.write_broadcast({"command": "ping"})
+
+    async def shutdown(self):
+        self.server.write_broadcast({
+            "command": "notice",
+            "style": "info",
+            "text": (
+                "The server has been shut down for maintenance "
+                "but should be back online soon. If you experience any "
+                "problems, please restart your client. <br/><br/>"
+                "We apologize for this interruption."
+            )
+        })

--- a/server/config.py
+++ b/server/config.py
@@ -75,6 +75,7 @@ class ConfigurationStore:
         self.SHUTDOWN_KICK_IDLE_PLAYERS = False
 
         self.CONTROL_SERVER_PORT = 4000
+        self.HEALTH_SERVER_PORT = 2000
         self.METRICS_PORT = 8011
         self.ENABLE_METRICS = False
 

--- a/server/config.py
+++ b/server/config.py
@@ -72,6 +72,7 @@ class ConfigurationStore:
         # on the pod to be larger than this value. With docker compose, use
         # --timeout (-t) to set a longer timeout.
         self.SHUTDOWN_GRACE_PERIOD = 30 * 60
+        self.SHUTDOWN_KICK_IDLE_PLAYERS = False
 
         self.CONTROL_SERVER_PORT = 4000
         self.METRICS_PORT = 8011

--- a/server/config.py
+++ b/server/config.py
@@ -107,6 +107,8 @@ class ConfigurationStore:
         self.FORCE_STEAM_LINK = False
 
         self.ALLOW_PASSWORD_LOGIN = True
+        # How many seconds a connection has to authenticate before being killed
+        self.LOGIN_TIMEOUT = 5 * 60
 
         self.NEWBIE_BASE_MEAN = 500
         self.NEWBIE_MIN_GAMES = 10

--- a/server/config.py
+++ b/server/config.py
@@ -104,9 +104,6 @@ class ConfigurationStore:
         self.FAF_POLICY_SERVER_BASE_URL = "http://faf-policy-server"
         self.USE_POLICY_SERVER = True
 
-        self.FORCE_STEAM_LINK_AFTER_DATE = 1536105599  # 5 september 2018 by default
-        self.FORCE_STEAM_LINK = False
-
         self.ALLOW_PASSWORD_LOGIN = True
         # How many seconds a connection has to authenticate before being killed
         self.LOGIN_TIMEOUT = 5 * 60
@@ -180,10 +177,14 @@ class ConfigurationStore:
                 with open(config_file) as f:
                     new_values.update(yaml.safe_load(f))
             except FileNotFoundError:
-                self._logger.info("No configuration file found at %s", config_file)
+                self._logger.warning(
+                    "No configuration file found at %s",
+                    config_file
+                )
             except TypeError:
                 self._logger.info(
-                    "Configuration file at %s appears to be empty", config_file
+                    "Configuration file at %s appears to be empty",
+                    config_file
                 )
 
         triggered_callback_keys = tuple(

--- a/server/config.py
+++ b/server/config.py
@@ -67,6 +67,11 @@ class ConfigurationStore:
 
         self.DIRTY_REPORT_INTERVAL = 1
         self.PING_INTERVAL = 45
+        # How many seconds to wait for games to end before doing a hard shutdown.
+        # If using kubernetes, you must set terminationGracePeriodSeconds
+        # on the pod to be larger than this value. With docker compose, use
+        # --timeout (-t) to set a longer timeout.
+        self.SHUTDOWN_GRACE_PERIOD = 30 * 60
 
         self.CONTROL_SERVER_PORT = 4000
         self.METRICS_PORT = 8011

--- a/server/core/service.py
+++ b/server/core/service.py
@@ -30,6 +30,17 @@ class Service():
         """
         pass  # pragma: no cover
 
+    async def graceful_shutdown(self) -> None:
+        """
+        Called once after the graceful shutdown period is initiated.
+
+        This signals that the service should stop accepting new events but
+        continue to wait for existing ones to complete normally. The hook
+        funciton `shutdown` will be called after the grace period has ended to
+        fully shutdown the service.
+        """
+        pass  # pragma: no cover
+
     async def shutdown(self) -> None:
         """
         Called once after the server received the shutdown signal.

--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -57,3 +57,9 @@ class AuthenticationError(Exception):
         super().__init__(*args, **kwargs)
         self.message = message
         self.method = method
+
+
+class DisabledError(Exception):
+    """
+    The operation is disabled due to an impending server shutdown.
+    """

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -293,3 +293,16 @@ class GameService(Service):
 
     async def graceful_shutdown(self):
         self._allow_new_games = False
+
+        await self.close_lobby_games()
+
+    async def close_lobby_games(self):
+        self._logger.info("Closing all games currently in lobby")
+        for game in self.pending_games:
+            for game_connection in list(game.connections):
+                # Tell the client to kill the FA process
+                game_connection.player.write_message({
+                    "command": "notice",
+                    "style": "kill"
+                })
+                await game_connection.abort()

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -216,9 +216,16 @@ class GameService(Service):
                 )
 
     @property
+    def all_games(self) -> ValuesView[Game]:
+        return self._games.values()
+
+    @property
     def live_games(self) -> list[Game]:
-        return [game for game in self._games.values()
-                if game.state is GameState.LIVE]
+        return [
+            game
+            for game in self.all_games
+            if game.state is GameState.LIVE
+        ]
 
     @property
     def open_games(self) -> list[Game]:
@@ -233,17 +240,19 @@ class GameService(Service):
 
         The client ignores everything "closed". This property fetches all such not-closed games.
         """
-        return [game for game in self._games.values()
-                if game.state is GameState.LOBBY or game.state is GameState.LIVE]
-
-    @property
-    def all_games(self) -> ValuesView[Game]:
-        return self._games.values()
+        return [
+            game
+            for game in self.all_games
+            if game.state in (GameState.LOBBY, GameState.LIVE)
+        ]
 
     @property
     def pending_games(self) -> list[Game]:
-        return [game for game in self._games.values()
-                if game.state is GameState.LOBBY or game.state is GameState.INITIALIZING]
+        return [
+            game
+            for game in self.all_games
+            if game.state in (GameState.LOBBY, GameState.INITIALIZING)
+        ]
 
     def remove_game(self, game: Game):
         if game.id in self._games:

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -168,7 +168,6 @@ class Game:
         Depending on the state, it is either:
           - (LOBBY) The currently connected players
           - (LIVE) Players who participated in the game
-          - Empty list
         """
         if self.state is GameState.LOBBY:
             return self.get_connected_players()

--- a/server/info.py
+++ b/server/info.py
@@ -1,0 +1,12 @@
+"""
+Static meta information about the container/process
+"""
+
+import os
+import platform
+
+PYTHON_VERSION = platform.python_version()
+
+# Environment variables
+VERSION = os.getenv("VERSION") or "dev"
+CONTAINER_NAME = os.getenv("CONTAINER_NAME") or "faf-python-server"

--- a/server/ladder_service/violation_service.py
+++ b/server/ladder_service/violation_service.py
@@ -91,7 +91,7 @@ class ViolationService(Service):
             })
             extra_text = ""
             if violation.count > 1:
-                delta_text = humanize.naturaldelta(
+                delta_text = humanize.precisedelta(
                     violation.get_ban_expiration() - now
                 )
                 extra_text = f" You can queue again in {delta_text}"

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -257,7 +257,11 @@ class LobbyConnection:
     async def command_matchmaker_info(self, message):
         await self.send({
             "command": "matchmaker_info",
-            "queues": [queue.to_dict() for queue in self.ladder_service.queues.values()]
+            "queues": [
+                queue.to_dict()
+                for queue in self.ladder_service.queues.values()
+                if queue.is_running
+            ]
         })
 
     async def send_game_list(self):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -30,7 +30,12 @@ from .db.models import (
 )
 from .db.models import login as t_login
 from .decorators import timed, with_logger
-from .exceptions import AuthenticationError, BanError, ClientError
+from .exceptions import (
+    AuthenticationError,
+    BanError,
+    ClientError,
+    DisabledError
+)
 from .factions import Faction
 from .game_service import GameService
 from .gameconnection import GameConnection
@@ -203,6 +208,10 @@ class LobbyConnection:
         except ConnectionError as e:
             # Propagate connection errors to the ServerContext error handler.
             raise e
+        except DisabledError:
+            # TODO: Respond with correlation uid for original message
+            await self.send({"command": "disabled", "request": cmd})
+            self._logger.info("Ignoring disabled command: %s", cmd)
         except Exception as ex:  # pragma: no cover
             await self.send({"command": "invalid"})
             self._logger.exception(ex)

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -70,6 +70,10 @@ class MatchmakerQueue:
 
         self.matchmaker = TeamMatchMaker()
 
+    @property
+    def is_running(self) -> bool:
+        return self._is_running
+
     def add_map_pool(
         self,
         map_pool: MapPool,
@@ -102,7 +106,7 @@ class MatchmakerQueue:
         in the queue.
         """
         self._logger.debug("MatchmakerQueue initialized for %s", self.name)
-        while self._is_running:
+        while self.is_running:
             try:
                 await self.timer.next_pop()
 
@@ -268,6 +272,7 @@ class MatchmakerQueue:
 
     def shutdown(self):
         self._is_running = False
+        self.timer.cancel()
 
     def to_dict(self):
         """

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -283,7 +283,10 @@ class MatchmakerQueue:
             "queue_pop_time": datetime.fromtimestamp(
                 self.timer.next_queue_pop, timezone.utc
             ).isoformat(),
-            "queue_pop_time_delta": self.timer.next_queue_pop - time.time(),
+            "queue_pop_time_delta": round(
+                self.timer.next_queue_pop - time.time(),
+                ndigits=2
+            ),
             "num_players": self.num_players,
             "boundary_80s": [search.boundary_80 for search in self._queue.keys()],
             "boundary_75s": [search.boundary_75 for search in self._queue.keys()],

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -2,7 +2,6 @@
 Manages connected and authenticated players
 """
 
-import contextlib
 from typing import Optional, ValuesView
 
 import aiocron
@@ -264,17 +263,6 @@ class PlayerService(Service):
                 "SELECT `user_id` FROM uniqueid_exempt"
             )
             self.uniqueid_exempt = frozenset(map(lambda x: x[0], result))
-
-    async def shutdown(self):
-        for player in self:
-            if player.lobby_connection is not None:
-                with contextlib.suppress(Exception):
-                    player.lobby_connection.write_warning(
-                        "The server has been shut down for maintenance, "
-                        "but should be back online soon. If you experience any "
-                        "problems, please restart your client. <br/><br/>"
-                        "We apologize for this interruption."
-                    )
 
     def on_connection_lost(self, conn: "LobbyConnection") -> None:
         if not conn.player:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from unittest import mock
 import hypothesis
 import pytest
 
+from server import ServerInstance
+from server.broadcast_service import BroadcastService
 from server.config import TRACE, config
 from server.db import FAFDatabase
 from server.game_service import GameService
@@ -307,6 +309,18 @@ async def player_service(database):
     player_service = PlayerService(database)
     await player_service.initialize()
     return player_service
+
+
+@pytest.fixture
+async def broadcast_service(game_service, message_queue_service, player_service):
+    broadcast_service = BroadcastService(
+        mock.create_autospec(ServerInstance),
+        message_queue_service,
+        game_service,
+        player_service
+    )
+    await broadcast_service.initialize()
+    return broadcast_service
 
 
 @pytest.fixture

--- a/tests/data/test_conf.yaml
+++ b/tests/data/test_conf.yaml
@@ -23,9 +23,6 @@ WWW_URL: "https://www.faforever.com"
 CONTENT_URL: "http://content.faforever.com"
 FAF_POLICY_SERVER_BASE_URL: "http://faf-policy-server"
 
-FORCE_STEAM_LINK_AFTER_DATE: 1536105599
-FORCE_STEAM_LINK: false
-
 NEWBIE_BASE_MEAN: 500
 NEWBIE_MIN_GAMES: 10
 TOP_PLAYER_MIN_RATING: 1600

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -26,6 +26,7 @@ from server import (
 from server.config import config
 from server.control import ControlServer
 from server.db.models import login
+from server.health import HealthServer
 from server.protocol import Protocol, QDataStreamProtocol, SimpleJsonProtocol
 from server.servercontext import ServerContext
 from tests.utils import exhaust_callbacks
@@ -255,12 +256,24 @@ def lobby_server_proxy(request, lobby_contexts_proxy):
 
 @pytest.fixture
 async def control_server(lobby_instance):
-    server = ControlServer(
-        lobby_instance,
+    server = ControlServer(lobby_instance)
+    await server.start(
         "127.0.0.1",
         config.CONTROL_SERVER_PORT
     )
-    await server.start()
+
+    yield server
+
+    await server.shutdown()
+
+
+@pytest.fixture
+async def health_server(lobby_instance):
+    server = HealthServer(lobby_instance)
+    await server.start(
+        "127.0.0.1",
+        config.HEALTH_SERVER_PORT
+    )
 
     yield server
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -498,7 +498,7 @@ async def connect_and_sign_in(
     credentials,
     lobby_server: ServerContext,
     address: Optional[tuple[str, int]] = None
-):
+) -> tuple[int, int, Protocol]:
     proto = await connect_client(lobby_server, address)
     session = await get_session(proto)
     await perform_login(proto, credentials)

--- a/tests/integration_tests/test_control_server.py
+++ b/tests/integration_tests/test_control_server.py
@@ -58,16 +58,3 @@ async def test_games(control_server, lobby_server, game_service):
             data = await resp.json()
 
             assert data == [listify(game_service[msg["uid"]].to_dict())]
-
-
-@fast_forward(2)
-async def test_ready(control_server, lobby_instance):
-    url = f"http://{control_server.host}:{control_server.port}/ready"
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url) as resp:
-            assert resp.status == 200
-
-        await lobby_instance.shutdown()
-
-        async with session.get(url) as resp:
-            assert resp.status == 503

--- a/tests/integration_tests/test_control_server.py
+++ b/tests/integration_tests/test_control_server.py
@@ -58,3 +58,16 @@ async def test_games(control_server, lobby_server, game_service):
             data = await resp.json()
 
             assert data == [listify(game_service[msg["uid"]].to_dict())]
+
+
+@fast_forward(2)
+async def test_ready(control_server, lobby_instance):
+    url = f"http://{control_server.host}:{control_server.port}/ready"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            assert resp.status == 200
+
+        await lobby_instance.shutdown()
+
+        async with session.get(url) as resp:
+            assert resp.status == 503

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -36,6 +36,7 @@ async def host_game(
     game_id = int(msg["uid"])
 
     await open_fa(proto)
+    await read_until_command(proto, "HostGame", target="game")
 
     return game_id
 

--- a/tests/integration_tests/test_health_server.py
+++ b/tests/integration_tests/test_health_server.py
@@ -1,0 +1,16 @@
+import aiohttp
+
+from tests.utils import fast_forward
+
+
+@fast_forward(2)
+async def test_ready(health_server, lobby_instance):
+    url = f"http://{health_server.host}:{health_server.port}/ready"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            assert resp.status == 200
+
+        await lobby_instance.shutdown()
+
+        async with session.get(url) as resp:
+            assert resp.status == 503

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -127,7 +127,10 @@ def game_stats_service():
 
 def add_connected_player(game: Game, player):
     game.game_service.player_service[player.id] = player
-    gc = make_mock_game_connection(state=GameConnectionState.CONNECTED_TO_HOST, player=player)
+    gc = make_mock_game_connection(
+        state=GameConnectionState.CONNECTED_TO_HOST,
+        player=player
+    )
     game.set_player_option(player.id, "Army", 0)
     game.set_player_option(player.id, "StartSpot", 0)
     game.set_player_option(player.id, "Team", 0)

--- a/tests/unit_tests/test_broadcast_service.py
+++ b/tests/unit_tests/test_broadcast_service.py
@@ -1,0 +1,5 @@
+
+async def test_broadcast_shutdown(broadcast_service):
+    await broadcast_service.shutdown()
+
+    broadcast_service.server.write_broadcast.assert_called_once()

--- a/tests/unit_tests/test_broadcast_service.py
+++ b/tests/unit_tests/test_broadcast_service.py
@@ -1,5 +1,14 @@
+import asyncio
+
 
 async def test_broadcast_shutdown(broadcast_service):
     await broadcast_service.shutdown()
 
     broadcast_service.server.write_broadcast.assert_called_once()
+
+
+async def test_wait_report_dirties(broadcast_service):
+    await asyncio.wait_for(
+        broadcast_service.wait_report_dirtes(),
+        timeout=1
+    )

--- a/tests/unit_tests/test_broadcast_service.py
+++ b/tests/unit_tests/test_broadcast_service.py
@@ -7,6 +7,14 @@ async def test_broadcast_shutdown(broadcast_service):
     broadcast_service.server.write_broadcast.assert_called_once()
 
 
+async def test_broadcast_ping(broadcast_service):
+    broadcast_service.broadcast_ping()
+
+    broadcast_service.server.write_broadcast.assert_called_once_with(
+        {"command": "ping"}
+    )
+
+
 async def test_wait_report_dirties(broadcast_service):
     await asyncio.wait_for(
         broadcast_service.wait_report_dirtes(),

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -1,4 +1,7 @@
+import pytest
+
 from server.db.models import game_stats
+from server.exceptions import DisabledError
 from server.games import CustomGame, Game, LadderGame, VisibilityState
 from server.players import PlayerState
 
@@ -16,6 +19,15 @@ async def test_initialize_game_counter_empty(game_service, database):
     await game_service.initialise_game_counter()
 
     assert game_service.game_id_counter == 0
+
+
+async def test_graceful_shutdown(game_service):
+    await game_service.graceful_shutdown()
+
+    with pytest.raises(DisabledError):
+        game_service.create_game(
+            game_mode="faf",
+        )
 
 
 async def test_create_game(players, game_service):

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -585,7 +585,7 @@ async def test_command_admin_closeFA(lobbyconnection, player_factory):
         "user_id": tuna.id
     })
 
-    tuna.lobby_connection.send.assert_any_call({
+    tuna.lobby_connection.write.assert_any_call({
         "command": "notice",
         "style": "kill",
     })

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from server.lobbyconnection import LobbyConnection
-from server.protocol import DisconnectedError
 from server.rating import RatingType
 
 
@@ -112,27 +110,3 @@ async def test_mark_dirty(player_factory, player_service):
 async def test_update_data(player_service):
     await player_service.update_data()
     assert player_service.is_uniqueid_exempt(1) is True
-
-
-async def test_broadcast_shutdown(player_factory, player_service):
-    player = player_factory()
-    lconn = mock.create_autospec(LobbyConnection)
-    player.lobby_connection = lconn
-    player_service[0] = player
-
-    await player_service.shutdown()
-
-    player.lobby_connection.write_warning.assert_called_once()
-
-
-async def test_broadcast_shutdown_error(player_factory, player_service):
-    player = player_factory()
-    lconn = mock.create_autospec(LobbyConnection)
-    lconn.write_warning.side_effect = DisconnectedError
-    player.lobby_connection = lconn
-
-    player_service[0] = player
-
-    await player_service.shutdown()
-
-    player.lobby_connection.write_warning.assert_called_once()


### PR DESCRIPTION
Adds a graceful shutdown mode where the server will stop allowing new games to be created and wait until all active games have completed before shutting down normally. The grace period time before a hard shutdown happens can be configured or short circuited by sending a second `SIGTERM` or `SIGINT` to the process.

Also adds a kubernetes health check server on port 2000 by default that will ensure kubernetes waits long enough for the server to start before sending over new traffic. 

Closes #469