### PR TITLE
Waive time requirement for ranking custom games when recalling

### DIFF
--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -34,7 +34,7 @@ class CustomGame(Game):
         # In other words, only if a team unaminously recalled would we know
         # there weren't any connection issues.
         looks_like_quitting = {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING}
-        all_outcomes = {}
+        all_outcomes = set()
         for outcome in team_army_outcomes:
             all_outcomes |= outcome
         possible_conn_issues = len(all_outcomes & looks_like_quitting) > 0

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -31,7 +31,7 @@ class CustomGame(Game):
         # As we only get extremely limited data (the army results), our lens of
         # what can look like "quitting out" is rather large (i.e. the player is
         # "defeated").
-        # In other words, only if a team unaminously recalled would we know
+        # In other words, only if a team unanimously recalled would we know
         # there weren't any connection issues.
         looks_like_quitting = {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING}
         all_outcomes = set()

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -3,6 +3,7 @@ import time
 from server.rating import RatingType
 
 from .game import Game
+from .game_results import ArmyOutcome
 from .typedefs import GameType, InitMode, ValidityState
 
 
@@ -18,9 +19,25 @@ class CustomGame(Game):
         new_kwargs.update(kwargs)
         super().__init__(id, *args, **new_kwargs)
 
-    async def _run_pre_rate_validity_checks(self):
+    async def _run_pre_rate_validity_checks(self, team_army_outcomes: list[set[ArmyOutcome]]):
         assert self.launched_at is not None
 
+        # if there were connection issues, they are likely to show up early in
+        # the match and manifest as players quitting out - in these cases, we
+        # grant a grace period to custom games before we count them as ranked
         limit = len(self.players) * 60
-        if not self.enforce_rating and time.time() - self.launched_at < limit:
+        duration = time.time() - self.launched_at
+
+        # As we only get extremely limited data (the army results), our lens of
+        # what can look like "quitting out" is rather large (i.e. the player is
+        # "defeated").
+        # In other words, only if a team unaminously recalled would we know
+        # there weren't any connection issues.
+        looks_like_quitting = {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING}
+        all_outcomes = {}
+        for outcome in team_army_outcomes:
+            all_outcomes |= outcome
+        possible_conn_issues = len(all_outcomes & looks_like_quitting) > 0
+
+        if not self.enforce_rating and (possible_conn_issues and duration < limit):
             await self.mark_invalid(ValidityState.TOO_SHORT)

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -39,5 +39,5 @@ class CustomGame(Game):
             all_outcomes |= outcome
         possible_conn_issues = len(all_outcomes & looks_like_quitting) > 0
 
-        if not self.enforce_rating and (possible_conn_issues and duration < limit):
+        if not self.enforce_rating and possible_conn_issues and duration < limit:
             await self.mark_invalid(ValidityState.TOO_SHORT)

--- a/server/games/custom_game.py
+++ b/server/games/custom_game.py
@@ -34,9 +34,7 @@ class CustomGame(Game):
         # In other words, only if a team unanimously recalled would we know
         # there weren't any connection issues.
         looks_like_quitting = {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING}
-        all_outcomes = set()
-        for outcome in team_army_outcomes:
-            all_outcomes |= outcome
+        all_outcomes = {outcome for team in team_army_outcomes for outcome in team}
         possible_conn_issues = len(all_outcomes & looks_like_quitting) > 0
 
         if not self.enforce_rating and possible_conn_issues and duration < limit:

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -487,7 +487,7 @@ class Game:
 
             self.game_service.mark_dirty(self)
 
-    async def _run_pre_rate_validity_checks(self):
+    async def _run_pre_rate_validity_checks(self, team_army_results: list[set[ArmyOutcome]]):
         pass
 
     async def process_game_results(self):
@@ -504,8 +504,6 @@ class Game:
         if self.state not in (GameState.LIVE, GameState.ENDED):
             raise GameError("Cannot rate game that has not been launched.")
 
-        await self._run_pre_rate_validity_checks()
-
         basic_info = self.get_basic_info()
 
         team_army_results = [
@@ -518,6 +516,8 @@ class Game:
             {self.get_player_outcome(player) for player in team}
             for team in basic_info.teams
         ]
+        
+        await self._run_pre_rate_validity_checks(team_player_partial_outcomes)
 
         try:
             # TODO: Remove override once game result messages are reliable

