### PR TITLE
Refactor game options handling / Issue/#859 game title constraints

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ aio_pika = "~=8.2"
 aiocron = "*"
 aiohttp = "*"
 aiomysql = {git = "https://github.com/aio-libs/aiomysql"}
+cachetools = "*"
 docopt = "*"
 humanize = ">=2.6.0"
 maxminddb = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4d529b570c113ec473c190611dff3214e3c53b6e91cb90fd53d49249c2638849"
+            "sha256": "fbf667c3fa0630610daae2298439d383883041c04a430f2c17a66fc02e641701"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -151,6 +151,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==23.1.0"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:086ee420196f7b2ab9ca2db2520aca326318b68fe5ba8bc4d49cca91add450f2",
+                "sha256:861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==5.3.2"
         },
         "cffi": {
             "hashes": [

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -7,14 +7,15 @@ from collections import Counter
 from typing import Optional, Union, ValuesView
 
 import aiocron
-from sqlalchemy import select
+from cachetools import LRUCache
+from sqlalchemy import func, select
 
 from server.config import config
 
 from . import metrics
 from .core import Service
 from .db import FAFDatabase
-from .db.models import game_featuredMods
+from .db.models import game_featuredMods, map_version
 from .decorators import with_logger
 from .exceptions import DisabledError
 from .games import (
@@ -30,6 +31,7 @@ from .matchmaker import MatchmakerQueue
 from .message_queue_service import MessageQueueService
 from .players import Player
 from .rating_service import RatingService
+from .types import MAP_DEFAULT, Map, NeroxisGeneratedMap
 
 
 @with_logger
@@ -62,6 +64,9 @@ class GameService(Service):
 
         # A set of mod ids that are allowed in ranked games
         self.ranked_mods: set[str] = set()
+
+        # A cache of map_version info needed by Game
+        self.map_info_cache = LRUCache(maxsize=256)
 
         # The set of active games
         self._games: dict[int, Game] = dict()
@@ -120,6 +125,44 @@ class GameService(Service):
             # Turn resultset into a list of uids
             self.ranked_mods = {row.uid for row in result}
 
+    async def get_map(self, folder_name: str) -> Map:
+        folder_name = folder_name.lower()
+        filename = f"maps/{folder_name}.zip"
+
+        map = self.map_info_cache.get(filename)
+        if map is not None:
+            return map
+
+        async with self._db.acquire() as conn:
+            result = await conn.execute(
+                select(
+                    map_version.c.id,
+                    map_version.c.filename,
+                    map_version.c.ranked,
+                )
+                .where(
+                    func.lower(map_version.c.filename) == filename
+                )
+            )
+            row = result.fetchone()
+            if not row:
+                # The map requested is not in the database. This is fine as
+                # players may be using privately shared or generated maps that
+                # are not in the vault.
+                return Map(
+                    id=None,
+                    folder_name=folder_name,
+                    ranked=NeroxisGeneratedMap.is_neroxis_map(folder_name),
+                )
+
+            map = Map(
+                id=row.id,
+                folder_name=folder_name,
+                ranked=row.ranked
+            )
+            self.map_info_cache[filename] = map
+            return map
+
     def mark_dirty(self, obj: Union[Game, MatchmakerQueue]):
         if isinstance(obj, Game):
             self._dirty_games.add(obj)
@@ -150,7 +193,7 @@ class GameService(Service):
         visibility=VisibilityState.PUBLIC,
         host: Optional[Player] = None,
         name: Optional[str] = None,
-        mapname: Optional[str] = None,
+        map: Map = MAP_DEFAULT,
         password: Optional[str] = None,
         matchmaker_queue_id: Optional[int] = None,
         **kwargs
@@ -164,10 +207,10 @@ class GameService(Service):
         game_id = self.create_uid()
         game_args = {
             "database": self._db,
-            "id_": game_id,
+            "id": game_id,
             "host": host,
             "name": name,
-            "map_": mapname,
+            "map": map,
             "game_mode": game_mode,
             "game_service": self,
             "game_stats_service": self.game_stats_service,

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -59,7 +59,7 @@ class GameService(Service):
         self._allow_new_games = False
         self._drain_event = None
 
-        # Populated below in really_update_static_ish_data.
+        # Populated below in update_data.
         self.featured_mods = dict()
 
         # A set of mod ids that are allowed in ranked games
@@ -101,14 +101,16 @@ class GameService(Service):
         time we need, but which can in principle change over time.
         """
         async with self._db.acquire() as conn:
-            rows = await conn.execute(select(
-                game_featuredMods.c.id,
-                game_featuredMods.c.gamemod,
-                game_featuredMods.c.name,
-                game_featuredMods.c.description,
-                game_featuredMods.c.publish,
-                game_featuredMods.c.order
-            ).select_from(game_featuredMods))
+            rows = await conn.execute(
+                select(
+                    game_featuredMods.c.id,
+                    game_featuredMods.c.gamemod,
+                    game_featuredMods.c.name,
+                    game_featuredMods.c.description,
+                    game_featuredMods.c.publish,
+                    game_featuredMods.c.order
+                )
+            )
 
             for row in rows:
                 self.featured_mods[row.gamemod] = FeaturedMod(
@@ -120,7 +122,9 @@ class GameService(Service):
                     row.order
                 )
 
-            result = await conn.execute("SELECT uid FROM table_mod WHERE ranked = 1")
+            result = await conn.execute(
+                "SELECT uid FROM table_mod WHERE ranked = 1"
+            )
 
             # Turn resultset into a list of uids
             self.ranked_mods = {row.uid for row in result}

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -21,8 +21,7 @@ from .games import (
     GameConnectionState,
     GameError,
     GameState,
-    ValidityState,
-    Victory
+    ValidityState
 )
 from .games.typedefs import FA
 from .player_service import PlayerService
@@ -228,23 +227,7 @@ class GameConnection(GpgNetServerProtocol):
         if not self.is_host():
             return
 
-        if key == "Victory":
-            self.game.gameOptions["Victory"] = Victory.__members__.get(
-                value.upper(), None
-            )
-        else:
-            self.game.gameOptions[key] = value
-
-        if key == "Slots":
-            self.game.max_players = int(value)
-        elif key == "ScenarioFile":
-            raw = repr(value)
-            map_scenario_path = raw.replace("\\", "/").replace("//", "/").replace("'", "")
-            map_folder_name = map_scenario_path.split("/")[2].lower()
-            self.game.map = await self.game_service.get_map(map_folder_name)
-        elif key == "Title":
-            with contextlib.suppress(ValueError):
-                self.game.name = value
+        await self.game.game_options.set_option(key, value)
 
         self._mark_dirty()
 

--- a/server/games/__init__.py
+++ b/server/games/__init__.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 
 from .coop import CoopGame
 from .custom_game import CustomGame
-from .game import Game, GameError
+from .game import Game, GameError, GameOptions
 from .ladder_game import LadderGame
 from .typedefs import (
     FeaturedModType,
@@ -37,6 +37,7 @@ __all__ = (
     "Game",
     "GameConnectionState",
     "GameError",
+    "GameOptions",
     "GameState",
     "GameType",
     "InitMode",

--- a/server/games/coop.py
+++ b/server/games/coop.py
@@ -12,7 +12,7 @@ class CoopGame(Game):
         super().__init__(*args, **kwargs)
 
         self.validity = ValidityState.COOP_NOT_RANKED
-        self.gameOptions.update({
+        self.game_options.update({
             "Victory": Victory.SANDBOX,
             "TeamSpawn": "fixed",
             "RevealedCivilians": "No",

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -12,13 +12,13 @@ class CustomGame(Game):
     init_mode = InitMode.NORMAL_LOBBY
     game_type = GameType.CUSTOM
 
-    def __init__(self, id_, *args, **kwargs):
+    def __init__(self, id, *args, **kwargs):
         new_kwargs = {
             "rating_type": RatingType.GLOBAL,
             "setup_timeout": 30
         }
         new_kwargs.update(kwargs)
-        super().__init__(id_, *args, **new_kwargs)
+        super().__init__(id, *args, **new_kwargs)
 
     async def _run_pre_rate_validity_checks(self):
         limit = len(self.players) * 60

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -359,8 +359,6 @@ class Game:
                 return
 
             self._players_with_unsent_army_stats.remove(player)
-            # Stat processing contacts the API and can take quite a while so
-            # we don't want to await it
             asyncio.create_task(
                 self._game_stats_service.process_game_stats(
                     player, self, self._army_stats_list
@@ -688,12 +686,13 @@ class Game:
         await self._validate_game_options(valid_options)
 
     async def _validate_game_options(
-        self, valid_options: dict[str, tuple[Any, ValidityState]]
+        self,
+        valid_options: dict[str, tuple[Any, ValidityState]]
     ) -> bool:
         for key, value in self.game_options.items():
             if key in valid_options:
-                (valid_value, validity_state) = valid_options[key]
-                if valid_value != self.game_options[key]:
+                valid_value, validity_state = valid_options[key]
+                if value != valid_value:
                     await self.mark_invalid(validity_state)
                     return False
         return True
@@ -743,8 +742,8 @@ class Game:
         modId = self.game_service.featured_mods[self.game_mode].id
 
         # Write out the game_stats record.
-        # In some cases, games can be invalidated while running: we check for those cases when
-        # the game ends and update this record as appropriate.
+        # In some cases, games can be invalidated while running: we check for
+        # those cases when the game ends and update this record as appropriate.
 
         game_type = str(self.game_options.get("Victory").value)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -164,8 +164,13 @@ class Game:
         """
         Verifies that names only contain ascii characters.
         """
+        value = value.strip()
+
         if not value.isascii():
-            raise ValueError("Name must be ascii!")
+            raise ValueError("Game title must be ascii!")
+
+        if not value:
+            raise ValueError("Game title must not be empty!")
 
         self.set_name_unchecked(value)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -905,6 +905,7 @@ class Game:
             "featured_mod": self.game_mode,
             "sim_mods": self.mods,
             "mapname": self.map.folder_name,
+            # DEPRECATED: Use `mapname` instead
             "map_file_path": self.map.file_path,
             "host": self.host.login if self.host else "",
             "num_players": len(connected_players),

--- a/server/games/ladder_game.py
+++ b/server/games/ladder_game.py
@@ -27,8 +27,8 @@ class LadderGame(Game):
     init_mode = InitMode.AUTO_LOBBY
     game_type = GameType.MATCHMAKER
 
-    def __init__(self, id_, *args, **kwargs):
-        super().__init__(id_, *args, **kwargs)
+    def __init__(self, id, *args, **kwargs):
+        super().__init__(id, *args, **kwargs)
         self._launch_future = asyncio.Future()
 
     async def wait_hosted(self, timeout: float):

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -563,7 +563,7 @@ class LadderService(Service):
 
             game_options = queue.get_game_options()
             if game_options:
-                game.gameOptions.update(game_options)
+                game.game_options.update(game_options)
 
             self._logger.debug("Starting ladder game: %s", game)
 

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -143,8 +143,9 @@ class LadderService(Service):
                 map_pool_maps[id_] = (name, list())
             _, map_list = map_pool_maps[id_]
             if row.map_id is not None:
-                # FIXME: Database filenames contain the maps/ prefix and .zip suffix.
-                # Really in the future, just send a better description
+                # Database filenames contain the maps/ prefix and .zip suffix.
+                # This comes from the content server which hosts the files at
+                # https://content.faforever.com/maps/name.zip
                 folder_name = re.match(r"maps/(.+)\.zip", row.filename).group(1)
                 map_list.append(
                     Map(

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -22,10 +22,7 @@ from server.db.models import (
     game_player_stats,
     game_stats,
     leaderboard,
-    leaderboard_rating_journal
-)
-from server.db.models import map as t_map
-from server.db.models import (
+    leaderboard_rating_journal,
     map_pool,
     map_pool_map_version,
     map_version,
@@ -132,11 +129,10 @@ class LadderService(Service):
                 map_pool_map_version.c.map_params,
                 map_version.c.id.label("map_id"),
                 map_version.c.filename,
-                t_map.c.display_name
+                map_version.c.ranked,
             ).select_from(
                 map_pool.outerjoin(map_pool_map_version)
                 .outerjoin(map_version)
-                .outerjoin(t_map)
             )
         )
         map_pool_maps = {}
@@ -147,8 +143,16 @@ class LadderService(Service):
                 map_pool_maps[id_] = (name, list())
             _, map_list = map_pool_maps[id_]
             if row.map_id is not None:
+                # FIXME: Database filenames contain the maps/ prefix and .zip suffix.
+                # Really in the future, just send a better description
+                folder_name = re.match(r"maps/(.+)\.zip", row.filename).group(1)
                 map_list.append(
-                    Map(row.map_id, row.display_name, row.filename, row.weight)
+                    Map(
+                        id=row.map_id,
+                        folder_name=folder_name,
+                        ranked=row.ranked,
+                        weight=row.weight,
+                    )
                 )
             elif row.map_params is not None:
                 try:
@@ -518,19 +522,19 @@ class LadderService(Service):
             pool = queue.get_map_pool_for_rating(rating)
             if not pool:
                 raise RuntimeError(f"No map pool available for rating {rating}!")
-            _, _, map_path, _ = pool.choose_map(played_map_ids)
+            game_map = pool.choose_map(played_map_ids)
 
             game = self.game_service.create_game(
                 game_class=LadderGame,
                 game_mode=queue.featured_mod,
                 host=host,
                 name="Matchmaker Game",
+                map=game_map,
                 matchmaker_queue_id=queue.id,
                 rating_type=queue.rating_type,
-                max_players=len(all_players)
+                max_players=len(all_players),
             )
             game.init_mode = InitMode.AUTO_LOBBY
-            game.map_file_path = map_path
             game.set_name_unchecked(game_name(team1, team2))
 
             team1 = sorted(team1, key=get_displayed_rating)
@@ -561,15 +565,11 @@ class LadderService(Service):
             if game_options:
                 game.gameOptions.update(game_options)
 
-            mapname = re.match("maps/(.+).zip", map_path).group(1)
-            # FIXME: Database filenames contain the maps/ prefix and .zip suffix.
-            # Really in the future, just send a better description
-
             self._logger.debug("Starting ladder game: %s", game)
 
             def make_game_options(player: Player) -> GameLaunchOptions:
                 return GameLaunchOptions(
-                    mapname=mapname,
+                    mapname=game_map.folder_name,
                     expected_players=len(all_players),
                     game_options=game_options,
                     team=game.get_player_option(player.id, "Team"),

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -952,6 +952,7 @@ class LobbyConnection:
 
         mod = message.get("mod") or FeaturedModType.FAF
         mapname = message.get("mapname") or "scmp_007"
+        game_map = await self.game_service.get_map(mapname)
         password = message.get("password")
         game_mode = mod.lower()
         rating_min = message.get("rating_min")
@@ -970,7 +971,7 @@ class LobbyConnection:
             game_class=game_class,
             host=self.player,
             name=title,
-            mapname=mapname,
+            map=game_map,
             password=password,
             rating_type=RatingType.GLOBAL,
             displayed_rating_range=InclusiveRange(rating_min, rating_max),

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -949,6 +949,8 @@ class LobbyConnection:
         title = message.get("title") or f"{self.player.login}'s game"
         if not title.isascii():
             raise ClientError("Title must contain only ascii characters.")
+        if not title.strip():
+            raise ClientError("Title must not be empty.")
 
         mod = message.get("mod") or FeaturedModType.FAF
         mapname = message.get("mapname") or "scmp_007"

--- a/tests/integration_tests/test_coop.py
+++ b/tests/integration_tests/test_coop.py
@@ -9,18 +9,18 @@ from .conftest import connect_and_sign_in, read_until, read_until_command
 from .test_game import host_game, send_player_options
 
 
-@fast_forward(5)
+@fast_forward(100)
 async def test_host_coop_game(lobby_server):
     _, _, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
     )
 
-    await read_until_command(proto, "game_info")
+    await read_until_command(proto, "game_info", timeout=10)
 
     await host_game(proto, mod="coop", title="")
 
-    msg = await read_until_command(proto, "game_info")
+    msg = await read_until_command(proto, "game_info", timeout=10)
 
     assert msg["title"] == "test's game"
     assert msg["mapname"] == "scmp_007"
@@ -29,7 +29,7 @@ async def test_host_coop_game(lobby_server):
     assert msg["game_type"] == "coop"
 
 
-@fast_forward(30)
+@fast_forward(100)
 async def test_single_player_game_recorded(lobby_server, database):
     test_id, _, proto = await connect_and_sign_in(
         ("test", "test_password"), lobby_server

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -175,7 +175,6 @@ async def test_graceful_shutdown(
     lobby_instance,
     lobby_server,
     tmp_user,
-    monkeypatch
 ):
     _, _, proto = await connect_and_sign_in(
         await tmp_user("Player"),
@@ -622,7 +621,7 @@ async def test_info_broadcast_to_rabbitmq(lobby_server, channel):
     _, _, proto = await connect_and_sign_in(
         ("test", "test_password"), lobby_server
     )
-    await read_until_command(proto, "game_info")
+    await read_until_command(proto, "game_info", timeout=10)
     # matchmaker_info is broadcast whenever the timer pops
     await read_until_command(mq_proto_all, "matchmaker_info")
 
@@ -640,6 +639,7 @@ async def test_info_broadcast_to_rabbitmq(lobby_server, channel):
     ("ban_expired", "ban_expired"),
     ("No_UID", "his_pw")
 ])
+@fast_forward(10)
 async def test_game_host_authenticated(lobby_server, user):
     _, _, proto = await connect_and_sign_in(user, lobby_server)
     await read_until_command(proto, "game_info")
@@ -651,15 +651,15 @@ async def test_game_host_authenticated(lobby_server, user):
         "visibility": "public",
     })
 
-    msg = await read_until_command(proto, "game_launch")
+    msg = await read_until_command(proto, "game_launch", timeout=10)
 
     assert msg["mod"] == "faf"
     assert "args" in msg
     assert isinstance(msg["uid"], int)
 
 
-@fast_forward(5)
-async def test_host_missing_fields(event_loop, lobby_server, player_service):
+@fast_forward(10)
+async def test_host_missing_fields(lobby_server):
     player_id, session, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
@@ -671,10 +671,10 @@ async def test_host_missing_fields(event_loop, lobby_server, player_service):
         "command": "game_host",
         "mod": "",
         "visibility": "public",
-        "title": ""
+        "title": "",
     })
 
-    msg = await read_until_command(proto, "game_info")
+    msg = await read_until_command(proto, "game_info", timeout=10)
 
     assert msg["title"] == "test's game"
     assert msg["game_type"] == "custom"

--- a/tests/unit_tests/test_coop_game.py
+++ b/tests/unit_tests/test_coop_game.py
@@ -1,15 +1,19 @@
 from unittest import mock
 
 from server.games import CoopGame
+from server.types import Map
 
 
 async def test_create_coop_game(database):
     CoopGame(
-        id_=0,
+        id=0,
         database=database,
         host=mock.Mock(),
         name="Some game",
-        map_="some_map",
+        map=Map(
+            id=None,
+            folder_name="some_map"
+        ),
         game_mode="coop",
         game_service=mock.Mock(),
         game_stats_service=mock.Mock()

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -8,12 +8,14 @@ from tests.unit_tests.conftest import add_connected_players
 
 
 @pytest.fixture
-async def custom_game(event_loop, database, game_service, game_stats_service):
+async def custom_game(database, game_service, game_stats_service):
     return CustomGame(42, database, game_service, game_stats_service)
 
 
 async def test_rate_game_early_abort_no_enforce(
-        game_service, game_stats_service, custom_game, player_factory):
+    custom_game: CustomGame,
+    player_factory
+):
     custom_game.state = GameState.LOBBY
     players = [
         player_factory("Dostya", player_id=1, global_rating=(1500, 500)),
@@ -32,7 +34,9 @@ async def test_rate_game_early_abort_no_enforce(
 
 
 async def test_rate_game_early_abort_with_enforce(
-        game_service, game_stats_service, custom_game, player_factory):
+    custom_game: CustomGame,
+    player_factory,
+):
     custom_game.state = GameState.LOBBY
     players = [
         player_factory("Dostya", player_id=1, global_rating=(1500, 500)),
@@ -52,7 +56,9 @@ async def test_rate_game_early_abort_with_enforce(
 
 
 async def test_rate_game_late_abort_no_enforce(
-        game_service, game_stats_service, custom_game, player_factory):
+    custom_game: CustomGame,
+    player_factory,
+):
     custom_game.state = GameState.LOBBY
     players = [
         player_factory("Dostya", player_id=1, global_rating=(1500, 500)),
@@ -71,7 +77,10 @@ async def test_rate_game_late_abort_no_enforce(
 
 
 async def test_global_rating_higher_after_custom_game_win(
-        custom_game: CustomGame, game_add_players, rating_service):
+    custom_game: CustomGame,
+    game_add_players,
+    rating_service,
+):
     game = custom_game
     game.state = GameState.LOBBY
     players = game_add_players(game, 2)

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -22,6 +22,7 @@ from server.games import (
 from server.games.game_results import ArmyOutcome
 from server.games.typedefs import FeaturedModType
 from server.rating import InclusiveRange, RatingType
+from server.types import Map
 from tests.unit_tests.conftest import (
     add_connected_player,
     add_connected_players,
@@ -168,7 +169,11 @@ async def test_ffa_not_rated(game, game_add_players):
 
 async def test_generated_map_is_rated(game, game_add_players):
     game.state = GameState.LOBBY
-    game.map_file_path = "maps/neroxis_map_generator_1.0.0_1234.zip"
+    game.map = Map(
+        None,
+        "neroxis_map_generator_1.0.0_23g6m_aiea",
+        ranked=True
+    )
     game_add_players(game, 2, team=1)
     await game.launch()
     await game.add_result(0, 1, "victory", 5)
@@ -179,7 +184,7 @@ async def test_generated_map_is_rated(game, game_add_players):
 
 async def test_unranked_generated_map_not_rated(game, game_add_players):
     game.state = GameState.LOBBY
-    game.map_file_path = "maps/neroxis_map_generator_sneaky_map.zip"
+    game.map = Map(None, "neroxis_map_generator_sneaky_map")
     game_add_players(game, 2, team=1)
     await game.launch()
     await game.add_result(0, 1, "victory", 5)
@@ -643,8 +648,8 @@ async def test_to_dict(game, player_factory):
         "state": "playing",
         "featured_mod": game.game_mode,
         "sim_mods": game.mods,
-        "mapname": game.map_folder_name,
-        "map_file_path": game.map_file_path,
+        "mapname": game.map.folder_name,
+        "map_file_path": game.map.file_path,
         "host": game.host.login,
         "num_players": len(game.players),
         "max_players": game.max_players,
@@ -1010,7 +1015,7 @@ async def test_game_results(game: Game, players):
             }
         ]
     assert result_dict["game_id"] == game.id
-    assert result_dict["map_id"] == game.map_id
+    assert result_dict["map_id"] == game.map.id
     assert result_dict["featured_mod"] == "faf"
     assert result_dict["sim_mod_ids"] == []
 

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -142,11 +142,11 @@ async def check_game_settings(
     game: Game, settings: list[tuple[str, Any, ValidityState]]
 ):
     for key, value, expected in settings:
-        old = game.gameOptions.get(key)
-        game.gameOptions[key] = value
+        old = game.game_options.get(key)
+        game.game_options[key] = value
         await game.validate_game_settings()
         assert game.validity is expected
-        game.gameOptions[key] = old
+        game.game_options[key] = old
 
 
 async def test_add_result_unknown(game, game_add_players):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -263,7 +263,6 @@ async def test_single_team_not_rated(game, game_add_players):
     n_players = 4
     game.state = GameState.LOBBY
     game_add_players(game, n_players, team=2)
-    print(game._player_options)
     await game.launch()
     game.launched_at = time.time() - 60 * 20
     for i in range(n_players):
@@ -799,6 +798,7 @@ async def test_get_army_score_conflicting_results_tied(game, game_add_players):
 async def test_equality(game):
     assert game == game
     assert game != Game(5, mock.Mock(), mock.Mock(), mock.Mock())
+    assert game != "a string"
 
 
 async def test_hashing(game):

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -613,6 +613,12 @@ async def test_name_sanitization(game, players):
     with pytest.raises(ValueError):
         game.name = "Hello ⏴⏵⏶⏷⏸⏹⏺⏻♿"
 
+    with pytest.raises(ValueError):
+        game.name = "    \n\n\t"
+
+    with pytest.raises(ValueError):
+        game.name = ""
+
     game.name = "A" * 256
     assert game.name == "A" * 128
 

--- a/tests/unit_tests/test_game_options.py
+++ b/tests/unit_tests/test_game_options.py
@@ -1,0 +1,119 @@
+import asyncio
+import pathlib
+from unittest import mock
+
+import pytest
+
+from server.games import GameOptions, Victory
+
+
+@pytest.fixture
+def game_options() -> GameOptions:
+    return GameOptions(0)
+
+
+def test_type_transformations(game_options):
+    game_options["Victory"] = "sandbox"
+    assert game_options["Victory"] is Victory.SANDBOX
+
+    game_options["Slots"] = "10"
+    assert game_options["Slots"] == 10
+
+    game_options["ScenarioFile"] = "/maps/map_name/map_name_scenario.lua"
+    assert game_options["ScenarioFile"] == pathlib.PurePath(
+        "/maps/map_name/map_name_scenario.lua"
+    )
+
+
+def test_type_transformations_invalid(game_options, caplog):
+    with caplog.at_level("WARNING"):
+        game_options["Victory"] = "invalid"
+
+    assert "Invalid victory type 'invalid'! Using 'None' instead." in caplog.messages
+    assert "Victory" not in game_options
+
+    with pytest.raises(ValueError):
+        game_options["Slots"] = "foobar"
+
+    assert "Slots" not in game_options
+
+
+async def test_callbacks(game_options):
+    callback = mock.Mock()
+    callback2 = mock.Mock()
+    async_callback = mock.AsyncMock()
+
+    game_options.add_callback("OneCallback", callback)
+    game_options.add_callback("ManyCallbacks", callback)
+    game_options.add_callback("ManyCallbacks", callback2)
+    game_options.add_async_callback("ManyCallbacks", async_callback)
+
+    game_options["OneCallback"] = "Some Value"
+    callback.assert_called_once_with("Some Value")
+
+    game_options["ManyCallbacks"] = "Another Value"
+    callback.assert_called_with("Another Value")
+    callback2.assert_called_once_with("Another Value")
+    async_callback.assert_called_once_with("Another Value")
+
+    async_callback.assert_not_awaited()
+    await asyncio.sleep(0)
+    async_callback.assert_awaited_once_with("Another Value")
+
+
+async def test_await_callbacks(game_options):
+    callback = mock.Mock()
+    callback2 = mock.Mock()
+    async_callback = mock.AsyncMock()
+
+    game_options.add_callback("OneCallback", callback)
+    game_options.add_callback("ManyCallbacks", callback)
+    game_options.add_callback("ManyCallbacks", callback2)
+    game_options.add_async_callback("ManyCallbacks", async_callback)
+
+    await game_options.set_option("OneCallback", "Some Value")
+    callback.assert_called_once_with("Some Value")
+
+    await game_options.set_option("ManyCallbacks", "Another Value")
+    callback.assert_called_with("Another Value")
+    callback2.assert_called_once_with("Another Value")
+    async_callback.assert_awaited_once_with("Another Value")
+
+
+async def test_callback_error(game_options, caplog):
+    callback = mock.Mock()
+    async_callback = mock.AsyncMock()
+
+    def raises_error(_):
+        raise RuntimeError("test")
+
+    game_options.add_callback("Foo", raises_error)
+    game_options.add_callback("Foo", callback)
+    game_options.add_async_callback("Foo", async_callback)
+
+    with caplog.at_level("TRACE"):
+        game_options["Foo"] = "Some Value"
+
+    callback.assert_called_once_with("Some Value")
+    async_callback.assert_called_once_with("Some Value")
+    assert "Error running callback for 'Foo' (value 'Some Value')" in caplog.messages
+
+
+async def test_async_callback_error(game_options, caplog):
+    callback = mock.Mock()
+    async_callback = mock.AsyncMock()
+
+    async def async_raises_error(_):
+        raise RuntimeError("test")
+
+    game_options.add_callback("Foo", callback)
+    game_options.add_async_callback("Foo", async_raises_error)
+    game_options.add_async_callback("Foo", async_callback)
+
+    with caplog.at_level("TRACE"):
+        game_options["Foo"] = "Some Value"
+        await asyncio.sleep(0)
+
+    callback.assert_called_once_with("Some Value")
+    async_callback.assert_called_once_with("Some Value")
+    assert "Error running async callback for 'Foo' (value 'Some Value')" in caplog.messages

--- a/tests/unit_tests/test_game_rating.py
+++ b/tests/unit_tests/test_game_rating.py
@@ -120,14 +120,14 @@ def get_published_results_by_player_id(mock_service):
 
 
 @pytest.fixture
-async def game(event_loop, database, game_service, game_stats_service):
+async def game(database, game_service, game_stats_service):
     return Game(
         42, database, game_service, game_stats_service, rating_type=RatingType.GLOBAL
     )
 
 
 @pytest.fixture
-async def custom_game(event_loop, database, game_service, game_stats_service):
+async def custom_game(database, game_service, game_stats_service):
     return CustomGame(42, database, game_service, game_stats_service)
 
 

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -19,6 +19,7 @@ from server.games import (
 )
 from server.players import PlayerState
 from server.protocol import DisconnectedError
+from server.types import Map
 from tests.utils import exhaust_callbacks
 
 
@@ -140,13 +141,12 @@ async def test_handle_action_GameState_lobby_sends_HostGame(
     players
 ):
     game_connection.player = players.hosting
-    game.map_file_path = "maps/some_map.zip"
-    game.map_folder_name = "some_map"
+    game.map = Map(None, "some_map")
 
     await game_connection.handle_action("GameState", ["Lobby"])
     await exhaust_callbacks(event_loop)
 
-    assert_message_sent(game_connection, "HostGame", [game.map_folder_name])
+    assert_message_sent(game_connection, "HostGame", [game.map.folder_name])
 
 
 async def test_handle_action_GameState_lobby_calls_ConnectToHost(
@@ -160,8 +160,6 @@ async def test_handle_action_GameState_lobby_calls_ConnectToHost(
     game_connection.player = players.joining
     players.joining.game = game
     game.host = players.hosting
-    game.map_file_path = "maps/some_map.zip"
-    game.map_folder_name = "some_map"
 
     await game_connection.handle_action("GameState", ["Lobby"])
     await exhaust_callbacks(event_loop)
@@ -183,8 +181,7 @@ async def test_handle_action_GameState_lobby_calls_ConnectToPeer(
     players.joining.game = game
 
     game.host = players.hosting
-    game.map_file_path = "maps/some_map.zip"
-    game.map_folder_name = "some_map"
+    game.map = Map(None, "some_map")
     peer_conn = mock.Mock()
     players.peer.game_connection = peer_conn
     game.connections = [peer_conn]
@@ -229,8 +226,7 @@ async def test_handle_action_GameState_lobby_calls_abort(
     players.joining.game = game
     game.host = players.hosting
     game.host.state = PlayerState.IDLE
-    game.map_file_path = "maps/some_map.zip"
-    game.map_folder_name = "some_map"
+    game.map = Map(None, "some_map")
 
     await game_connection.handle_action("GameState", ["Lobby"])
     await exhaust_callbacks(event_loop)
@@ -415,7 +411,7 @@ async def test_handle_action_GameOption(
     assert game.max_players == 7
     # I don't know what these paths actually look like
     await game_connection.handle_action("GameOption", ["ScenarioFile", "C:\\Maps\\Some_Map"])
-    assert game.map_file_path == "maps/some_map.zip"
+    assert game.map.file_path == "maps/some_map.zip"
     await game_connection.handle_action("GameOption", ["Title", "All welcome"])
     assert game.name == "All welcome"
     await game_connection.handle_action("GameOption", ["ArbitraryKey", "ArbitraryValue"])
@@ -525,7 +521,7 @@ async def test_handle_action_OperationComplete(
     database,
 ):
     coop_game.id = 1  # reuse existing corresponding game_stats row
-    coop_game.map_file_path = "maps/prothyon16.v0005.zip"
+    coop_game.map = Map(None, "prothyon16.v0005")
     game_connection.game = coop_game
     time_taken = "09:08:07.654321"
 
@@ -549,7 +545,7 @@ async def test_handle_action_OperationComplete(
 async def test_handle_action_OperationComplete_primary_incomplete(
     primary, coop_game: CoopGame, game_connection: GameConnection, database
 ):
-    coop_game.map_file_path = "maps/prothyon16.v0005.zip"
+    coop_game.map = Map(None, "prothyon16.v0005")
     game_connection.game = coop_game
     time_taken = "09:08:07.654321"
 
@@ -572,7 +568,7 @@ async def test_handle_action_OperationComplete_primary_incomplete(
 async def test_handle_action_OperationComplete_non_coop_game(
     ugame: Game, game_connection: GameConnection, database
 ):
-    ugame.map_file_path = "maps/prothyon16.v0005.zip"
+    ugame.map = Map(None, "prothyon16.v0005")
     game_connection.game = ugame
     time_taken = "09:08:07.654321"
 
@@ -595,7 +591,7 @@ async def test_handle_action_OperationComplete_non_coop_game(
 async def test_handle_action_OperationComplete_invalid(
     coop_game: CoopGame, game_connection: GameConnection, database
 ):
-    coop_game.map_file_path = "maps/prothyon16.v0005.zip"
+    coop_game.map = Map(None, "prothyon16.v0005")
     coop_game.validity = ValidityState.OTHER_UNRANK
     game_connection.game = coop_game
     time_taken = "09:08:07.654321"
@@ -619,7 +615,7 @@ async def test_handle_action_OperationComplete_invalid(
 async def test_handle_action_OperationComplete_duplicate(
     coop_game: CoopGame, game_connection: GameConnection, database, caplog
 ):
-    coop_game.map_file_path = "maps/prothyon16.v0005.zip"
+    coop_game.map = Map(None, "prothyon16.v0005")
     game_connection.game = coop_game
     time_taken = "09:08:07.654321"
 

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -24,7 +24,7 @@ from tests.utils import exhaust_callbacks
 
 
 @pytest.fixture
-async def real_game(event_loop, database, game_service, game_stats_service):
+async def real_game(database, game_service, game_stats_service):
     return Game(42, database, game_service, game_stats_service)
 
 

--- a/tests/unit_tests/test_games_service.py
+++ b/tests/unit_tests/test_games_service.py
@@ -12,6 +12,7 @@ from server.games import (
     VisibilityState
 )
 from server.players import PlayerState
+from server.types import Map
 from tests.unit_tests.conftest import add_connected_player
 from tests.utils import fast_forward
 
@@ -37,6 +38,8 @@ async def test_graceful_shutdown(game_service):
     with pytest.raises(DisabledError):
         game_service.create_game(
             game_mode="faf",
+            map=Map(None, "SCMP_007"),
+
         )
 
 
@@ -66,7 +69,7 @@ async def test_create_game(players, game_service):
         game_mode="faf",
         host=players.hosting,
         name="Test",
-        mapname="SCMP_007",
+        map=Map(None, "SCMP_007"),
         password=None
     )
     assert game is not None
@@ -83,7 +86,7 @@ async def test_all_games(players, game_service):
         game_mode="faf",
         host=players.hosting,
         name="Test",
-        mapname="SCMP_007",
+        map=Map(None, "SCMP_007"),
         password=None
     )
     assert game in game_service.pending_games
@@ -110,7 +113,7 @@ async def test_create_game_other_gamemode(players, game_service):
         game_mode="labwars",
         host=players.hosting,
         name="Test",
-        mapname="SCMP_007",
+        map=Map(None, "SCMP_007"),
         password=None
     )
     assert game is not None
@@ -125,7 +128,7 @@ async def test_close_lobby_games(players, game_service):
         game_mode="faf",
         host=players.hosting,
         name="Test",
-        mapname="SCMP_007",
+        map=Map(None, "SCMP_007"),
         password=None
     )
     game.state = GameState.LOBBY

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -190,8 +190,8 @@ async def test_start_game_with_game_options(
 
     assert game.rating_type == queue.rating_type
     assert game.max_players == 2
-    assert game.gameOptions["Share"] == "ShareUntilDeath"
-    assert game.gameOptions["UnitCap"] == 500
+    assert game.game_options["Share"] == "ShareUntilDeath"
+    assert game.game_options["UnitCap"] == 500
 
     LadderGame.wait_launched.assert_called_once()
 

--- a/tests/unit_tests/test_ladder_service.py
+++ b/tests/unit_tests/test_ladder_service.py
@@ -59,21 +59,21 @@ async def test_load_from_database(ladder_service, queue_factory):
         assert queue.rating_peak == 1000.0
         assert len(queue.map_pools) == 3
         assert list(queue.map_pools[1][0].maps.values()) == [
-            Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
-            Map(id=16, name="SCMP_015", path="maps/scmp_015.v0002.zip"),
-            Map(id=17, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
+            Map(15, "scmp_015", ranked=True),
+            Map(16, "scmp_015.v0002", ranked=True),
+            Map(17, "scmp_015.v0003", ranked=True),
         ]
         assert list(queue.map_pools[2][0].maps.values()) == [
-            Map(id=11, name="SCMP_011", path="maps/scmp_011.zip"),
-            Map(id=14, name="SCMP_014", path="maps/scmp_014.zip"),
-            Map(id=15, name="SCMP_015", path="maps/scmp_015.zip"),
-            Map(id=16, name="SCMP_015", path="maps/scmp_015.v0002.zip"),
-            Map(id=17, name="SCMP_015", path="maps/scmp_015.v0003.zip"),
+            Map(11, "scmp_011", ranked=True),
+            Map(14, "scmp_014", ranked=True),
+            Map(15, "scmp_015", ranked=True),
+            Map(16, "scmp_015.v0002", ranked=True),
+            Map(17, "scmp_015.v0003", ranked=True),
         ]
         assert list(queue.map_pools[3][0].maps.values()) == [
-            Map(id=1, name="SCMP_001", path="maps/scmp_001.zip"),
-            Map(id=2, name="SCMP_002", path="maps/scmp_002.zip"),
-            Map(id=3, name="SCMP_003", path="maps/scmp_003.zip"),
+            Map(1, "scmp_001", ranked=True),
+            Map(2, "scmp_002", ranked=True),
+            Map(3, "scmp_003", ranked=True),
         ]
 
         queue = ladder_service.queues["neroxis1v1"]
@@ -444,7 +444,7 @@ async def test_start_game_start_spots(
         rating_type=RatingType.GLOBAL
     )
     queue.add_map_pool(
-        MapPool(1, "test", [Map(1, "scmp_007", "maps/scmp_007.zip")]),
+        MapPool(1, "test", [Map(1, "scmp_007")]),
         min_rating=None,
         max_rating=None
     )

--- a/tests/unit_tests/test_laddergame.py
+++ b/tests/unit_tests/test_laddergame.py
@@ -14,7 +14,7 @@ from tests.unit_tests.test_game import add_connected_players
 @pytest.fixture()
 async def laddergame(database, game_service, game_stats_service):
     return LadderGame(
-        id_=465312,
+        id=465312,
         database=database,
         game_service=game_service,
         game_stats_service=game_stats_service,

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -242,7 +242,7 @@ async def test_command_game_host_creates_game(
         "host": players.hosting,
         "visibility": VisibilityState.PUBLIC,
         "password": test_game_info["password"],
-        "mapname": test_game_info["mapname"],
+        "map": await mock_games.get_map(test_game_info["mapname"]),
         "rating_type": RatingType.GLOBAL,
         "displayed_rating_range": InclusiveRange(None, None),
         "enforce_rating_range": False

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -78,8 +78,7 @@ def mock_geoip():
 
 
 @pytest.fixture
-def lobbyconnection(
-    event_loop,
+async def lobbyconnection(
     database,
     mock_protocol,
     mock_games,
@@ -288,7 +287,6 @@ async def test_command_game_host_creates_correct_game(
 
 
 async def test_command_game_join_calls_join_game(
-    mocker,
     database,
     lobbyconnection,
     game_service,

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -36,6 +36,7 @@ def test_choose_map(map_pool_factory):
         assert chosen_map == Map(4, "choose_me.v001")
 
 
+@pytest.mark.flaky
 def test_choose_map_with_weights(map_pool_factory):
     map_pool = map_pool_factory(maps=[
         Map(1, "some_map.v001", weight=1),


### PR DESCRIPTION
This takes a few ideas that were started in #900 and reworks them into a standalone PR. Map data is now fetched when the game is created and immediately whenever the map is changed. This will allow us to update the validity for unranked maps immediately instead of waiting until the game is launched to perform that check. Since the map data may be accessed more frequently now, we cache it in the game service using an LRU cache.

Closes #859 