### PR TITLE
Fix docker build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,13 @@
+[metadata]
+name=Forged Alliance Forever Server
+description=Lobby/game server project
+license=GPLv3
+url=http://www.faforever.com
+
+[options]
+include_package_data=True
+packages=find:
+
 [isort]
 multi_line_output=3
 known_first_party=server,tests,integration_tests

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,6 @@ import subprocess
 from distutils.core import setup
 from pathlib import Path
 
-from setuptools import find_packages
-
-import server
-
 
 def get_version() -> str:
     output = subprocess.run(
@@ -27,13 +23,5 @@ def get_version() -> str:
 
 
 setup(
-    name="Forged Alliance Forever Server",
     version=get_version(),
-    packages=["server"] + find_packages(),
-    url="http://www.faforever.com",
-    license=server.__license__,
-    author=server.__author__,
-    author_email=server.__contact__,
-    description="Lobby/game server project",
-    include_package_data=True
 )


### PR DESCRIPTION
The docker build was failing because the package was not able to install. This is due to the package importing itself during install time, which has caused issues in the past as well. I'm not sure when/why it started failing this time around, but the most robust fix is to remove the self importing behavior. We lose some package metadata, but it doesn't matter.

I also moved all static metadata into the `setup.cfg` file.