### PR TITLE
Issue/#995 Improve player state tracking

### DIFF
--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -42,7 +42,8 @@ class GameConnection(GpgNetServerProtocol):
         protocol: Protocol,
         player_service: PlayerService,
         games: GameService,
-        state: GameConnectionState = GameConnectionState.INITIALIZING
+        state: GameConnectionState = GameConnectionState.INITIALIZING,
+        setup_timeout: int = 60,
     ):
         """
         Construct a new GameConnection
@@ -52,38 +53,35 @@ class GameConnection(GpgNetServerProtocol):
             f"{self.__class__.__qualname__}.{game.id}"
         )
         self._db = database
-        self._logger.debug("GameConnection initializing")
 
         self.protocol = protocol
         self._state = state
         self.game_service = games
         self.player_service = player_service
 
-        self._player = player
+        self.player = player
         player.game_connection = self  # Set up weak reference to self
-        self._game = game
+        self.game = game
+
+        self.setup_timeout = setup_timeout
 
         self.finished_sim = False
+
+        self._logger.debug("GameConnection initializing")
+        if self.state is GameConnectionState.INITIALIZING:
+            asyncio.get_event_loop().create_task(
+                self.timeout_game_connection(setup_timeout)
+            )
+
+    async def timeout_game_connection(self, timeout):
+        await asyncio.sleep(timeout)
+        if self.state is GameConnectionState.INITIALIZING:
+            self._logger.debug("GameConection timed out...")
+            await self.abort("Player took too long to start the game")
 
     @property
     def state(self) -> GameConnectionState:
         return self._state
-
-    @property
-    def game(self) -> Game:
-        return self._game
-
-    @game.setter
-    def game(self, val: Game):
-        self._game = val
-
-    @property
-    def player(self) -> Player:
-        return self._player
-
-    @player.setter
-    def player(self, val: Player):
-        self._player = val
 
     def is_host(self) -> bool:
         if not self.game or not self.player:
@@ -122,6 +120,7 @@ class GameConnection(GpgNetServerProtocol):
             self.game.add_game_connection(self)
             self.player.state = PlayerState.HOSTING
         else:
+            self._state = GameConnectionState.INITIALIZED
             self.player.state = PlayerState.JOINING
 
     async def _handle_lobby_state(self):

--- a/server/gameconnection.py
+++ b/server/gameconnection.py
@@ -485,10 +485,10 @@ class GameConnection(GpgNetServerProtocol):
                     )
         # Signals that the FA executable has been closed
         elif state == "Ended":
-            await self.on_connection_lost()
+            await self.on_connection_closed()
         self._mark_dirty()
 
-    async def handle_game_ended(self, *args:  list[Any]):
+    async def handle_game_ended(self, *args: list[Any]):
         """
         Signals that the simulation has ended.
         """
@@ -591,7 +591,21 @@ class GameConnection(GpgNetServerProtocol):
                     exc_info=True
                 )
 
+    async def on_connection_closed(self):
+        """
+        The connection is closed by the player.
+        """
+        try:
+            await self.game.disconnect_player(self.player)
+        except Exception as e:  # pragma: no cover
+            self._logger.exception(e)
+        finally:
+            await self.abort()
+
     async def on_connection_lost(self):
+        """
+        The connection is lost due to a disconnect from the lobby server.
+        """
         try:
             await self.game.remove_game_connection(self)
         except Exception as e:  # pragma: no cover

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -391,6 +391,17 @@ class Game:
         self._logger.info("Added game connection %s", game_connection)
         self._connections[game_connection.player] = game_connection
 
+    async def disconnect_player(self, player: Player):
+        if player.game_connection not in self._connections.values():
+            return
+
+        self._configured_player_ids.discard(player.id)
+
+        if self.state is GameState.LOBBY and player.id in self._player_options:
+            del self._player_options[player.id]
+
+        await self.remove_game_connection(player.game_connection)
+
     async def remove_game_connection(self, game_connection):
         """
         Remove a game connection from this game.
@@ -404,10 +415,6 @@ class Game:
         player = game_connection.player
         del self._connections[player]
         del player.game
