### PR TITLE
Issue/#890 Add 'flaky' package to rerun flaky tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,6 +1,6 @@
 [scripts]
 devserver = "python main.py --configuration-file dev-config.yml"
-tests = "py.test --doctest-modules --doctest-continue-on-failure --cov-report=term-missing --cov-branch --cov=server --mysql_database=faf -o testpaths=tests -m 'not rabbitmq'"
+tests = "py.test --doctest-modules --doctest-continue-on-failure --no-flaky-report --cov-report=term-missing --cov-branch --cov=server --mysql_database=faf -o testpaths=tests -m 'not rabbitmq'"
 e2e = "py.test -o testpaths=e2e_tests"
 vulture = "vulture main.py server/ --sort-by-size"
 doc = "pdoc3 --html --force server"
@@ -29,6 +29,7 @@ trueskill = "*"
 uvloop = {version = "*", markers = "sys_platform != 'win32'"}
 
 [dev-packages]
+flaky = "*"
 hypothesis = "*"  # Versions between 6.47.1 and 6.56.4 added a prerelease dependency. See https://github.com/pypa/pipenv/issues/1760
 pdoc3 = "*"
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "45212a314b0079d6993e0b0fe9c852d4f35e1e02e37cb5100afeed01be3f4af1"
+            "sha256": "4d529b570c113ec473c190611dff3214e3c53b6e91cb90fd53d49249c2638849"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -394,11 +394,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
-                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
+                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.4"
+            "version": "==3.6"
         },
         "maxminddb": {
             "hashes": [
@@ -982,6 +982,15 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==1.2.0"
+        },
+        "flaky": {
+            "hashes": [
+                "sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d",
+                "sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.7.0"
         },
         "hypothesis": {
             "hashes": [


### PR DESCRIPTION
The pytest log output seems to get a little garbled when a flaky test fails twice so in the case of a real issue it may be necessary to run the test locally without the 'flaky' package in order to be able to make sense of the logs for debugging.

The test report generated by the 'flaky' package also seems to be completely unhelpful so I disabled it using the command line switch.

Closes #890