### PR TITLE
Add `hosted_at` field to game_info message

### DIFF
--- a/e2e_tests/test_matchmaking.py
+++ b/e2e_tests/test_matchmaking.py
@@ -57,6 +57,7 @@ async def test_ladder_1v1_match(client_factory):
         "sim_mods": {},
         "num_players": 0,
         "max_players": 2,
+        "hosted_at": None,
         "launched_at": None,
         "rating_type": "ladder_1v1",
         "rating_min": None,

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -26,6 +26,7 @@ from server.games.game_results import (
     resolve_game
 )
 from server.rating import InclusiveRange, RatingType
+from server.timing import datetime_now
 
 from ..players import Player, PlayerState
 from .typedefs import (
@@ -78,6 +79,7 @@ class Game:
         self._game_stats_service = game_stats_service
         self.game_service = game_service
         self._player_options: dict[int, dict[str, Any]] = defaultdict(dict)
+        self.hosted_at = None
         self.launched_at = None
         self.finished = False
         self._logger = logging.getLogger(
@@ -264,6 +266,7 @@ class Game:
 
     def set_hosted(self):
         self._hosted_future.set_result(None)
+        self.hosted_at = datetime_now()
 
     async def add_result(
         self,
@@ -894,6 +897,7 @@ class Game:
             "host": self.host.login if self.host else "",
             "num_players": len(connected_players),
             "max_players": self.max_players,
+            "hosted_at": self.hosted_at.isoformat() if self.hosted_at else None,
             "launched_at": self.launched_at,
             "rating_type": self.rating_type,
             "rating_min": self.displayed_rating_range.lo,

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -624,6 +624,7 @@ async def test_to_dict(game, player_factory):
         "host": game.host.login,
         "num_players": len(game.players),
         "max_players": game.max_players,
+        "hosted_at": None,
         "launched_at": game.launched_at,
         "rating_type": game.rating_type,
         "rating_min": game.displayed_rating_range.lo,


### PR DESCRIPTION
Feature is being requested in the client now https://github.com/FAForever/downlords-faf-client/issues/3054 and the issue is almost 6 years old on the server. Since it's like 3 lines of code, here you go.

Closes #333 
Closes #892