### PR TITLE
Issue/#1015 Fix pop timer rate calculation

### DIFF
--- a/server/matchmaker/matchmaker_queue.py
+++ b/server/matchmaker/matchmaker_queue.py
@@ -108,6 +108,15 @@ class MatchmakerQueue:
     def num_players(self) -> int:
         return sum(len(search.players) for search in self._queue.keys())
 
+    @property
+    def num_new_queued_players(self) -> int:
+        """ Get the number of players who have joined the queue and not yet had a failed matching attempt in the last pop.
+
+        Returns:
+            int: Number of players who have joined the queue since last matching attempt.
+        """
+        return sum(len(search.players) for search in self._queue.keys() if search.failed_matching_attempts == 0)
+
     async def queue_pop_timer(self) -> None:
         """ Periodically tries to match all Searches in the queue. The amount
         of time until next queue 'pop' is determined by the number of players

--- a/server/matchmaker/pop_timer.py
+++ b/server/matchmaker/pop_timer.py
@@ -56,9 +56,12 @@ class PopTimer(object):
         num_players = self.queue.num_players
         metrics.matchmaker_players.labels(self.queue.name).set(num_players)
 
+        num_new_players = self.queue.num_new_queued_players
+        metrics.matchmaker_new_players.labels(self.queue.name).set(num_new_players)
+
         self._last_queue_pop = time()
         self.next_queue_pop = self._last_queue_pop + self.time_until_next_pop(
-            num_players, time_remaining
+            num_new_players, time_remaining
         )
 
     def time_until_next_pop(self, num_queued: int, time_queued: float) -> float:
@@ -82,8 +85,9 @@ class PopTimer(object):
 
         players_per_match = self.queue.team_size * 2
         desired_players = config.QUEUE_POP_DESIRED_MATCHES * players_per_match
-        # Obtained by solving $ NUM_PLAYERS = rate * time $ for time.
-        next_pop_time = desired_players * total_times / total_players
+        player_addition_rate = total_players / total_times
+        # Obtained by solving $ desired_players = player_addition_rate * time $ for time.
+        next_pop_time = desired_players / player_addition_rate
         if next_pop_time > config.QUEUE_POP_TIME_MAX:
             self._logger.info(
                 "Required time (%.2fs) for %s is larger than max pop time (%ds). "

--- a/server/metrics.py
+++ b/server/metrics.py
@@ -67,6 +67,10 @@ matchmaker_players = Gauge(
     "server_matchmaker_queue_players", "Players in the queue at pop time", ["queue"]
 )
 
+matchmaker_new_players = Gauge(
+    "server_matchmaker_queue_new_players", "Number of newly added players to the queue at pop time", ["queue"]
+)
+
 matchmaker_queue_pop = Gauge(
     "server_matchmaker_queue_pop_timer_seconds",
     "Queue pop timer duration in seconds",

--- a/tests/unit_tests/test_pop_timer.py
+++ b/tests/unit_tests/test_pop_timer.py
@@ -43,3 +43,16 @@ def test_queue_pop_time_moving_average_size(queue_factory):
 
     # The rate should be extremely low, meaning the pop time should be high
     assert t1.time_until_next_pop(0, 100) == config.QUEUE_POP_TIME_MAX
+
+
+def test_queue_pop_time_moving_average_size_stability(queue_factory):
+    # Test perfect number of players joining has a stable pop time
+    team_size = 2
+    desired_players = team_size * config.QUEUE_POP_DESIRED_MATCHES
+    t1 = PopTimer(queue_factory(team_size=2))
+    initial_time_to_pop = (config.QUEUE_POP_TIME_MAX + config.QUEUE_POP_TIME_MIN) / 2  # Arbitrary time between min and max
+    next_time_to_pop = initial_time_to_pop
+    for _ in range(100):
+        next_time_to_pop = t1.time_until_next_pop(desired_players, next_time_to_pop)
+
+    assert t1.time_until_next_pop(desired_players, next_time_to_pop) == next_time_to_pop  # Perfect size should not change the next time


### PR DESCRIPTION
This fixes #1015 which notes that the queue pop timer rate is calculated incorrectly.

Fixed by finding the number of new players who have joined the queue - turned out to be pretty simple thanks to some existing logic.

Unit tests:

`pipenv run tests tests/unit_tests -k pop`
<img width="376" height="55" alt="image" src="https://github.com/user-attachments/assets/30b73593-7a5a-48cd-ae45-3bfe3d7158e6" />

`pipenv run tests tests/unit_tests`
<img width="836" height="808" alt="image" src="https://github.com/user-attachments/assets/571d4199-5bd4-437f-b16e-69409d2679cc" />

Closes #1015 

---

Some notes on the consequences of this change:

1. This **will** have negative effects on queue waiting times:
    - The pop timer will be given *strictly fewer* people (since it no longer sees people unmatched from the previous pop). This results in longer pop times.
    - The queue matching logic becomes more relaxed the more pops have happened for a person, so individually longer pop times can result in multiplicatively longer waiting times for unmatched players.
    - Combined, this will result in longer wait times for players to be matched. 
        - Two solutions are (a) Lower the maximum time, perhaps from 90 to 60 seconds, or (b) Add extra calculation to take into account the waiting players. e.g. assume they came in at a flat rate over the maximum pop time.
2. This was previously mitigated by adding a minimum pop time of 15 seconds (#1014). As the calculations should now be more stable, we could decrease the minimum pop time further to e.g. 10 or 5 seconds. At peak times, this might be beneficial.