-        self._configured_player_ids.discard(player.id)
-
-        if self.state is GameState.LOBBY and player.id in self._player_options:
-            del self._player_options[player.id]
 
         self._logger.info("Removed game connection %s", game_connection)
 

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -103,6 +103,7 @@ class Game:
         self.displayed_rating_range = displayed_rating_range or InclusiveRange()
         self.enforce_rating_range = enforce_rating_range
         self.matchmaker_queue_id = matchmaker_queue_id
+        self.setup_timeout = setup_timeout
         self.state = GameState.INITIALIZING
         self._connections = {}
         self._configured_player_ids: set[int] = set()

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -611,8 +611,6 @@ class LadderService(Service):
             game_id = game.id if game else None
             msg = {"command": "match_cancelled", "game_id": game_id}
             for player in all_players:
-                if player.state == PlayerState.STARTING_AUTOMATCH:
-                    player.state = PlayerState.IDLE
                 player.write_message(msg)
 
             if abandoning_players:

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -1069,6 +1069,10 @@ class LobbyConnection:
     ):
         assert self.player is not None
         assert self.game_connection is None
+        assert self.player.state in (
+            PlayerState.IDLE,
+            PlayerState.STARTING_AUTOMATCH,
+        )
 
         # TODO: Fix setting up a ridiculous amount of cyclic pointers here
         if is_host:
@@ -1080,8 +1084,12 @@ class LobbyConnection:
             player=self.player,
             protocol=self.protocol,
             player_service=self.player_service,
-            games=self.game_service
+            games=self.game_service,
+            setup_timeout=game.setup_timeout,
         )
+
+        if self.player.state is PlayerState.IDLE:
+            self.player.state = PlayerState.STARTING_GAME
 
         self.player.game = game
         cmd = {

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -787,10 +787,6 @@ class LobbyConnection:
         game.add_game_connection(self.game_connection)
         self.player.state = PlayerState.PLAYING
         self.player.game = game
-        # TODO: When the player drops, their player options are deleted as a
-        # method of tracking when people are actually connected to the host
-        # during the lobby phase. However, that means when they reconnect here
-        # they will not show up in the `game_info` message.
 
     async def command_ask_session(self, message):
         user_agent = message.get("user_agent")

--- a/server/players.py
+++ b/server/players.py
@@ -21,6 +21,7 @@ class PlayerState(Enum):
     JOINING = 4
     SEARCHING_LADDER = 5
     STARTING_AUTOMATCH = 6
+    STARTING_GAME = 7
 
 
 class Player:

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -632,7 +632,12 @@ async def test_double_host_message(lobby_server):
         "mod": "faf",
         "visibility": "public",
     })
-    await read_until_command(proto, "game_launch", timeout=10)
+    msg = await read_until_command(proto, "notice", timeout=10)
+    assert msg == {
+        "command": "notice",
+        "style": "error",
+        "text": "Can't host a game while in state STARTING_GAME",
+    }
 
 
 @fast_forward(30)
@@ -661,7 +666,12 @@ async def test_double_join_message(lobby_server):
         "command": "game_join",
         "uid": game_id
     })
-    await read_until_command(guest_proto, "game_launch", timeout=10)
+    msg = await read_until_command(guest_proto, "notice", timeout=10)
+    assert msg == {
+        "command": "notice",
+        "style": "error",
+        "text": "Can't join a game while in state STARTING_GAME",
+    }
 
 
 @fast_forward(30)

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -768,8 +768,7 @@ async def test_restore_game_session_lobby(lobby_server):
     msg = await read_until_command(guest_proto, "game_info", timeout=10)
     assert msg["teams_ids"] == [
         {"team_id": 1, "player_ids": [host_id]},
-        # TODO: Team 2 should have guest_id!
-        # {"team_id": 2, "player_ids": [guest_id]},
+        {"team_id": 2, "player_ids": [guest_id]},
     ]
 
 