--- a/server/games/game.py
+++ b/server/games/game.py
@@ -516,7 +516,7 @@ class Game:
             {self.get_player_outcome(player) for player in team}
             for team in basic_info.teams
         ]
-        
+
         await self._run_pre_rate_validity_checks(team_player_partial_outcomes)
 
         try:

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -18,6 +18,7 @@ class ArmyOutcome(Enum):
     """
     VICTORY = "VICTORY"
     DEFEAT = "DEFEAT"
+    RECALL = "RECALL" # treated the same as `DEFEAT` except for conn issues
     DRAW = "DRAW"
     UNKNOWN = "UNKNOWN"
     CONFLICTING = "CONFLICTING"
@@ -29,6 +30,7 @@ class ArmyReportedOutcome(Enum):
     """
     VICTORY = "VICTORY"
     DEFEAT = "DEFEAT"
+    RECALL = "RECALL"
     DRAW = "DRAW"
     # This doesn't seem to be reported by the game anymore
     MUTUAL_DRAW = "MUTUAL_DRAW"

--- a/server/games/game_results.py
+++ b/server/games/game_results.py
@@ -18,7 +18,7 @@ class ArmyOutcome(Enum):
     """
     VICTORY = "VICTORY"
     DEFEAT = "DEFEAT"
-    RECALL = "RECALL" # treated the same as `DEFEAT` except for conn issues
+    RECALL = "RECALL"  # treated the same as `DEFEAT` except for conn issues
     DRAW = "DRAW"
     UNKNOWN = "UNKNOWN"
     CONFLICTING = "CONFLICTING"

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -12,6 +12,29 @@ async def custom_game(database, game_service, game_stats_service):
     return CustomGame(42, database, game_service, game_stats_service)
 
 
+
+async def test_rate_game_early_recall(
+    custom_game: CustomGame,
+    player_factory
+):
+    custom_game.state = GameState.LOBBY
+    players = [
+        player_factory("Dostya", player_id=1, global_rating=(1500, 500)),
+        player_factory("Rhiza", player_id=2, global_rating=(1500, 500)),
+    ]
+    add_connected_players(custom_game, players)
+    custom_game.set_player_option(1, "Team", 2)
+    custom_game.set_player_option(2, "Team", 3)
+    await custom_game.launch()
+    await custom_game.add_result(0, 0, "victory", 5)
+    await custom_game.add_result(0, 1, "recall", -5)
+
+    custom_game.launched_at = time.time() - 60  # seconds
+
+    await custom_game.on_game_finish()
+    assert custom_game.validity == ValidityState.VALID
+
+
 async def test_rate_game_early_abort_no_enforce(
     custom_game: CustomGame,
     player_factory

--- a/tests/unit_tests/test_custom_game.py
+++ b/tests/unit_tests/test_custom_game.py
@@ -12,7 +12,6 @@ async def custom_game(database, game_service, game_stats_service):
     return CustomGame(42, database, game_service, game_stats_service)
 
 
-
 async def test_rate_game_early_recall(
     custom_game: CustomGame,
     player_factory

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -1,4 +1,4 @@
-    from typing import Optional
+from typing import Optional
 
 import pytest
 

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -1,3 +1,5 @@
+    from typing import Optional
+
 import pytest
 
 from server.games.game_results import (
@@ -6,7 +8,6 @@ from server.games.game_results import (
     GameResolutionError,
     resolve_game
 )
-from typing import Optional
 
 
 class ResolutionTest:

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -37,68 +37,39 @@ def testresolve():
 def test_ranks_all_1v1_possibilities():
     """
     Document expectations for all outcomes of 1v1 games.
