### PR TITLE
Add localizable fields to ban notices

### DIFF
--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -39,6 +39,16 @@ class BanError(Exception):
             "moderation@faforever.com</i>"
         )
 
+    def to_notice(self):
+        return {
+            "command": "notice",
+            "style": "error",
+            "text": self.message(),
+            "localization_key": "ban.error",
+            "ban_reason": self.ban_reason,
+            "ban_expires_at": self.ban_expiry.isoformat(),
+        }
+
     def _ban_duration_text(self):
         ban_duration = self.ban_expiry - datetime_now()
         if ban_duration.days > 365 * 100:

--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -40,6 +40,9 @@ class BanError(Exception):
         )
 
     def to_notice(self):
+        """
+        Return a localized notice payload with a legacy text fallback.
+        """
         return {
             "command": "notice",
             "style": "error",

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -222,11 +222,7 @@ class LobbyConnection:
                 "text": e.message
             })
         except BanError as e:
-            await self.send({
-                "command": "notice",
-                "style": "error",
-                "text": e.message()
-            })
+            await self.send(e.to_notice())
             await self.abort(e.message())
         except ClientError as e:
             self._logger.warning(

--- a/tests/integration_tests/test_login.py
+++ b/tests/integration_tests/test_login.py
@@ -41,6 +41,9 @@ async def test_server_ban(lobby_server, user):
     assert msg == {
         "command": "notice",
         "style": "error",
+        "localization_key": "ban.error",
+        "ban_reason": "Test permanent ban",
+        "ban_expires_at": "9999-12-31T23:59:59+00:00",
         "text": (
             "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
             "<br><br><i>If you would like to appeal this ban, please send an "
@@ -76,6 +79,9 @@ async def test_server_ban_token(lobby_server, user, jwk_priv_key, jwk_kid):
     assert msg == {
         "command": "notice",
         "style": "error",
+        "localization_key": "ban.error",
+        "ban_reason": "Test permanent ban",
+        "ban_expires_at": "9999-12-31T23:59:59+00:00",
         "text": (
             "You are banned from FAF forever. <br>Reason: <br>Test permanent ban"
             "<br><br><i>If you would like to appeal this ban, please send an "


### PR DESCRIPTION
## Summary
- Adds structured localization fields to ban notice messages.
- Keeps the existing text fallback for backwards compatibility with current clients.
- Includes the ban reason and ISO-formatted expiry time so clients can render localized ban text themselves.

## Validation
- [x] `python -m py_compile server\exceptions.py server\lobbyconnection.py tests\integration_tests\test_login.py`
- [ ] `python -m pytest tests\integration_tests\test_login.py -k "ban"` could not be run locally because pytest is not installed in this environment.

Closes #640

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server ban notifications now include structured details: localization support, ban reason, and ban expiration timestamp, giving users clearer, actionable context when access is restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->