### PR TITLE
Feature/#1032 working veto system

### DIFF
--- a/server/ladder_service/veto_system.py
+++ b/server/ladder_service/veto_system.py
@@ -116,7 +116,7 @@ class VetoService(Service):
                         map_pool_map_version_ids=[
                             map.map_pool_map_version_id
                             for map in matchmaker_queue_map_pool.map_pool.maps.values()
-                        ] + [-1],
+                        ],
                         veto_tokens_per_player=veto_tokens_per_player,
                         max_tokens_per_map=max_tokens_per_map,
                         minimum_maps_after_veto=minimum_maps_after_veto

--- a/server/ladder_service/veto_system.py
+++ b/server/ladder_service/veto_system.py
@@ -260,9 +260,13 @@ def _is_valid_veto_config_for_queue(
 ) -> bool:
     num_maps = len(queue_config.map_pool.maps)
 
+    if (queue_config.minimum_maps_after_veto > num_maps):
+        return False
+
     if (
         queue_config.max_tokens_per_map == 0
-        and queue_config.minimum_maps_after_veto >= num_maps
+        and queue_config.minimum_maps_after_veto == num_maps
+        and queue_config.veto_tokens_per_player > 0
     ):
         return False
 
@@ -270,11 +274,6 @@ def _is_valid_veto_config_for_queue(
         total_players = queue.team_size * 2
         vetoable_maps_per_player = queue_config.veto_tokens_per_player / queue_config.max_tokens_per_map
         vetoable_maps = total_players * vetoable_maps_per_player
-
-        # tokens/map > number of maps that may be vetoed
-        # TODO: because vetoable_maps >= 0 this inequality also implies
-        # queue_config.minimum_maps_after_veto > num_maps
-
         if vetoable_maps > num_maps - queue_config.minimum_maps_after_veto:
             return False
 

--- a/server/ladder_service/veto_system.py
+++ b/server/ladder_service/veto_system.py
@@ -274,7 +274,7 @@ def _is_valid_veto_config_for_queue(
         # tokens/map > number of maps that may be vetoed
         # TODO: because vetoable_maps >= 0 this inequality also implies
         # queue_config.minimum_maps_after_veto > num_maps
-        # Why is it strictly greater than here but greater than or equal to above?
+
         if vetoable_maps > num_maps - queue_config.minimum_maps_after_veto:
             return False
 

--- a/server/matchmaker/map_pool.py
+++ b/server/matchmaker/map_pool.py
@@ -105,7 +105,7 @@ class MapPool(object):
         self._logger.debug("______map_list________________: %s", map_list)
         final_weights = [adjusted_weights.get(mp_mv_id, 0) * m.weight for mp_mv_id, m in map_list]
         self._logger.debug("______final_weights________________: %s", final_weights)
-        return random.choices([map for _, map in map_list], weights=final_weights, k=1)[0].get_map()
+        return random.choices([map for _, map in map_list], weights=final_weights, k=1)[0].get_map()  # nosec B311
 
     def __repr__(self) -> str:
         return f"MapPool({self.id}, {self.name}, {list(self.maps.values())})"

--- a/server/matchmaker/map_pool.py
+++ b/server/matchmaker/map_pool.py
@@ -38,11 +38,16 @@ class MapPool(object):
         adjusted_weights = notzero_weights.copy()
 
         def get_notrepeated_weight_transfer_targets(current_weight, rep_count):
-            for base_threshold in base_thresholds:
+            thresholds = list(base_thresholds)
+            factor = repeat_factor ** (rep_count - 1)
+            if factor < 1:
+                thresholds.extend(t * factor for t in base_thresholds if t * factor < base_thresholds[-1])
+
+            for threshold in thresholds:
                 targets = [
                     target_id for target_id in notzero_weights
                     if repetition_counts.get(target_id, 0) == 0 and
-                    notzero_weights[target_id] >= base_threshold * repeat_factor ** (rep_count - 1) * current_weight
+                    notzero_weights[target_id] >= threshold * current_weight
                 ]
                 if targets:
                     return targets

--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -66,7 +66,7 @@ class MatchmakerQueue:
         self.team_size = team_size
         self.rating_peak = 1000.0
         self.params = params or {}
-        self.map_pools = {info.id: info for info in map_pools}
+        self.map_pools = {info.map_pool.id: info for info in map_pools}
 
         self._queue: dict[Search, None] = OrderedDict()
         self.on_match_found = on_match_found

--- a/server/types.py
+++ b/server/types.py
@@ -146,6 +146,7 @@ class NeroxisGeneratedMap(NamedTuple):
             folder_name=folder_name,
             ranked=True,
             weight=self.weight,
+            map_pool_map_version_id=self.map_pool_map_version_id,
         )
 
 

--- a/tests/integration_tests/test_matchmaker_vetoes.py
+++ b/tests/integration_tests/test_matchmaker_vetoes.py
@@ -175,7 +175,7 @@ async def test_map_pool_changes_causing_silent_update_and_not_stops_search(playe
             )
         await ladder_service.update_data()
         msg = await read_until_command(proto, "vetoes_info", timeout=10)
-        print(f"Received vetoes_info: {msg}")
+
         assert msg.get("forced") is False
         assert msg["vetoes"] == gen_vetoes([])
         assert player.state == PlayerState.SEARCHING_LADDER

--- a/tests/unit_tests/test_map_pool.py
+++ b/tests/unit_tests/test_map_pool.py
@@ -250,7 +250,7 @@ def test_choose_map_raises_on_empty_map_pool(map_pool_factory):
             {1: 0, 2: 1.5, 3: 1.5}
         ),
         # Really complex redistribution test
