### PR TITLE
Use max rating deviation per team to calculate match quality

### DIFF
--- a/server/matchmaker/algorithm/team_matchmaker.py
+++ b/server/matchmaker/algorithm/team_matchmaker.py
@@ -325,17 +325,17 @@ class TeamMatchMaker(Matchmaker):
         minority_bonus = min(minority_bonus, config.MINORITY_BONUS)
         rating_disparity = abs(match[0].cumulative_rating - match[1].cumulative_rating)
         unfairness = rating_disparity / config.MAXIMUM_RATING_IMBALANCE
-        deviation = statistics.pstdev(ratings)
-        rating_variety = deviation / config.MAXIMUM_RATING_DEVIATION
+        max_team_deviation = max(map(statistics.pstdev, [match[0].displayed_ratings, match[1].displayed_ratings]))
+        max_rating_variety = max_team_deviation / config.MAXIMUM_RATING_DEVIATION
 
         # Visually this creates a cone in the unfairness-rating_variety plane
         # that slowly raises with the time bonuses.
-        quality = 1 - sqrt(unfairness ** 2 + rating_variety ** 2) + time_bonus + minority_bonus
+        quality = 1 - sqrt(unfairness ** 2 + max_rating_variety ** 2) + time_bonus + minority_bonus
         if not any(team.has_high_rated_player() for team in match):
             quality += newbie_bonus
         self._logger.debug(
             "bonuses: %s rating disparity: %s -> unfairness: %f deviation: %f -> variety: %f -> game quality: %f",
-            newbie_bonus + time_bonus + minority_bonus, rating_disparity, unfairness, deviation, rating_variety, quality
+            newbie_bonus + time_bonus + minority_bonus, rating_disparity, unfairness, max_team_deviation, max_rating_variety, quality
         )
         return GameCandidate(match, quality)
 

--- a/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
+++ b/tests/unit_tests/test_matchmaker_algorithm_team_matchmaker.py
@@ -80,10 +80,10 @@ def test_team_matchmaker_algorithm(player_factory):
 
     matches, unmatched = matchmaker.find(s, 4, 1000)
 
-    assert set(matches[1][0].get_original_searches()) == {c1, s[2], s[5]}
-    assert set(matches[1][1].get_original_searches()) == {c3, s[1], s[6]}
-    assert set(matches[0][0].get_original_searches()) == {c4, s[4]}
-    assert set(matches[0][1].get_original_searches()) == {c2, s[0], s[3]}
+    assert set(matches[0][0].get_original_searches()) == {c1, s[2], s[5]}
+    assert set(matches[0][1].get_original_searches()) == {c3, s[1], s[6]}
+    assert set(matches[1][0].get_original_searches()) == {c4, s[4]}
+    assert set(matches[1][1].get_original_searches()) == {c2, s[0], s[3]}
     assert set(unmatched) == {s[7]}
     for match in matches:
         assert matchmaker.assign_game_quality(match, 4, 1000).quality > config.MINIMUM_GAME_QUALITY


### PR DESCRIPTION
#975 

The idea here is to keep rating variety within each team of a match low. Instead of discounting quality for deviation across all ratings in a match, the deviation for each team is limited.

This fixes imbalances on maps with uneven spawn positions (lot of mexes, air spot, navy spot, ...), where the overall match variety may be low, but one team gets a lot of rating variety whereas the other is very balanced. One team will have the best and the worst rated players, while the other will have the average ratings.

This will either give the strong player an advantage on a strong spot, or a disadvantage when they are on a weak spot, as the majority of the game will be in the hands of his weaker teammates.

By limiting the maximum variety per team, matches like this should have lower quality assigned.