### PR TITLE
Add `pipenv verify` to lint actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,3 +39,18 @@ jobs:
         with:
           flake8_version: 6.0.0
           plugins: flake8-quotes~=3.3
+
+  pipenv-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install pipenv
+
+      - run: pipenv verify


### PR DESCRIPTION
This should help to make sure the pipfile.lock stays properly updated. Pipenv will verify that the hash in the pipfile.lock matches certain data from the Pipfile, so if a dependency is added or removed in the Pipfile, the pipfile.lock needs to be updated as well.