### PR TITLE
Add workflow dispatch for building docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,22 +4,46 @@ name: Build
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Repository
+      ref:
+        description: Ref
+      tag:
+        description: Tag
+        required: true
+        default: faforever/faf-python-server:latest
 
 jobs:
   docker-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Extract tag name
-        id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-
-      - name: Build and publish docker image
-        uses: docker/build-push-action@v1.1.1
+      - uses: actions/checkout@v4
         with:
-          repository: faforever/faf-python-server
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: faforever/faf-python-server
+          tags:
+            type=semver,pattern={{raw}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          build_args: GITHUB_REF=${{ steps.vars.outputs.tag }}
-          tag_with_ref: true
+
+      - name: Build and publish docker image
+        uses: docker/build-push-action@v6
+        with:
+          build-args: GITHUB_REF=${{ github.ref_name }}
+          tags: ${{ inputs.tag || steps.meta.outputs.tags }}
+          push: true


### PR DESCRIPTION
Updates our build workflow to use the latest versions of the docker build actions and adds a workflow dispatch trigger for manually building images. Manually building images is necessary for being able to test development work on our new k8s test infrastructure as k8s doesn't have an image builder like docker-compose does.