### PR TITLE
Replace ban notice text with structured banned message

### DIFF
--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -2,6 +2,8 @@
 Common exception definitions
 """
 
+from datetime import timezone
+
 import humanize
 
 from server.timing import datetime_now
@@ -38,6 +40,16 @@ class BanError(Exception):
             "<i>If you would like to appeal this ban, please send an email to: "
             "moderation@faforever.com</i>"
         )
+
+    def to_dict(self):
+        expires_at = self.ban_expiry
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return {
+            "command": "banned",
+            "expires_at": expires_at.astimezone(timezone.utc).isoformat(),
+            "reason": self.ban_reason,
+        }
 
     def _ban_duration_text(self):
         ban_duration = self.ban_expiry - datetime_now()

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -222,11 +222,7 @@ class LobbyConnection:
                 "text": e.message
             })
         except BanError as e:
-            await self.send({
-                "command": "notice",
-                "style": "error",
-                "text": e.message()
-            })
+            await self.send(e.to_dict())
             await self.abort(e.message())
         except ClientError as e:
             self._logger.warning(

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -38,15 +38,9 @@ async def test_server_ban(lobby_server, user):
     proto = await connect_client(lobby_server)
     await perform_login(proto, user)
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
-            "<br><br><i>If you would like to appeal this ban, please send an "
-            "email to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "banned"
+    assert msg["reason"] == "Test permanent ban"
+    assert "expires_at" in msg
 
 
 @pytest.mark.parametrize("user", [
@@ -73,15 +67,9 @@ async def test_server_ban_token(lobby_server, user, jwk_priv_key, jwk_kid):
         "unique_id": "some_id"
     })
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
-            "<br><br><i>If you would like to appeal this ban, please send an "
-            "email to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "banned"
+    assert msg["reason"] == "Test permanent ban"
+    assert "expires_at" in msg
 
 
 @pytest.mark.parametrize("user", ["ban_revoked", "ban_expired"])

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -845,15 +845,9 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
     await proto.send_message({"command": command})
 
     msg = await proto.read_message()
-    assert msg == {
-        "command": "notice",
-        "style": "error",
-        "text": (
-            "You are banned from FAF forever. <br>Reason: <br>Test live ban<br>"
-            "<br><i>If you would like to appeal this ban, please send an email "
-            "to: moderation@faforever.com</i>"
-        )
-    }
+    assert msg["command"] == "banned"
+    assert msg["reason"] == "Test live ban"
+    assert "expires_at" in msg
 
 
 @fast_forward(5)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -1,4 +1,3 @@
-import re
 from hashlib import sha256
 from unittest import mock
 
@@ -1303,18 +1302,14 @@ async def test_abort_connection_if_banned(
     lobbyconnection.player.id = 203
     with pytest.raises(BanError) as banned_error:
         await lobbyconnection.abort_connection_if_banned()
-    assert banned_error.value.message() == (
-        "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
-        "<br><br><i>If you would like to appeal this ban, please send an email "
-        "to: moderation@faforever.com</i>"
-    )
+    assert banned_error.value.to_dict()["command"] == "banned"
+    assert banned_error.value.to_dict()["reason"] == "Test permanent ban"
+    assert "expires_at" in banned_error.value.to_dict()
 
     # test user who is banned for another 46 hours
     lobbyconnection.player.id = 204
     with pytest.raises(BanError) as banned_error:
         await lobbyconnection.abort_connection_if_banned()
-    assert re.match(
-        r"You are banned from FAF for 1 day and 2[12]\.[0-9]+ hours. <br>"
-        "Reason: <br>Test ongoing ban with 46 hours left",
-        banned_error.value.message()
-    )
+    assert banned_error.value.to_dict()["command"] == "banned"
+    assert banned_error.value.to_dict()["reason"] == "Test ongoing ban with 46 hours left"
+    assert "expires_at" in banned_error.value.to_dict()


### PR DESCRIPTION
## Summary
- send a structured `banned` command when a user is rejected for an active ban
- include the ban reason and UTC ISO `expires_at` value for client-side localization
- update login and live-ban tests to assert the structured response

## Validation
- `python -m py_compile FAForever-server\server\exceptions.py FAForever-server\server\lobbyconnection.py FAForever-server\tests\integration_tests\test_login.py FAForever-server\tests\integration_tests\test_server.py FAForever-server\tests\unit_tests\test_lobbyconnection.py`
- `python -m pytest tests\unit_tests\test_lobbyconnection.py::test_abort_connection_if_banned tests\integration_tests\test_login.py::test_server_ban tests\integration_tests\test_login.py::test_server_ban_token tests\integration_tests\test_server.py::test_server_ban_prevents_hosting --mysql_database=faf -q`

Result: 13 passed, 8 warnings from test RSA key length.

Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Ban notifications now provide structured information including the ban reason and expiration time in a standardized format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/server/pull/1084)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->