### PR TITLE
Refactor/veto stuff

### DIFF
--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -639,7 +639,7 @@ class LadderService(Service):
                     game_options=game_options,
                     team=game.get_player_option(player.id, "Team"),
                     faction=game.get_player_option(player.id, "Faction"),
-                    map_position=game.get_player_option(player.id, "StartSpot")
+                    map_position=game.get_player_option(player.id, "StartSpot"),
                 )
 
             await self.launch_match(game, host, all_guests, make_game_options)

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -639,8 +639,7 @@ class LadderService(Service):
                     game_options=game_options,
                     team=game.get_player_option(player.id, "Team"),
                     faction=game.get_player_option(player.id, "Faction"),
-                    map_position=game.get_player_option(player.id, "StartSpot"),
-                    map_pool_map_version_id=game_map.map_pool_map_version_id
+                    map_position=game.get_player_option(player.id, "StartSpot")
                 )
 
             await self.launch_match(game, host, all_guests, make_game_options)

--- a/server/types.py
+++ b/server/types.py
@@ -29,7 +29,6 @@ class GameLaunchOptions(NamedTuple):
     expected_players: Optional[int] = None
     map_position: Optional[int] = None
     game_options: Optional[dict[str, Any]] = None
-    map_pool_map_version_id: Optional[int] = None
 
 
 class MatchmakerQueueMapPoolVetoData(NamedTuple):

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -45,8 +45,6 @@ async def test_game_launch_message(lobby_server):
 
     assert "scmp_015" in msg1["mapname"]
     del msg1["mapname"]
-    mpmv_id = msg1["map_pool_map_version_id"]
-    assert mpmv_id in [1, 2, 3]
     assert msg1 == {
         "command": "game_launch",
         "args": ["/numgames", 0],
@@ -59,8 +57,7 @@ async def test_game_launch_message(lobby_server):
         "team": 2,
         "faction": 1,
         "expected_players": 2,
-        "map_position": 1,
-        "map_pool_map_version_id": mpmv_id
+        "map_position": 1
     }
 
 

--- a/tests/integration_tests/test_matchmaker.py
+++ b/tests/integration_tests/test_matchmaker.py
@@ -57,7 +57,7 @@ async def test_game_launch_message(lobby_server):
         "team": 2,
         "faction": 1,
         "expected_players": 2,
-        "map_position": 1
+        "map_position": 1,
     }
 
 

--- a/tests/integration_tests/test_matchmaker_vetoes.py
+++ b/tests/integration_tests/test_matchmaker_vetoes.py
@@ -10,14 +10,17 @@ from .test_game import (
 )
 
 
-async def test_used_pools_have_some_maps_and_all_map_names_are_unique(database, ladder_service):
-    async with database.acquire() as conn:
-        map_pools = await ladder_service.fetch_map_pools(conn)
-        for pool_id in [1, 2, 3, 4]:
-            _, maps = map_pools[pool_id]
+async def test_used_pools_have_some_maps_and_all_map_names_are_unique(ladder_service):
+    all_map_pools = []
+    for queue in ladder_service.queues.values():
+        all_map_pools.extend(queue.map_pools)
+
+    for mq_map_pool in all_map_pools:
+        if mq_map_pool.map_pool.id in [1, 2, 3, 4]:
+            maps = list(mq_map_pool.map_pool.maps.values())
             folder_names = [m.folder_name for m in maps if hasattr(m, "folder_name")]
-            assert len(folder_names) > 0
-            assert len(folder_names) == len(set(folder_names)), f"Pool {pool_id} has duplicate map names: {folder_names}"
+            assert len(folder_names) > 0, f"Pool {mq_map_pool.map_pool.id} has no regular maps"
+            assert len(folder_names) == len(set(folder_names)), f"Pool {mq_map_pool.map_pool.id} has duplicate map names: {folder_names}"
 
 
 async def test_vetoes_are_assigned_to_player_with_adjusting(lobby_server, player_service):

--- a/tests/integration_tests/test_matchmaker_vetoes.py
+++ b/tests/integration_tests/test_matchmaker_vetoes.py
@@ -10,12 +10,13 @@ from .test_game import (
 )
 
 
-async def test_used_pools_have_unique_map_names(database, ladder_service):
+async def test_used_pools_have_some_maps_and_all_map_names_are_unique(database, ladder_service):
     async with database.acquire() as conn:
         map_pools = await ladder_service.fetch_map_pools(conn)
         for pool_id in [1, 2, 3, 4]:
             _, maps = map_pools[pool_id]
-            folder_names = [m.folder_name for m in maps]
+            folder_names = [m.folder_name for m in maps if hasattr(m, "folder_name")]
+            assert len(folder_names) > 0
             assert len(folder_names) == len(set(folder_names)), f"Pool {pool_id} has duplicate map names: {folder_names}"
 
 

--- a/tests/integration_tests/test_matchmaker_vetoes.py
+++ b/tests/integration_tests/test_matchmaker_vetoes.py
@@ -10,6 +10,15 @@ from .test_game import (
 )
 
 