-    Assumes that the order of teams doesn't matter.
-    With five possible outcomes there are 15 possibilities.
+    With six possible outcomes there are 36 possibilities.
     """
-    team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.VICTORY}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
 
-    team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.DEFEAT}]
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    ERROR = 0
+    DRAW = 1
+    WIN = 2
+    LOSS = 3
+    #        Victory  Defeat   Recall   Draw     Unknown  Conflicting
+    grid = [[ERROR,   WIN,     WIN,     WIN,     WIN,     WIN  ]  # Victory
+            [LOSS,    DRAW,    DRAW,    ERROR,   ERROR,   ERROR]  # Defeat
+            [LOSS,    DRAW,    DRAW,    ERROR,   ERROR,   ERROR]  # Recall
+            [LOSS,    ERROR,   ERROR,   DRAW,    ERROR,   ERROR]  # Draw
+            [LOSS,    ERROR,   ERROR,   ERROR,   ERROR,   ERROR]  # Unknown
+            [LOSS,    ERROR,   ERROR,   ERROR,   ERROR,   ERROR]] # Conflicting
+    outcome_list = [ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT, ArmyOutcome.RECALL,
+            ArmyOutcome.DRAW, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING]
 
-    team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.DRAW}]
-    resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    win_resolution = [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    draw_resolution = [GameOutcome.DRAW, GameOutcome.DRAW]
+    loss_resolution = [GameOutcome.DEFEAT, GameOutcome.VICTORY]
 
-    team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.UNKNOWN}]
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
-
-    team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.CONFLICTING}]
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
-
-    team_outcomes = [{ArmyOutcome.DEFEAT}, {ArmyOutcome.DEFEAT}]
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.DRAW, GameOutcome.DRAW]
-
-    team_outcomes = [{ArmyOutcome.DEFEAT}, {ArmyOutcome.DRAW}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.DEFEAT}, {ArmyOutcome.UNKNOWN}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.DEFEAT}, {ArmyOutcome.CONFLICTING}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.DRAW}, {ArmyOutcome.DRAW}]
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.DRAW, GameOutcome.DRAW]
-
-    team_outcomes = [{ArmyOutcome.DRAW}, {ArmyOutcome.UNKNOWN}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.DRAW}, {ArmyOutcome.CONFLICTING}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.UNKNOWN}, {ArmyOutcome.UNKNOWN}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.UNKNOWN}, {ArmyOutcome.CONFLICTING}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
-
-    team_outcomes = [{ArmyOutcome.CONFLICTING}, {ArmyOutcome.CONFLICTING}]
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
+    for outcome1, row in grid:
+        for outcome2, resolution in row:
+            team_outcomes = [{outcome_list[outcome1]}, {outcome_list[outcome2]}]
+            if resolution == ERROR:
+                with pytest.raises(GameResolutionError):
+                    resolve_game(team_outcomes)
+            elif resolution == WIN:
+                assert resolve_game(team_outcomes) == win_resolution
+            elif resolution == DRAW:
+                assert resolve_game(team_outcomes) == draw_resolution
+            elif resolution == LOSS:
+                assert resolve_game(team_outcomes) == loss_resolution
 
 
 def test_team_outcome_ignores_unknown():

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -7,6 +7,24 @@ from server.games.game_results import (
     resolve_game
 )
 
+class ResolutionTest:
+    resolution: Optional[list[GameOutcome]]
+
+    def __init__(self, resolution: Optional[list[GameOutcome]]):
+        self.resolution = resolution
+
+    def __call__(self, partial_outcomes: list[set[ArmyOutcome]]):
+        if self.resolution is None:
+            with pytest.raises(GameResolutionError):
+                resolve_game(partial_outcomes)
+        else:
+            assert resolve_game(partial_outcomes) == self.resolution
+
+ResolveError = ResolutionTest(None)
+ResolveWin = ResolutionTest([GameOutcome.VICTORY, GameOutcome.DEFEAT])
+ResolveDraw = ResolutionTest([GameOutcome.DRAW, GameOutcome.DRAW])
+ResolveLoss = ResolutionTest([GameOutcome.DEFEAT, GameOutcome.VICTORY])
+
 
 def test_only_rate_with_two_parties():
     one_party = [{ArmyOutcome.VICTORY}]
@@ -17,21 +35,14 @@ def test_only_rate_with_two_parties():
         {ArmyOutcome.DEFEAT}
     ]
 
-    with pytest.raises(GameResolutionError):
-        resolve_game(one_party)
-
-    with pytest.raises(GameResolutionError):
-        resolve_game(three_parties)
-
+    ResolveError(one_party)
+    ResolveError(three_parties)
     resolve_game(two_parties)
 
 
 def testresolve():
     team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.DEFEAT}]
-
-    ranks = resolve_game(team_outcomes)
-
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    ResolveWin(team_outcomes)
 
 
 def test_ranks_all_1v1_possibilities():
@@ -40,36 +51,24 @@ def test_ranks_all_1v1_possibilities():
     With six possible outcomes there are 36 possibilities.
     """
 
