### PR TITLE
Use cached_property to create Futures

### DIFF
--- a/server/games/game.py
+++ b/server/games/game.py
@@ -6,6 +6,7 @@ import pathlib
 import time
 from collections import defaultdict
 from datetime import datetime
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Optional
 
 from sqlalchemy import and_, bindparam
@@ -139,11 +140,14 @@ class Game:
         self.game_options.add_callback("Title", self.on_title_changed)
 
         self.mods: dict[str, str] = {}
-        self._hosted_future: asyncio.Future[None] = asyncio.Future()
         self._finish_lock = asyncio.Lock()
 
         self._logger.debug("%s created", self)
         asyncio.get_event_loop().create_task(self.timeout_game(setup_timeout))
+
+    @cached_property
+    def _hosted_future(self) -> asyncio.Future:
+        return asyncio.get_running_loop().create_future()
 
     async def timeout_game(self, timeout: int = 60):
         await asyncio.sleep(timeout)

--- a/server/games/ladder_game.py
+++ b/server/games/ladder_game.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from functools import cached_property
 from typing import Optional
 
 from server.config import config
@@ -27,9 +28,9 @@ class LadderGame(Game):
     init_mode = InitMode.AUTO_LOBBY
     game_type = GameType.MATCHMAKER
 
-    def __init__(self, id, *args, **kwargs):
-        super().__init__(id, *args, **kwargs)
-        self._launch_future: asyncio.Future[None] = asyncio.Future()
+    @cached_property
+    def _launch_future(self) -> asyncio.Future:
+        return asyncio.get_running_loop().create_future()
 
     async def wait_hosted(self, timeout: float):
         return await asyncio.wait_for(

--- a/server/matchmaker/search.py
+++ b/server/matchmaker/search.py
@@ -4,6 +4,7 @@ import logging
 import math
 import statistics
 import time
+from functools import cached_property
 from typing import Any, Callable, ClassVar, Optional
 
 import trueskill
@@ -44,7 +45,6 @@ class Search:
         self._players = players
         self.rating_type = rating_type
         self.start_time = start_time or time.time()
-        self._match = asyncio.get_event_loop().create_future()
         self._failed_matching_attempts = 0
         self.on_matched = on_matched
 
@@ -54,6 +54,10 @@ class Search:
     @property
     def players(self) -> list[Player]:
         return self._players
+
+    @cached_property
+    def _match(self) -> asyncio.Future:
+        return asyncio.get_running_loop().create_future()
 
     def adjusted_rating(self, player: Player) -> Rating:
         """

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -100,9 +100,8 @@ async def test_game_launch_message_game_options(lobby_server, tmp_user):
         }
 
 
-@pytest.mark.flaky
 @fast_forward(15)
-async def test_game_matchmaking_start(lobby_server, database):
+async def test_game_matchmaking_start(lobby_server, database, game_service):
     host_id, host, guest_id, guest = await queue_players_for_matchmaking(lobby_server)
 
     # The player that queued last will be the host
@@ -139,8 +138,7 @@ async def test_game_matchmaking_start(lobby_server, database):
     })
 
     # Wait for db to be updated
-    await read_until_launched(host, game_id)
-    await read_until_launched(guest, game_id)
+    await game_service[game_id].wait_launched(None)
 
     async with database.acquire() as conn:
         result = await conn.execute(select(


### PR DESCRIPTION
Resolves #894 

Also, fix one flaky test (`test_game_matchmaking_start`) by fully waiting for the game to start.

I took a look at other flaky tests, but I couldn't reproduce their flakiness: they had been continuing to pass.

The only flaky one which sometimes failed is [`test_game_matchmaking_close_fa_and_requeue`](https://github.com/FAForever/server/blob/181bee80bd79a5507219999a811aa71515e9aeb3/tests/integration_tests/test_matchmaker.py#L327), and I believe this is happening due to `@fast_forward` not working as wished with `loop.run_in_executor` futures.

Removing `@fast_forward` decorator fixes this test's flakiness, but increases runtime (from ~1 to about ~2.5 seconds), so I didn't touch that.