### PR TITLE
Fix issue where players added or removed from friend or foe lists did not have games updated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-docstring-first
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.7
+    rev: v2.0.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.13.2
     hooks:
     -   id: isort

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -316,6 +316,15 @@ class LobbyConnection:
             ]
         })
 
+    async def send_game_list_to_player(self, player: Player):
+        await player.send_message({
+            "command": "game_info",
+            "games": [
+                game.to_dict() for game in self.game_service.open_games
+                if game.is_visible_to_player(player)
+            ]
+        })
+
     async def command_social_remove(self, message):
         if "friend" in message:
             subject_id = message["friend"]
@@ -335,6 +344,10 @@ class LobbyConnection:
 
         with contextlib.suppress(KeyError):
             player_attr.remove(subject_id)
+
+        subject_player = self.player_service.get_player(int(subject_id))
+        with contextlib.suppress(DisconnectedError):
+            self.send_game_list_to_player(subject_player)
 
     async def command_social_add(self, message):
         if "friend" in message:
@@ -359,6 +372,10 @@ class LobbyConnection:
             ))
 
         player_attr.add(subject_id)
+
+        subject_player = self.player_service.get_player(int(subject_id))
+        with contextlib.suppress(DisconnectedError):
+            self.send_game_list_to_player(subject_player)
 
     async def kick(self):
         await self.send({


### PR DESCRIPTION
**Changes**
- Add `send_game_list_to_player()` that will send the game's they have access to a specific player rather than just the logged in user.
- When social add or remove is called, it will send an updated game list to the target of the social add or remove.

**Potential Issues**
- Lots of social adds and removes has the potential for abuse of resources (DDOS). This would really be apparent if there are lots of games as well.
- The client might not accept the game list updates.

**TODO**

- Need to add unit/integration tests around this functionality.

Closes #1002 