-        # 1 -> [5,6], [2,3] -> [5,6,8], [7,9] -> 5
+        # 1 -> [5], [2,3] -> [5,6,8], [7,9] -> 5
         (
             {1: 0.9, 2: 0.6, 3: 0.4, 4: 0.2, 5: 0.75, 6: 0.6, 7: 1, 8: 0.5, 9: 1},
             [1, 1, 2, 3, 7, 9],
@@ -261,8 +261,8 @@ def test_choose_map_raises_on_empty_map_pool(map_pool_factory):
                 2: 0,
                 3: 0,
                 4: 0.2,
-                5: pytest.approx(3.655405, rel=1e-6),
-                6: pytest.approx(1.324324, rel=1e-6),
+                5: pytest.approx(4.055405, rel=1e-6),
+                6: pytest.approx(0.924324, rel=1e-6),
                 7: 0,
                 8: pytest.approx(0.770270, rel=1e-6),
                 9: 0
@@ -279,8 +279,8 @@ def test_choose_map_raises_on_empty_map_pool(map_pool_factory):
                 2: 0,
                 3: 0,
                 4: 0.2,
-                5: pytest.approx(3.655405, rel=1e-6),
-                6: pytest.approx(1.324324, rel=1e-6),
+                5: pytest.approx(4.055405, rel=1e-6),
+                6: pytest.approx(0.924324, rel=1e-6),
                 7: 0,
                 8: pytest.approx(0.770270, rel=1e-6),
                 9: 0

--- a/tests/unit_tests/test_veto_system.py
+++ b/tests/unit_tests/test_veto_system.py
@@ -27,8 +27,6 @@ def test_is_valid_veto_config_for_queue(queue_factory):
     ) is False
 
     # minimum_maps_after_veto equal to map pool size
-    # TODO: Is calling this invalid really the desired behavior? When
-    # max_tokens_per_map != 0, they are allowed to be equal
     assert _is_valid_veto_config_for_queue(
         queue,
         MatchmakerQueueMapPool(
@@ -40,7 +38,7 @@ def test_is_valid_veto_config_for_queue(queue_factory):
             max_tokens_per_map=0,
             minimum_maps_after_veto=1,
         )
-    ) is False
+    ) is True
 
     assert _is_valid_veto_config_for_queue(
         queue,


### PR DESCRIPTION
Working on #1032
I need some feedback, what is right, what is wrong, what needs to be changed, etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players can submit per-pool map vetoes from the lobby; matchmaking consumes those vetoes to influence initial map weights.

* **Improvements**
  * Anti-repetition weight adjustments refined for more varied map selection.
  * Map/version metadata and per-pool veto configuration (tokens, limits, minima) now propagate through matchmaking and game launch.

* **Tests**
  * Extensive unit and integration tests added covering veto flows, dynamic token logic, and selection outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->