### PR TITLE
Add game id to rating change message

### DIFF
--- a/server/rating_service/rating_service.py
+++ b/server/rating_service/rating_service.py
@@ -187,6 +187,7 @@ class RatingService(Service):
 
         for rating_result in rating_results:
             await self._publish_rating_changes(
+                rating_result.game_id,
                 rating_result.rating_type,
                 rating_result.old_ratings,
                 rating_result.new_ratings,
@@ -248,6 +249,7 @@ class RatingService(Service):
         )
 
         return GameRatingResult(
+            game_id,
             rating_type,
             old_ratings,
             new_ratings,
@@ -456,6 +458,7 @@ class RatingService(Service):
 
     async def _publish_rating_changes(
         self,
+        game_id: int,
         rating_type: str,
         old_ratings: RatingDict,
         new_ratings: RatingDict,
@@ -472,6 +475,7 @@ class RatingService(Service):
             old_rating = old_ratings[player_id]
 
             rating_change_dict = {
+                "game_id": game_id,
                 "player_id": player_id,
                 "rating_type": rating_type,
                 "new_rating_mean": new_rating.mean,

--- a/server/rating_service/typedefs.py
+++ b/server/rating_service/typedefs.py
@@ -41,6 +41,7 @@ class GameRatingSummary(NamedTuple):
 
 
 class GameRatingResult(NamedTuple):
+    game_id: int
     rating_type: str
     old_ratings: RatingDict
     new_ratings: RatingDict

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -366,6 +366,7 @@ async def test_game_ended_broadcasts_rating_update(lobby_server, channel):
     new_persisted_ratings = await get_player_ratings(host_proto, "test", "Rhiza")
 
     rhiza_message = {
+        "game_id": 41956,
         "player_id": 3,  # Rhiza
         "rating_type": "global",
         "new_rating_mean": new_persisted_ratings["Rhiza"][0],
@@ -376,6 +377,7 @@ async def test_game_ended_broadcasts_rating_update(lobby_server, channel):
     }
 
     test_message = {
+        "game_id": 41956,
         "player_id": 1,  # test
         "rating_type": "global",
         "new_rating_mean": new_persisted_ratings["test"][0],


### PR DESCRIPTION
right now the league service has no way of knowing which game is associated with a rating change message. This is a problem because the client can't know which entry to fetch from the league score journal when the client wants to display a specific replay.

We add the game id to the message to fix this.