### PR TITLE
Issue/#993 use single player validity state again

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -645,14 +645,12 @@ class Game:
         """
         A subset of checks that need to be overridden in coop games.
         """
-        if None in self.teams or not self.is_even:
-            await self.mark_invalid(ValidityState.UNEVEN_TEAMS_NOT_RANKED)
-            return
-
-        # TODO: This validity state seems to be impossible to get because it is
-        # already covered by UNEVEN_TEAMS_NOT_RANKED above.
         if len(self.players) < 2:
             await self.mark_invalid(ValidityState.SINGLE_PLAYER)
+            return
+
+        if None in self.teams or not self.is_even:
+            await self.mark_invalid(ValidityState.UNEVEN_TEAMS_NOT_RANKED)
             return
 
         valid_options = {

--- a/tests/unit_tests/test_game.py
+++ b/tests/unit_tests/test_game.py
@@ -274,7 +274,7 @@ async def test_single_player_not_rated(game, game_add_players):
     game.launched_at = time.time() - 60 * 20
     await game.add_result(0, 0, "victory", 5)
     await game.on_game_finish()
-    assert game.validity is ValidityState.UNEVEN_TEAMS_NOT_RANKED
+    assert game.validity is ValidityState.SINGLE_PLAYER
 
 
 async def test_game_visible_to_host(game: Game, players):


### PR DESCRIPTION
Swaps the order of the single player and uneven teams checks so that single player takes priority. Previously, the single player check would never happen because uneven teams would take precedence.

Closes #993