### PR TITLE
Ensure all generated maps are ranked

### DIFF
--- a/server/types.py
+++ b/server/types.py
@@ -66,7 +66,7 @@ class NeroxisGeneratedMap(NamedTuple):
     weight: int = 1
 
     _NAME_PATTERN = re.compile(
-        "neroxis_map_generator_([0-9.]+)_([a-z2-7]+)_([a-z2-7]+)"
+        "neroxis_map_generator_([0-9.]+)_.+"
     )
 
     @classmethod

--- a/tests/unit_tests/test_types.py
+++ b/tests/unit_tests/test_types.py
@@ -1,4 +1,4 @@
-from server.types import Address
+from server.types import Address, NeroxisGeneratedMap
 
 
 def test_address_from_string():
@@ -11,3 +11,15 @@ def test_address_from_string_with_scheme():
     address = Address.from_string("http://localhost:4000")
 
     assert address == Address("http://localhost", 4000)
+
+
+def test_is_neroxis_map():
+    assert NeroxisGeneratedMap.is_neroxis_map(
+        "neroxis_map_generator_1.13.0_htvbrglnjszew_baeaeaa_aaaaaadhlwmjq",
+    ) is True
+    assert NeroxisGeneratedMap.is_neroxis_map(
+        "neroxis_map_generator_1.13.0_zxgxph43rfbj4_aycaeaa_aaaaaadhlwuas",
+    ) is True
+    assert NeroxisGeneratedMap.is_neroxis_map(
+        "neroxis_map_generator_1.13.0_avkycu6ce63e2_baeaeaa_aaaaaadhlxdhe",
+    ) is True


### PR DESCRIPTION
The regex for determining if something was a generated map is too restrictive and accidentally excludes some generated maptypes.