-    ERROR = 0
-    DRAW = 1
-    WIN = 2
-    LOSS = 3
-    #        Victory  Defeat   Recall   Draw     Unknown  Conflicting
-    grid = [[ERROR,   WIN,     WIN,     WIN,     WIN,     WIN  ]  # Victory
-            [LOSS,    DRAW,    DRAW,    ERROR,   ERROR,   ERROR]  # Defeat
-            [LOSS,    DRAW,    DRAW,    ERROR,   ERROR,   ERROR]  # Recall
-            [LOSS,    ERROR,   ERROR,   DRAW,    ERROR,   ERROR]  # Draw
-            [LOSS,    ERROR,   ERROR,   ERROR,   ERROR,   ERROR]  # Unknown
-            [LOSS,    ERROR,   ERROR,   ERROR,   ERROR,   ERROR]] # Conflicting
-    outcome_list = [ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT, ArmyOutcome.RECALL,
-            ArmyOutcome.DRAW, ArmyOutcome.UNKNOWN, ArmyOutcome.CONFLICTING]
+    ERR_ = ResolveError
+    WIN_ = ResolveWin
+    DRAW = ResolveDraw
+    LOSS = ResolveLoss
+    #        Victory     Recall      Unknown
+    #              Defeat      Draw        Conflicting
+    grid = [[ERR_, WIN_, WIN_, WIN_, WIN_, WIN_],  # Victory
+            [LOSS, DRAW, DRAW, ERR_, ERR_, ERR_],  # Defeat
+            [LOSS, DRAW, DRAW, ERR_, ERR_, ERR_],  # Recall
+            [LOSS, ERR_, ERR_, DRAW, ERR_, ERR_],  # Draw
+            [LOSS, ERR_, ERR_, ERR_, ERR_, ERR_],  # Unknown
+            [LOSS, ERR_, ERR_, ERR_, ERR_, ERR_]]  # Conflicting
+    outcome_list = [o for o in ArmyOutcome]
 
-    win_resolution = [GameOutcome.VICTORY, GameOutcome.DEFEAT]
-    draw_resolution = [GameOutcome.DRAW, GameOutcome.DRAW]
-    loss_resolution = [GameOutcome.DEFEAT, GameOutcome.VICTORY]
-
-    for outcome1, row in grid:
-        for outcome2, resolution in row:
+    for outcome1, row in enumerate(grid):
+        for outcome2, Resolution in enumerate(row):
             team_outcomes = [{outcome_list[outcome1]}, {outcome_list[outcome2]}]
-            if resolution == ERROR:
-                with pytest.raises(GameResolutionError):
-                    resolve_game(team_outcomes)
-            elif resolution == WIN:
-                assert resolve_game(team_outcomes) == win_resolution
-            elif resolution == DRAW:
-                assert resolve_game(team_outcomes) == draw_resolution
-            elif resolution == LOSS:
-                assert resolve_game(team_outcomes) == loss_resolution
+            Resolution(team_outcomes)
 
 
 def test_team_outcome_ignores_unknown():
@@ -77,9 +76,7 @@ def test_team_outcome_ignores_unknown():
         {ArmyOutcome.VICTORY, ArmyOutcome.UNKNOWN},
         {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN},
     ]
-
-    ranks = resolve_game(team_outcomes)
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    ResolveWin(team_outcomes)
 
 
 def test_team_outcome_throws_if_unilateral_draw():
@@ -87,9 +84,7 @@ def test_team_outcome_throws_if_unilateral_draw():
         {ArmyOutcome.DRAW, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN},
     ]
-
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
+    ResolveError(team_outcomes)
 
 
 def test_team_outcome_victory_has_priority_over_defeat():
@@ -97,10 +92,7 @@ def test_team_outcome_victory_has_priority_over_defeat():
         {ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.DEFEAT},
     ]
-
-    ranks = resolve_game(team_outcomes)
-
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    ResolveWin(team_outcomes)
 
 
 def test_team_outcome_victory_has_priority_over_draw():
@@ -108,10 +100,7 @@ def test_team_outcome_victory_has_priority_over_draw():
         {ArmyOutcome.VICTORY, ArmyOutcome.DRAW},
         {ArmyOutcome.DRAW, ArmyOutcome.DEFEAT},
     ]
-
-    ranks = resolve_game(team_outcomes)
-
-    assert ranks == [GameOutcome.VICTORY, GameOutcome.DEFEAT]
+    ResolveWin(team_outcomes)
 
 
 def test_team_outcome_no_double_victory():
@@ -119,9 +108,7 @@ def test_team_outcome_no_double_victory():
         {ArmyOutcome.VICTORY, ArmyOutcome.VICTORY},
         {ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT},
     ]
