### PR TITLE
Add localizable metadata to ban notice

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67adacda446396d91de50fe41c426c738226113aa0b3e3f16a00f2141ff7bc8a"
+            "sha256": "a187fb4a62ec0cc2dab78542af7c21eb559388bac49e0f84f35f656aa1e19200"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -6,6 +6,9 @@ import humanize
 
 from server.timing import datetime_now
 
+BAN_NOTICE_I18N_KEY = "notice.ban"
+BAN_APPEAL_EMAIL = "moderation@faforever.com"
+
 
 class ClientError(Exception):
     """
@@ -31,12 +34,23 @@ class BanError(Exception):
         self.ban_expiry = ban_expiry
         self.ban_reason = ban_reason
 
+    def localization(self):
+        return {
+            "i18n_key": BAN_NOTICE_I18N_KEY,
+            "i18n_args": {
+                "duration": self._ban_duration_text(),
+                "reason": self.ban_reason,
+                "appeal_email": BAN_APPEAL_EMAIL
+            }
+        }
+
     def message(self):
+        data = self.localization()["i18n_args"]
         return (
-            f"You are banned from FAF {self._ban_duration_text()}. <br>"
-            f"Reason: <br>{self.ban_reason}<br><br>"
+            f"You are banned from FAF {data['duration']}. <br>"
+            f"Reason: <br>{data['reason']}<br><br>"
             "<i>If you would like to appeal this ban, please send an email to: "
-            "moderation@faforever.com</i>"
+            f"{data['appeal_email']}</i>"
         )
 
     def _ban_duration_text(self):

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -222,12 +222,16 @@ class LobbyConnection:
                 "text": e.message
             })
         except BanError as e:
-            await self.send({
+            ban_notice = {
                 "command": "notice",
                 "style": "error",
-                "text": e.message()
+                "text": e.message(),
+                **e.localization()
+            }
+            await self.send({
+                **ban_notice
             })
-            await self.abort(e.message())
+            await self.abort(ban_notice["text"])
         except ClientError as e:
             self._logger.warning(
                 "ClientError[%s]: %s",

--- a/server/protocol/qdatastream.py
+++ b/server/protocol/qdatastream.py
@@ -92,7 +92,7 @@ class QDataStreamProtocol(Protocol):
                 raise NotImplementedError("Only string serialization is supported")
 
             msg += QDataStreamProtocol.pack_qstring(arg)
-        return QDataStreamProtocol.pack_block(msg)
+        return QDataStreamProtocol.pack_block(bytes(msg))
 
     @staticmethod
     def encode_message(message: dict) -> bytes:

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -45,7 +45,13 @@ async def test_server_ban(lobby_server, user):
             "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
             "<br><br><i>If you would like to appeal this ban, please send an "
             "email to: moderation@faforever.com</i>"
-        )
+        ),
+        "i18n_key": "notice.ban",
+        "i18n_args": {
+            "duration": "forever",
+            "reason": "Test permanent ban",
+            "appeal_email": "moderation@faforever.com"
+        }
     }
 
 
@@ -80,7 +86,13 @@ async def test_server_ban_token(lobby_server, user, jwk_priv_key, jwk_kid):
             "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
             "<br><br><i>If you would like to appeal this ban, please send an "
             "email to: moderation@faforever.com</i>"
-        )
+        ),
+        "i18n_key": "notice.ban",
+        "i18n_args": {
+            "duration": "forever",
+            "reason": "Test permanent ban",
+            "appeal_email": "moderation@faforever.com"
+        }
     }
 
 

--- a/tests/integration_tests/test_server.py
+++ b/tests/integration_tests/test_server.py
@@ -852,7 +852,13 @@ async def test_server_ban_prevents_hosting(lobby_server, database, command):
             "You are banned from FAF forever. <br>Reason: <br>Test live ban<br>"
             "<br><i>If you would like to appeal this ban, please send an email "
             "to: moderation@faforever.com</i>"
-        )
+        ),
+        "i18n_key": "notice.ban",
+        "i18n_args": {
+            "duration": "forever",
+            "reason": "Test live ban",
+            "appeal_email": "moderation@faforever.com"
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- add localization metadata for ban notices (i18n_key, i18n_args) while keeping existing 	ext`n- wire ban notice localization metadata into BanError handling path
- update integration tests for ban notice payload

## Verification
- python -m py_compile server/exceptions.py server/lobbyconnection.py tests/integration_tests/test_login.py tests/integration_tests/test_server.py
- pytest not run in this environment (module missing)

Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ban notice messages now include structured localization metadata with detailed information about ban duration, reason, and appeal contact details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/server/pull/1085)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->