### PR TITLE
Add localizable metadata to ban notices

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67adacda446396d91de50fe41c426c738226113aa0b3e3f16a00f2141ff7bc8a"
+            "sha256": "a187fb4a62ec0cc2dab78542af7c21eb559388bac49e0f84f35f656aa1e19200"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -39,6 +39,19 @@ class BanError(Exception):
             "moderation@faforever.com</i>"
         )
 
+    def notice(self):
+        return {
+            "command": "notice",
+            "style": "error",
+            "text": self.message(),
+            "i18n_key": "login.error.banned",
+            "i18n_args": [
+                self.ban_expiry.isoformat(),
+                self.ban_reason
+            ],
+            "expires_at": self.ban_expiry.isoformat()
+        }
+
     def _ban_duration_text(self):
         ban_duration = self.ban_expiry - datetime_now()
         if ban_duration.days > 365 * 100:

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -222,11 +222,7 @@ class LobbyConnection:
                 "text": e.message
             })
         except BanError as e:
-            await self.send({
-                "command": "notice",
-                "style": "error",
-                "text": e.message()
-            })
+            await self.send(e.notice())
             await self.abort(e.message())
         except ClientError as e:
             self._logger.warning(

--- a/server/protocol/qdatastream.py
+++ b/server/protocol/qdatastream.py
@@ -92,7 +92,7 @@ class QDataStreamProtocol(Protocol):
                 raise NotImplementedError("Only string serialization is supported")
 
             msg += QDataStreamProtocol.pack_qstring(arg)
-        return QDataStreamProtocol.pack_block(msg)
+        return QDataStreamProtocol.pack_block(bytes(msg))
 
     @staticmethod
     def encode_message(message: dict) -> bytes:

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -38,15 +38,15 @@ async def test_server_ban(lobby_server, user):
     proto = await connect_client(lobby_server)
     await perform_login(proto, user)
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
-            "<br><br><i>If you would like to appeal this ban, please send an "
-            "email to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "notice"
+    assert msg["style"] == "error"
+    assert msg["text"] == (
+        "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
+        "<br><br><i>If you would like to appeal this ban, please send an "
+        "email to: moderation@faforever.com</i>"
+    )
+    assert msg["i18n_key"] == "login.error.banned"
+    assert msg["i18n_args"] == [msg["expires_at"], "Test permanent ban"]
 
 
 @pytest.mark.parametrize("user", [
@@ -73,15 +73,15 @@ async def test_server_ban_token(lobby_server, user, jwk_priv_key, jwk_kid):
         "unique_id": "some_id"
     })
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
-            "<br><br><i>If you would like to appeal this ban, please send an "
-            "email to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "notice"
+    assert msg["style"] == "error"
+    assert msg["text"] == (
+        "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
+        "<br><br><i>If you would like to appeal this ban, please send an "
+        "email to: moderation@faforever.com</i>"
+    )
+    assert msg["i18n_key"] == "login.error.banned"
+    assert msg["i18n_args"] == [msg["expires_at"], "Test permanent ban"]
 
 
 @pytest.mark.parametrize("user", ["ban_revoked", "ban_expired"])

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -845,15 +845,15 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
     await proto.send_message({"command": command})
 
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test live ban<br>"
-            "<br><i>If you would like to appeal this ban, please send an email "
-            "to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "notice"
+    assert msg["style"] == "error"
+    assert msg["i18n_key"] == "login.error.banned"
+    assert msg["i18n_args"] == [msg["expires_at"], "Test live ban"]
+    assert msg["text"] == (
+        "You are banned from FAF forever. <br>Reason: <br>Test live ban<br>"
+        "<br><i>If you would like to appeal this ban, please send an email "
+        "to: moderation@faforever.com</i>"
+    )
 
 
 @fast_forward(5)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1308,6 +1308,17 @@ async def test_abort_connection_if_banned(
         "<br><br><i>If you would like to appeal this ban, please send an email "
         "to: moderation@faforever.com</i>"
     )
+    assert banned_error.value.notice() == {
+        "command": "notice",
+        "style": "error",
+        "text": banned_error.value.message(),
+        "i18n_key": "login.error.banned",
+        "i18n_args": [
+            banned_error.value.ban_expiry.isoformat(),
+            "Test permanent ban"
+        ],
+        "expires_at": banned_error.value.ban_expiry.isoformat()
+    }
 
     # test user who is banned for another 46 hours
     lobbyconnection.player.id = 204


### PR DESCRIPTION
Addresses #640

This keeps the existing English ban notice text for current clients, but adds structured fields clients can use for localization:

- `i18n_key`: `login.error.banned`
- `i18n_args`: `[expires_at, ban_reason]`
- `expires_at`: the ban expiry as an ISO timestamp

That gives the Downlord client enough data to translate/render the message locally without breaking older clients that still read `text`.

Companion PRs:
- FAForever/faf-java-commons#277
- FAForever/downlords-faf-client#3514

Verification:
- GitHub Actions `unit-test` — passed
- GitHub Actions `docker-build` — passed
- GitHub Actions lint jobs `isort`, `flake8`, `mypy`, `pipenv-verify` — passed
- Codecov `patch` and `project` — passed
- Codacy Static Code Analysis — passed
- CodeRabbit — passed
- Local: `python3 -m py_compile server/exceptions.py server/lobbyconnection.py tests/unit_tests/test_lobbyconnection.py tests/integration_tests/test_login.py`
- Local: `git diff --check`

Not run locally: pytest, because this machine does not have the repo pipenv/pytest environment installed.