-
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
+    ResolveError(team_outcomes)
 
 
 def test_team_outcome_unranked_if_ambiguous():
@@ -129,6 +116,4 @@ def test_team_outcome_unranked_if_ambiguous():
         {ArmyOutcome.UNKNOWN, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.DEFEAT},
     ]
-
-    with pytest.raises(GameResolutionError):
-        resolve_game(team_outcomes)
+    ResolveError(team_outcomes)

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -7,6 +7,7 @@ from server.games.game_results import (
     resolve_game
 )
 
+
 class ResolutionTest:
     resolution: Optional[list[GameOutcome]]
 
@@ -19,6 +20,7 @@ class ResolutionTest:
                 resolve_game(partial_outcomes)
         else:
             assert resolve_game(partial_outcomes) == self.resolution
+
 
 ResolveError = ResolutionTest(None)
 ResolveWin = ResolutionTest([GameOutcome.VICTORY, GameOutcome.DEFEAT])

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -6,6 +6,7 @@ from server.games.game_results import (
     GameResolutionError,
     resolve_game
 )
+from typing import Optional
 
 
 class ResolutionTest:

--- a/tests/unit_tests/test_game_resolution.py
+++ b/tests/unit_tests/test_game_resolution.py
@@ -24,10 +24,10 @@ class ResolutionTest:
             assert resolve_game(partial_outcomes) == self.resolution
 
 
-ResolveError = ResolutionTest(None)
-ResolveWin = ResolutionTest([GameOutcome.VICTORY, GameOutcome.DEFEAT])
-ResolveDraw = ResolutionTest([GameOutcome.DRAW, GameOutcome.DRAW])
-ResolveLoss = ResolutionTest([GameOutcome.DEFEAT, GameOutcome.VICTORY])
+resolve_to_error = ResolutionTest(None)
+resolve_to_win = ResolutionTest([GameOutcome.VICTORY, GameOutcome.DEFEAT])
+resolve_to_draw = ResolutionTest([GameOutcome.DRAW, GameOutcome.DRAW])
+resolve_to_loss = ResolutionTest([GameOutcome.DEFEAT, GameOutcome.VICTORY])
 
 
 def test_only_rate_with_two_parties():
@@ -39,14 +39,14 @@ def test_only_rate_with_two_parties():
         {ArmyOutcome.DEFEAT}
     ]
 
-    ResolveError(one_party)
-    ResolveError(three_parties)
+    resolve_to_error(one_party)
+    resolve_to_error(three_parties)
     resolve_game(two_parties)
 
 
 def testresolve():
     team_outcomes = [{ArmyOutcome.VICTORY}, {ArmyOutcome.DEFEAT}]
-    ResolveWin(team_outcomes)
+    resolve_to_win(team_outcomes)
 
 
 def test_ranks_all_1v1_possibilities():
