### PR TITLE
Add ban appeal notice to ban messages

### DIFF
--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -34,7 +34,9 @@ class BanError(Exception):
     def message(self):
         return (
             f"You are banned from FAF {self._ban_duration_text()}. <br>"
-            f"Reason: <br>{self.ban_reason}"
+            f"Reason: <br>{self.ban_reason}<br><br>"
+            "<i>If you would like to appeal this ban, please send an email to: "
+            "moderation@faforever.com</i>"
         )
 
     def _ban_duration_text(self):

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -39,7 +39,11 @@ async def test_server_ban(lobby_server, user):
     assert msg == {
         "command": "notice",
         "style": "error",
-        "text": "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
+        "text": (
+            "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
+            "<br><br><i>If you would like to appeal this ban, please send an "
+            "email to: moderation@faforever.com</i>"
+        )
     }
 
 

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -11,7 +11,7 @@ from .conftest import (
 )
 
 
-async def test_server_invalid_login(lobby_server):
+async def test_server_login_invalid(lobby_server):
     proto = await connect_client(lobby_server)
     # Try a user that doesn't exist
     await perform_login(proto, ("Cat", "epic"))
@@ -53,7 +53,7 @@ async def test_server_ban_revoked_or_expired(lobby_server, user):
     assert msg["login"] == user
 
 
-async def test_server_valid_login(lobby_server):
+async def test_server_login_valid(lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ("Rhiza", "puff_the_magic_dragon"))
     msg = await proto.read_message()
@@ -98,7 +98,7 @@ async def test_server_valid_login(lobby_server):
     }
 
 
-async def test_server_valid_login_admin(lobby_server):
+async def test_server_login_valid_admin(lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ("test", "test_password"))
     msg = await proto.read_message()
@@ -143,7 +143,7 @@ async def test_server_valid_login_admin(lobby_server):
     }
 
 
-async def test_server_valid_login_moderator(lobby_server):
+async def test_server_login_valid_moderator(lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ("moderator", "moderator"))
     msg = await proto.read_message()
@@ -202,7 +202,7 @@ async def test_policy_server_contacted(lobby_server, policy_server, player_servi
     policy_server.verify.assert_called_once()
 
 
-async def test_server_double_login(lobby_server):
+async def test_server_login_double(lobby_server):
     proto = await connect_client(lobby_server)
     await perform_login(proto, ("test", "test_password"))
     msg = await proto.read_message()
@@ -222,7 +222,7 @@ async def test_server_double_login(lobby_server):
     }
 
 
-async def test_server_valid_login_with_token(lobby_server, jwk_priv_key, jwk_kid):
+async def test_server_login_token_valid(lobby_server, jwk_priv_key, jwk_kid):
     proto = await connect_client(lobby_server)
     await proto.send_message({
         "command": "auth",
@@ -285,7 +285,7 @@ async def test_server_valid_login_with_token(lobby_server, jwk_priv_key, jwk_kid
     }
 
 
-async def test_server_login_bad_id_in_token(lobby_server, jwk_priv_key, jwk_kid):
+async def test_server_login_token_bad_id(lobby_server, jwk_priv_key, jwk_kid):
     proto = await connect_client(lobby_server)
     await proto.send_message({
         "command": "auth",
@@ -311,7 +311,7 @@ async def test_server_login_bad_id_in_token(lobby_server, jwk_priv_key, jwk_kid)
     }
 
 
-async def test_server_login_expired_token(lobby_server, jwk_priv_key, jwk_kid):
+async def test_server_login_token_expired(lobby_server, jwk_priv_key, jwk_kid):
     proto = await connect_client(lobby_server)
     await proto.send_message({
         "command": "auth",
@@ -333,7 +333,7 @@ async def test_server_login_expired_token(lobby_server, jwk_priv_key, jwk_kid):
     }
 
 
-async def test_server_login_malformed_token(lobby_server, jwk_priv_key, jwk_kid):
+async def test_server_login_token_malformed(lobby_server, jwk_priv_key, jwk_kid):
     """This scenario could only happen if the hydra signed a token that
     was missing critical data"""
     proto = await connect_client(lobby_server)
@@ -355,7 +355,11 @@ async def test_server_login_malformed_token(lobby_server, jwk_priv_key, jwk_kid)
     }
 
 
-async def test_server_login_lobby_scope_missing(lobby_server, jwk_priv_key, jwk_kid):
+async def test_server_login_token_lobby_scope_missing(
+    lobby_server,
+    jwk_priv_key,
+    jwk_kid,
+):
     """This scenario could only happen if the hydra signed a token that
     was missing critical data"""
     proto = await connect_client(lobby_server)

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -793,7 +793,11 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
     assert msg == {
         "command": "notice",
         "style": "error",
-        "text": "You are banned from FAF forever. <br>Reason: <br>Test live ban"
+        "text": (
+            "You are banned from FAF forever. <br>Reason: <br>Test live ban<br>"
+            "<br><i>If you would like to appeal this ban, please send an email "
+            "to: moderation@faforever.com</i>"
+        )
     }
 
 

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1076,8 +1076,11 @@ async def test_abort_connection_if_banned(
     lobbyconnection.player.id = 203
     with pytest.raises(BanError) as banned_error:
         await lobbyconnection.abort_connection_if_banned()
-    assert banned_error.value.message() == \
+    assert banned_error.value.message() == (
         "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
+        "<br><br><i>If you would like to appeal this ban, please send an email "
+        "to: moderation@faforever.com</i>"
+    )
 
     # test user who is banned for another 46 hours
     lobbyconnection.player.id = 204


### PR DESCRIPTION
There's not much space in the notification message dialog so part of the message gets hidden and you have to scroll to see the email:
![image](https://github.com/FAForever/server/assets/17941539/3fe10d1f-2046-45b7-bb04-5e0f8037630b)

Also adds checking for bans when users log in with a token. It shouldn't come up often but it's possible for a user to get a valid token immediately before the ban is issued. The token will then be valid for 1 hour which would previously allow them to log in even if they're banned.
