### PR TITLE
Get default config values from environment

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -156,7 +156,9 @@ class ConfigurationStore:
         self.QUEUE_POP_TIME_MOVING_AVG_SIZE = 5
 
         self._defaults = {
-            key: value for key, value in vars(self).items() if key.isupper()
+            key: value
+            for key, value in vars(self).items()
+            if key.isupper()
         }
 
         self._callbacks: dict[str, Callable] = {}
@@ -164,6 +166,12 @@ class ConfigurationStore:
 
     def refresh(self) -> None:
         new_values = self._defaults.copy()
+        # Add fallback values from environment.
+        # NOTE: Only works for string values!
+        for key in new_values:
+            value = os.getenv(key)
+            if value is not None:
+                new_values[key] = value
 
         config_file = os.getenv("CONFIGURATION_FILE")
         if config_file is not None:


### PR DESCRIPTION
@Brutus5000 requested this feature to make managing secrets easier in kubernetes. This way values like the database password which are never going to change dynamically anyway can be stored in a `Secret` object and mapped to the environment while non-sensitive data can be stored in a `ConfigMap` and mapped to a volume that will be able to trigger the dynamic changes. Since kubernetes doesn't really support merging those two things into a single file, this feature will make setting up the configuration a lot easier and more idiomatic.

NOTE: This will only work for values which are expected to be strings! This should not be a problem since this feature is only intended to be used for passwords.