@@ -55,24 +55,22 @@ def test_ranks_all_1v1_possibilities():
     With six possible outcomes there are 36 possibilities.
     """
 
-    ERR_ = ResolveError
-    WIN_ = ResolveWin
-    DRAW = ResolveDraw
-    LOSS = ResolveLoss
+    err_, win_, draw, loss = (resolve_to_error, resolve_to_win, resolve_to_draw, resolve_to_loss)
     #        Victory     Recall      Unknown
     #              Defeat      Draw        Conflicting
-    grid = [[ERR_, WIN_, WIN_, WIN_, WIN_, WIN_],  # Victory
-            [LOSS, DRAW, DRAW, ERR_, ERR_, ERR_],  # Defeat
-            [LOSS, DRAW, DRAW, ERR_, ERR_, ERR_],  # Recall
-            [LOSS, ERR_, ERR_, DRAW, ERR_, ERR_],  # Draw
-            [LOSS, ERR_, ERR_, ERR_, ERR_, ERR_],  # Unknown
-            [LOSS, ERR_, ERR_, ERR_, ERR_, ERR_]]  # Conflicting
-    outcome_list = [o for o in ArmyOutcome]
+    grid = [[err_, win_, win_, win_, win_, win_],  # Victory
+            [loss, draw, draw, err_, err_, err_],  # Defeat
+            [loss, draw, draw, err_, err_, err_],  # Recall
+            [loss, err_, err_, draw, err_, err_],  # Draw
+            [loss, err_, err_, err_, err_, err_],  # Unknown
+            [loss, err_, err_, err_, err_, err_]]  # Conflicting
+    outcome_list = list(ArmyOutcome)
+    assert len(outcome_list) == len(grid) == len(grid[0])
 
     for outcome1, row in enumerate(grid):
-        for outcome2, Resolution in enumerate(row):
+        for outcome2, resolution in enumerate(row):
             team_outcomes = [{outcome_list[outcome1]}, {outcome_list[outcome2]}]
-            Resolution(team_outcomes)
+            resolution(team_outcomes)
 
 
 def test_team_outcome_ignores_unknown():
@@ -80,7 +78,7 @@ def test_team_outcome_ignores_unknown():
         {ArmyOutcome.VICTORY, ArmyOutcome.UNKNOWN},
         {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN},
     ]
-    ResolveWin(team_outcomes)
+    resolve_to_win(team_outcomes)
 
 
 def test_team_outcome_throws_if_unilateral_draw():
@@ -88,7 +86,7 @@ def test_team_outcome_throws_if_unilateral_draw():
         {ArmyOutcome.DRAW, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.UNKNOWN},
     ]
-    ResolveError(team_outcomes)
+    resolve_to_error(team_outcomes)
 
 
 def test_team_outcome_victory_has_priority_over_defeat():
@@ -96,7 +94,7 @@ def test_team_outcome_victory_has_priority_over_defeat():
         {ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.DEFEAT},
     ]
-    ResolveWin(team_outcomes)
+    resolve_to_win(team_outcomes)
 
 
 def test_team_outcome_victory_has_priority_over_draw():
@@ -104,7 +102,7 @@ def test_team_outcome_victory_has_priority_over_draw():
         {ArmyOutcome.VICTORY, ArmyOutcome.DRAW},
         {ArmyOutcome.DRAW, ArmyOutcome.DEFEAT},
     ]
-    ResolveWin(team_outcomes)
+    resolve_to_win(team_outcomes)
 
 
 def test_team_outcome_no_double_victory():
@@ -112,7 +110,7 @@ def test_team_outcome_no_double_victory():
         {ArmyOutcome.VICTORY, ArmyOutcome.VICTORY},
         {ArmyOutcome.VICTORY, ArmyOutcome.DEFEAT},
     ]
-    ResolveError(team_outcomes)
+    resolve_to_error(team_outcomes)
 
 
 def test_team_outcome_unranked_if_ambiguous():
@@ -120,4 +118,4 @@ def test_team_outcome_unranked_if_ambiguous():
         {ArmyOutcome.UNKNOWN, ArmyOutcome.DEFEAT},
         {ArmyOutcome.DEFEAT, ArmyOutcome.DEFEAT},
     ]
-    ResolveError(team_outcomes)
+    resolve_to_error(team_outcomes)

--- a/tests/unit_tests/test_game_results.py
+++ b/tests/unit_tests/test_game_results.py
@@ -19,6 +19,7 @@ def game_results():
 def test_reported_result_to_resolved():
     assert ArmyReportedOutcome.VICTORY.to_resolved() is ArmyOutcome.VICTORY
     assert ArmyReportedOutcome.DEFEAT.to_resolved() is ArmyOutcome.DEFEAT
+    assert ArmyReportedOutcome.RECALL.to_resolved() is ArmyOutcome.RECALL
     assert ArmyReportedOutcome.DRAW.to_resolved() is ArmyOutcome.DRAW
     assert ArmyReportedOutcome.MUTUAL_DRAW.to_resolved() is ArmyOutcome.DRAW
 


### PR DESCRIPTION
The time requirement for ranking custom games is in place so that connection issues can be discovered early in the match and rehosted without penalty to rating. However, if a team unanimously agrees to recall during that time frame, it is safe to presume that it was not due to any connection issues and they actually do want to forfeit the match.

This PR introduces a check on the prevalidation step of ranking a game that skips the `TOO_SHORT` path if there wasn't anything that looks like it could have been a connection issue by introducing a `RECALL` army result.

Note that the game itself will still need to be [updated](https://github.com/FAForever/fa/pull/6960) to report such a result; this is only the preparation step to allow the server to handle recalling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a RECALL outcome to represent early recalls/withdrawals and included its resolution behavior.

* **Bug Fixes**
  * Pre-rate validity now considers per-team outcome indicators together with elapsed time before marking games as too short, reducing false invalidations for early disconnect/recall scenarios.

* **Tests**
  * Added unit coverage for early-recall scenarios and refactored outcome-resolution tests to exercise all outcome permutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->