@@ -810,8 +809,7 @@ async def test_restore_game_session_live(lobby_server):
     msg = await read_until_command(guest_proto, "game_info", timeout=10)
     assert msg["teams_ids"] == [
         {"team_id": 1, "player_ids": [host_id]},
-        # TODO: Team 2 should have guest_id!
-        {"team_id": 2, "player_ids": []},
+        {"team_id": 2, "player_ids": [guest_id]},
     ]
 
 

--- a/tests/integration_tests/test_game.py
+++ b/tests/integration_tests/test_game.py
@@ -4,6 +4,7 @@ import json
 import time
 from collections import defaultdict
 from datetime import datetime
+from unittest import mock
 
 import pytest
 from sqlalchemy import select
@@ -661,6 +662,227 @@ async def test_double_join_message(lobby_server):
         "uid": game_id
     })
     await read_until_command(guest_proto, "game_launch", timeout=10)
+
+
+@fast_forward(30)
+async def test_double_restore_game_session_message(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    game_id = await setup_game_1v1(host_proto, host_id, guest_proto, guest_id)
+
+    await guest_proto.close()
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(guest_proto, "game_info", timeout=10)
+
+    await guest_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    await guest_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    msg = await read_until_command(guest_proto, "notice", timeout=10)
+    assert msg == {
+        "command": "notice",
+        "style": "error",
+        "text": "Can't reconnect to a game while in state PLAYING",
+    }
+
+
+@fast_forward(30)
+async def test_restore_game_session_lobby(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    game_id = await host_game(host_proto)
+    await join_game(guest_proto, game_id)
+    await send_player_options(
+        host_proto,
+        [host_id, "Army", 1],
+        [host_id, "Team", 1],
+        [host_id, "StartSpot", 1],
+        [host_id, "Faction", 1],
+        [host_id, "Color", 1],
+        [guest_id, "Army", 2],
+        [guest_id, "Team", 2],
+        [guest_id, "StartSpot", 2],
+        [guest_id, "Faction", 2],
+        [guest_id, "Color", 2],
+    )
+    msg = await read_until_command(
+        guest_proto,
+        "game_info",
+        timeout=10,
+        num_players=2,
+    )
+    assert msg["teams_ids"] == [
+        {"team_id": 1, "player_ids": [host_id]},
+        {"team_id": 2, "player_ids": [guest_id]},
+    ]
+
+    # Guest disconnects while in lobby
+    await guest_proto.close()
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(
+        guest_proto,
+        "game_info",
+        timeout=10,
+        # Because there are other game_info messages flying around, make sure
+        # we read until with the entire game list sent during login.
+        games=mock.ANY,
+    )
+
+    await guest_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    # NOTE: This isn't realistic behavior but is a way for us to trigger another
+    # game_info message
+    await guest_proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Bogus"]
+    })
+    msg = await read_until_command(guest_proto, "game_info", timeout=10)
+    assert msg["teams_ids"] == [
+        {"team_id": 1, "player_ids": [host_id]},
+        # TODO: Team 2 should have guest_id!
+        # {"team_id": 2, "player_ids": [guest_id]},
+    ]
+
+
+@fast_forward(30)
+async def test_restore_game_session_live(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    game_id = await setup_game_1v1(host_proto, host_id, guest_proto, guest_id)
+
+    await guest_proto.close()
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(
+        guest_proto,
+        "game_info",
+        timeout=10,
+        # Because there are other game_info messages flying around, make sure
+        # we read until with the entire game list sent during login.
+        games=mock.ANY,
+    )
+
+    await guest_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    # NOTE: This isn't realistic behavior but is a way for us to trigger another
+    # game_info message
+    await guest_proto.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Bogus"]
+    })
+    msg = await read_until_command(guest_proto, "game_info", timeout=10)
+    assert msg["teams_ids"] == [
+        {"team_id": 1, "player_ids": [host_id]},
+        # TODO: Team 2 should have guest_id!
+        {"team_id": 2, "player_ids": []},
+    ]
+
+
+@fast_forward(30)
+async def test_restore_game_session_live_wrong_game(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    _, _, other_proto = await connect_and_sign_in(
+        ("test2", "test2"), lobby_server
+    )
+    game_id = await setup_game_1v1(host_proto, host_id, guest_proto, guest_id)
+
+    await read_until_command(guest_proto, "game_info", timeout=10)
+
+    await other_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    msg = await read_until_command(other_proto, "notice", timeout=10)
+    assert msg == {
+        "command": "notice",
+        "style": "info",
+        "text": "You are not part of this game",
+    }
+
+
+@fast_forward(10)
+async def test_restore_game_session_game_ended(lobby_server):
+    host_id, _, host_proto = await connect_and_sign_in(
+        ("test", "test_password"), lobby_server
+    )
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    game_id = await setup_game_1v1(host_proto, host_id, guest_proto, guest_id)
+
+    # Player disconnects and the other player reports that they won the game
+    await guest_proto.close()
+    for result in (
+        [1, "victory 10"],
+        [2, "defeat -10"],
+    ):
+        await host_proto.send_message({
+            "target": "game",
+            "command": "GameResult",
+            "args": result
+        })
+    # Report GameEnded
+    await host_proto.send_message({
+        "target": "game",
+        "command": "GameEnded",
+        "args": []
+    })
+    await read_until_command(
+        host_proto,
+        "game_info",
+        timeout=10,
+        uid=game_id,
+        state="closed",
+    )
+
+    # Player tries to reconnect too late
+    guest_id, _, guest_proto = await connect_and_sign_in(
+        ("Rhiza", "puff_the_magic_dragon"), lobby_server
+    )
+    await read_until_command(guest_proto, "game_info", timeout=10)
+
+    await guest_proto.send_message({
+        "command": "restore_game_session",
+        "game_id": game_id
+    })
+    msg = await read_until_command(guest_proto, "notice", timeout=10)
+    assert msg == {
+        "command": "notice",
+        "style": "info",
+        "text": "The game you were connected to no longer exists",
+    }
 
 
 @fast_forward(100)

--- a/tests/integration_tests/test_matchmaker_violations.py
+++ b/tests/integration_tests/test_matchmaker_violations.py
@@ -120,12 +120,24 @@ async def test_violation_persisted_across_logins(mocker, lobby_server):
 
     await read_until_command(host, "match_cancelled", timeout=120)
     await read_until_command(guest, "match_cancelled", timeout=10)
+    await read_until_command(host, "game_info", timeout=10, state="closed")
+
+    # DEPRECATED: Because the game sends a game_launch to the guest after the
+    # host times out, we need to simulate opening and closing the game before
+    # we can queue again. If we wait for the timeout, our violations expire.
+    await open_fa(guest)
+    await guest.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Ended"]
+    })
 
     # Second time searching there is no ban
     await start_search(host)
     await start_search(guest)
     await read_until_command(host, "match_cancelled", timeout=120)
     await read_until_command(guest, "match_cancelled", timeout=10)
