### PR TITLE
Dockerfile: Create app folder with non-root permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ FROM python:3.10-slim
 ARG GITHUB_REF
 ENV VERSION=$GITHUB_REF
 
-COPY --from=builder /code/.venv/lib/ /usr/local/lib/
-COPY --from=builder /code/main.py /code/
-
 RUN useradd --no-create-home faf
+
+COPY --from=builder /code/.venv/lib/ /usr/local/lib/
+COPY --from=builder --chown=faf:faf /code/main.py /code/
 
 WORKDIR /code/
 USER faf


### PR DESCRIPTION
On prod/test this is not an issue because we run the app as root.
But in Kubernetes we will tighten the screws. Unfortunately the `faf` user has no permission to write to the app.