+async def test_used_pools_have_unique_map_names(database, ladder_service):
+    async with database.acquire() as conn:
+        map_pools = await ladder_service.fetch_map_pools(conn)
+        for pool_id in [1, 2, 3, 4]:
+            _, maps = map_pools[pool_id]
+            folder_names = [m.folder_name for m in maps]
+            assert len(folder_names) == len(set(folder_names)), f"Pool {pool_id} has duplicate map names: {folder_names}"
+
+
 async def test_vetoes_are_assigned_to_player_with_adjusting(lobby_server, player_service):
     async def test_vetoes(proto, vetoes, expected_vetoes):
         await proto.send_message({
@@ -51,8 +60,7 @@ async def test_if_veto_bans_working(lobby_server, mocker):
 
         msg1 = await client_response(proto1)
 
-        chosen_map_pool_version_id = msg1["map_pool_map_version_id"]
-        assert chosen_map_pool_version_id == 3
+        assert msg1["mapname"] == "scmp_015.v0003"
 
         await end_game_as_draw([proto1, proto2], msg1["uid"])
 
@@ -75,8 +83,7 @@ async def test_dynamic_max_tokens_per_map(lobby_server, mocker):
 
         msg1 = await client_response(proto1)
 
-        chosen_map_pool_version_id = msg1["map_pool_map_version_id"]
-        assert chosen_map_pool_version_id == 8
+        assert msg1["mapname"] == "scmp_015.v0003"
         await end_game_as_draw([proto1, proto2], msg1["uid"])
 
 
@@ -99,12 +106,12 @@ async def test_partial_vetoes(lobby_server, mocker):
 
         msg1 = await client_response(proto1)
 
-        chosen_map_pool_version_id = msg1["map_pool_map_version_id"]
-        chosen_maps.add(chosen_map_pool_version_id)
-        assert chosen_map_pool_version_id in [10, 11], f"Expected map 10 or 11, got {chosen_map_pool_version_id}"
+        chosen_mapname = msg1["mapname"]
+        chosen_maps.add(chosen_mapname)
+        assert chosen_mapname in ["scmp_002", "scmp_003"], f"Expected scmp_002 or scmp_003, got {chosen_mapname}"
         await end_game_as_draw([proto1, proto2], msg1["uid"])
 
-    assert chosen_maps == {10, 11}, f"Expected games on both maps 10 and 11, got {chosen_maps}"
+    assert chosen_maps == {"scmp_002", "scmp_003"}, f"Expected games on both scmp_002 and scmp_003, got {chosen_maps}"
 
 
 @fast_forward(120)
@@ -130,8 +137,7 @@ async def test_vetoes_tmm(lobby_server, mocker):
             await read_until_command(proto, "match_found", timeout=30)
 
         msg1 = await client_response(players[0])
-        chosen_map_pool_version_id = msg1["map_pool_map_version_id"]
-        assert chosen_map_pool_version_id == 10
+        assert msg1["mapname"] == "scmp_002"
         await end_game_as_draw(players, msg1["uid"])
 
 

--- a/tests/integration_tests/test_matchmaker_vetoes.py
+++ b/tests/integration_tests/test_matchmaker_vetoes.py
@@ -11,16 +11,20 @@ from .test_game import (
 
 
 async def test_used_pools_have_some_maps_and_all_map_names_are_unique(ladder_service):
-    all_map_pools = []
+    used_map_pools = {}
     for queue in ladder_service.queues.values():
-        all_map_pools.extend(queue.map_pools)
+        for mq_map_pool in queue.map_pools.values():
+            pool_id = mq_map_pool.map_pool.id
+            if pool_id in [1, 2, 3]:
+                used_map_pools[pool_id] = mq_map_pool
 
-    for mq_map_pool in all_map_pools:
-        if mq_map_pool.map_pool.id in [1, 2, 3, 4]:
-            maps = list(mq_map_pool.map_pool.maps.values())
-            folder_names = [m.folder_name for m in maps if hasattr(m, "folder_name")]
-            assert len(folder_names) > 0, f"Pool {mq_map_pool.map_pool.id} has no regular maps"
-            assert len(folder_names) == len(set(folder_names)), f"Pool {mq_map_pool.map_pool.id} has duplicate map names: {folder_names}"
+    assert len(used_map_pools) == 3
+
+    for mq_map_pool in used_map_pools.values():
+        maps = list(mq_map_pool.map_pool.maps.values())
+        folder_names = [m.folder_name for m in maps if hasattr(m, "folder_name")]
+        assert len(folder_names) > 0, f"Pool {mq_map_pool.map_pool.id} has no regular maps"
+        assert len(folder_names) == len(set(folder_names)), f"Pool {mq_map_pool.map_pool.id} has duplicate map names: {folder_names}"
 
 
 async def test_vetoes_are_assigned_to_player_with_adjusting(lobby_server, player_service):


### PR DESCRIPTION
Removed map_pool_map_version_id from GameLaunchOptions and fixed the tests so they use map name instead
added additional test which checks if map names are unique since its not guaranteed but required for veto system tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Game launches no longer include map version IDs; map selection is conveyed by map name and start position, simplifying per-player launch options.

* **Tests**
  * Updated matchmaker tests to expect map names instead of version IDs.
  * Added a test ensuring each map pool has at least one map and that map names are unique within each pool.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->