+    await read_until_command(host, "game_info", timeout=10, state="closed")
 
     # Third time searching there is a short ban
     await host.send_message({
@@ -177,12 +189,34 @@ async def test_violation_persisted_across_parties(mocker, lobby_server):
 
     await read_until_command(host, "match_cancelled", timeout=120)
     await read_until_command(guest, "match_cancelled", timeout=10)
+    await read_until_command(host, "game_info", timeout=10, state="closed")
+
+    # DEPRECATED: Because the game sends a game_launch to the guest after the
+    # host times out, we need to simulate opening and closing the game before
+    # we can queue again. If we wait for the timeout, our violations expire.
+    await open_fa(guest)
+    await guest.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Ended"]
+    })
 
     # Second time searching there is no ban
     await start_search(host)
     await start_search(guest)
     await read_until_command(host, "match_cancelled", timeout=120)
     await read_until_command(guest, "match_cancelled", timeout=10)
+    await read_until_command(host, "game_info", timeout=10, state="closed")
+
+    # DEPRECATED: Because the game sends a game_launch to the guest after the
+    # host times out, we need to simulate opening and closing the game before
+    # we can queue again. If we wait for the timeout, our violations expire.
+    await open_fa(guest)
+    await guest.send_message({
+        "target": "game",
+        "command": "GameState",
+        "args": ["Ended"]
+    })
 
     # Third time searching there is a short ban
     await host.send_message({

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -659,7 +659,7 @@ async def test_game_host_authenticated(lobby_server, user):
 
 
 @fast_forward(10)
-async def test_host_missing_fields(lobby_server):
+async def test_game_host_missing_fields(lobby_server):
     player_id, session, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
@@ -684,7 +684,7 @@ async def test_host_missing_fields(lobby_server):
 
 
 @fast_forward(10)
-async def test_host_game_name_only_spaces(lobby_server):
+async def test_game_host_name_only_spaces(lobby_server):
     player_id, session, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
@@ -709,7 +709,7 @@ async def test_host_game_name_only_spaces(lobby_server):
 
 
 @fast_forward(10)
-async def test_host_game_name_non_ascii(lobby_server):
+async def test_game_host_name_non_ascii(lobby_server):
     player_id, session, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
@@ -733,12 +733,12 @@ async def test_host_game_name_non_ascii(lobby_server):
     }
 
 
+@fast_forward(10)
 async def test_play_game_while_queueing(lobby_server):
     player_id, session, proto = await connect_and_sign_in(
         ("test", "test_password"),
         lobby_server
     )
-
     await read_until_command(proto, "game_info")
 
     await proto.send_message({
@@ -761,6 +761,32 @@ async def test_play_game_while_queueing(lobby_server):
         "command": "notice",
         "style": "error",
         "text": "Can't join a game while in state SEARCHING_LADDER"
+    }
+
+    await proto.send_message({"command": "restore_game_session"})
+    msg = await read_until_command(proto, "notice")
+    assert msg == {
+        "command": "notice",
+        "style": "error",
+        "text": "Can't reconnect to a game while in state SEARCHING_LADDER"
+    }
+
+
+@fast_forward(10)
+async def test_restore_game_session_no_game(lobby_server):
+    player_id, session, proto = await connect_and_sign_in(
+        ("test", "test_password"),
+        lobby_server
+    )
+    await read_until_command(proto, "game_info")
+
+    await proto.send_message({"command": "restore_game_session", "game_id": 42})
+
+    msg = await read_until_command(proto, "notice")
+    assert msg == {
+        "command": "notice",
+        "style": "info",
+        "text": "The game you were connected to no longer exists"
     }
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -74,7 +74,7 @@ async def violation_service():
 
 
 @pytest.fixture
-def game_connection(
+async def game_connection(
     request,
     database,
     game,

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -114,6 +114,7 @@ def make_mock_game_connection(
     gc.state = state
     gc.player = player
     gc.finished_sim = False
+    player.game_connection = gc
     return gc
 
 

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -62,12 +62,12 @@ async def test_disconnect_all_peers(
         return "OK"
 
     # Set up a peer that will disconnect without error
-    ok_disconnect = mock.create_autospec(GameConnection)
+    ok_disconnect = mock.create_autospec(game_connection)
     ok_disconnect.state = GameConnectionState.CONNECTED_TO_HOST
     ok_disconnect.send_DisconnectFromPeer = fake_send_dc
 
     # Set up a peer that will throw an exception
-    fail_disconnect = mock.create_autospec(GameConnection)
+    fail_disconnect = mock.create_autospec(game_connection)
     fail_disconnect.send_DisconnectFromPeer.return_value = Exception("Test exception")
     fail_disconnect.state = GameConnectionState.CONNECTED_TO_HOST
 
@@ -81,7 +81,7 @@ async def test_disconnect_all_peers(
 
 
 async def test_connect_to_peer(game_connection):
-    peer = mock.create_autospec(GameConnection)
+    peer = mock.create_autospec(game_connection)
 
     await game_connection.connect_to_peer(peer)
 
@@ -92,7 +92,7 @@ async def test_connect_to_peer_disconnected(game_connection):
     # Weak reference has dissapeared
     await game_connection.connect_to_peer(None)
 
-    peer = mock.create_autospec(GameConnection)
+    peer = mock.create_autospec(game_connection)
     peer.send_ConnectToPeer.side_effect = DisconnectedError("Test error")
 
     # The client disconnects right as we send the message

--- a/tests/unit_tests/test_gameconnection.py
+++ b/tests/unit_tests/test_gameconnection.py
@@ -264,12 +264,12 @@ async def test_handle_action_GameState_launching_when_ended(
     game.launch.assert_not_called()
 
 
-async def test_handle_action_GameState_ended_calls_on_connection_lost(
+async def test_handle_action_GameState_ended_calls_on_connection_closed(
     game_connection: GameConnection
 ):
-    game_connection.on_connection_lost = mock.AsyncMock()
+    game_connection.on_connection_closed = mock.AsyncMock()
     await game_connection.handle_action("GameState", ["Ended"])
-    game_connection.on_connection_lost.assert_called_once_with()
+    game_connection.on_connection_closed.assert_called_once_with()
 
 
 async def test_handle_action_PlayerOption(game: Game, game_connection: GameConnection):

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -781,7 +781,7 @@ async def test_game_connection_not_restored_if_no_such_game_exists(lobbyconnecti
     lobbyconnection.send.assert_any_call({
         "command": "notice",
         "style": "info",
-        "text": "The game you were connected to does no longer exist"
+        "text": "The game you were connected to no longer exists"
     })
 
 
@@ -803,6 +803,7 @@ async def test_game_connection_not_restored_if_game_state_prohibits(
     game.password = None
     game.game_mode = "faf"
     game.id = 42
+    game.players = [lobbyconnection.player]
     game_service._games[42] = game
 
     await lobbyconnection.on_message_received({
@@ -836,6 +837,7 @@ async def test_game_connection_restored_if_game_exists(
     game.password = None
     game.game_mode = "faf"
     game.id = 42
+    game.players = [lobbyconnection.player]
     game_service._games[42] = game
 
     await lobbyconnection.on_message_received({

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -264,7 +264,7 @@ async def test_launch_game(lobbyconnection, game, player_factory):
     assert lobbyconnection.player.game == game
     assert lobbyconnection.player.game_connection == lobbyconnection.game_connection
     assert lobbyconnection.game_connection.player == lobbyconnection.player
-    assert lobbyconnection.player.state == PlayerState.IDLE
+    assert lobbyconnection.player.state == PlayerState.STARTING_GAME
     lobbyconnection.send.assert_called_once()
 
 
@@ -791,7 +791,6 @@ async def test_game_connection_not_restored_if_game_state_prohibits(
     game_service: GameService,
     game_stats_service,
     game_state,
-    mocker,
     database
 ):
     del lobbyconnection.player.game_connection
@@ -998,8 +997,9 @@ async def test_command_matchmaker_info(
     })
 
 
-async def test_connection_lost(lobbyconnection):
+async def test_connection_lost(lobbyconnection, players):
     lobbyconnection.game_connection = mock.create_autospec(GameConnection)
+    lobbyconnection.game_connection.player = players.hosting
     await lobbyconnection.on_connection_lost()
 
     lobbyconnection.game_connection.on_connection_lost.assert_called_once()


### PR DESCRIPTION
The state tracking was pretty messed up by the fact that the `HOSTING` and `JOINING` states don't get set until the game sends back GPGNet messages, so clients could do a `game_host` and then before their game was opened they could join a matchmaker queue. Once their game opened their player state would be set to `HOSTING` and any matches that they got would be stuck in the queue until they manually stopped searching because the matchmaker would refuse to launch matches when one of the players had a state other than `SEARCHING_LADDER`. Even if they closed their game instance, the player state would then be set to `IDLE` which still would not allow matches to launch.

This also makes an adjustment to how players are considered to be in a game. Now, if players disconnect from the lobby server without sending a `GameState: Idle` command they will still be considered part of the lobby. This is closer to how the behavior used to be except when someone does leave the game through the 'happy path' by closing their game, they should be completely removed from the internal state and consequently only be re-added when the host sends a new `PlayerOption` for them. This hopefully will reduce some of the issues that people have reported with there being more people in the lobby when they connect than it says in the client view.

Related to #995 
We won't mark it as closing since we should deploy these changes first and watch the logs to see if the issue has actually been solved. There may be other ways still in which the state tracking can go awry.