### PR TITLE
Punish the host with a matchmaker violation if game setup times out

### DIFF
--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -683,7 +683,10 @@ class LadderService(Service):
             raise NotConnectedError([
                 player for player in guests
                 if player not in connected_players
-            ])
+            # The host is included here, because he might be responsible for
+            # a guest being unable to connect, e.g. because they didn't
+            # receive his connect message.
+            ] + [host])
 
     async def get_game_history(
         self,

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -680,12 +680,12 @@ class LadderService(Service):
             await game.wait_launched(60 + 10 * len(guests))
         except asyncio.TimeoutError:
             connected_players = game.get_connected_players()
-            raise NotConnectedError([
-                player for player in guests
-                if player not in connected_players
             # The host is included here, because he might be responsible for
             # a guest being unable to connect, e.g. because they didn't
             # receive his connect message.
+            raise NotConnectedError([
+                player for player in guests
+                if player not in connected_players
             ] + [host])
 
     async def get_game_history(


### PR DESCRIPTION
The host might be responsible for other players failing to connect to the game. The host will now receive a matchmaker violation every time the game setup times out. This might punish innocent hosts, but to prevent abuse it is important to acknowledge the possible contribution of the host as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved match launch timeout handling by ensuring all players, including the host, are properly detected as disconnected when a match fails to launch within the timeout window. This enables more accurate failure handling and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->