### PR TITLE
Support API-driven avatar changes: login.avatar_id sync + refresh consumer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  FAF_DB_VERSION: v138
+  FAF_DB_VERSION: v143
   FLYWAY_VERSION: 7.5.4
 
 jobs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       - "3306:3306"
 
   faf-db-migrations:
-    image: faforever/faf-db-migrations:v138
+    image: faforever/faf-db-migrations:v143
     command: migrate
     environment:
       FLYWAY_URL: jdbc:mysql://faf-db/faf?useSSL=false

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -117,6 +117,7 @@ from typing import Optional, cast
 import server.metrics as metrics
 
 from .asyncio_extensions import map_suppress, synchronizedmethod
+from .avatar_change_queue_service import AvatarChangeQueueService
 from .broadcast_service import BroadcastService
 from .client_message_queue_service import ClientMessageQueueService
 from .config import TRACE, config
@@ -144,6 +145,7 @@ __license__ = "GPLv3"
 __copyright__ = "Copyright (c) 2011-2015 " + __author__
 
 __all__ = (
+    "AvatarChangeQueueService",
     "BroadcastService",
     "ClientMessageQueueService",
     "ConfigurationService",

--- a/server/avatar_change_queue_service.py
+++ b/server/avatar_change_queue_service.py
@@ -1,0 +1,109 @@
+"""
+Consume "player avatar changed" events from trusted microservices.
+
+# Wire contract
+Publishers post to the `MQ_EXCHANGE_NAME` topic exchange with routing key
+`success.player_avatar.update`. The body is a UTF-8 JSON object:
+
+- `player_id` (int, required): the player whose selected avatar changed.
+- `avatar_id` (int or null, optional): the newly selected avatar id, or
+  null if the player cleared their avatar. The lobby itself ignores
+  this field — it always re-reads the DB so it gets the matching
+  `url`/`tooltip` and applies the ownership check. The field is
+  shipped for the benefit of *other* subscribers that may want to act
+  on the change without an extra DB roundtrip.
+
+On receipt the lobby re-reads the affected player's avatar from the DB
+and marks them dirty so the existing `BroadcastService` emits a
+`player_info` to every connected client on its next tick.
+"""
+
+import json
+import logging
+import socket
+from typing import ClassVar, Optional
+
+from aio_pika.abc import AbstractIncomingMessage, AbstractQueue
+
+from .config import config
+from .core import Service
+from .decorators import with_logger
+from .message_queue_service import MessageQueueService
+from .player_service import PlayerService
+
+
+PLAYER_AVATAR_UPDATE_ROUTING_KEY = "success.player_avatar.update"
+
+
+@with_logger
+class AvatarChangeQueueService(Service):
+    """Consume `success.player_avatar.update` messages and refresh players."""
+
+    _logger: ClassVar[logging.Logger]
+
+    def __init__(
+        self,
+        message_queue_service: MessageQueueService,
+        player_service: PlayerService,
+    ):
+        self.message_queue_service = message_queue_service
+        self.player_service = player_service
+        self._queue: Optional[AbstractQueue] = None
+        self._consumer_tag: Optional[str] = None
+
+    async def initialize(self) -> None:
+        # Per-instance queue: every lobby pod must process every event so
+        # whichever pod is hosting the player can refresh its in-memory
+        # state. Naming follows `<exchange>.<service>.<routing-key>.<host>`,
+        # matching `ClientMessageQueueService`.
+        queue_name = (
+            f"{config.MQ_EXCHANGE_NAME}.lobby.player_avatar.update"
+            f".{socket.gethostname()}"
+        )
+        result = await self.message_queue_service.declare_queue_and_consume(
+            exchange_name=config.MQ_EXCHANGE_NAME,
+            routing_key=PLAYER_AVATAR_UPDATE_ROUTING_KEY,
+            callback=self._on_message,
+            queue_name=queue_name,
+        )
+        if result is not None:
+            self._queue, self._consumer_tag = result
+
+    async def shutdown(self) -> None:
+        if self._queue is not None and self._consumer_tag is not None:
+            await self._queue.cancel(self._consumer_tag)
+        self._queue = None
+        self._consumer_tag = None
+
+    async def _on_message(self, message: AbstractIncomingMessage) -> None:
+        async with message.process(requeue=False):
+            try:
+                payload = json.loads(message.body)
+            except (ValueError, UnicodeDecodeError):
+                self._logger.warning(
+                    "Dropping avatar-update message with non-JSON body"
+                )
+                return
+
+            if not isinstance(payload, dict):
+                self._logger.warning(
+                    "Dropping avatar-update message: payload is not a JSON object"
+                )
+                return
+
+            raw_player_id = payload.get("player_id")
+            try:
+                player_id = int(raw_player_id)
+            except (TypeError, ValueError):
+                self._logger.warning(
+                    "Dropping avatar-update message: invalid player_id %r",
+                    raw_player_id,
+                )
+                return
+
+            refreshed = await self.player_service.refresh_player_avatar(player_id)
+            if not refreshed:
+                self._logger.debug(
+                    "avatar-update for player %s ignored: not connected here",
+                    player_id,
+                )

--- a/server/avatar_change_queue_service.py
+++ b/server/avatar_change_queue_service.py
@@ -21,7 +21,7 @@ and marks them dirty so the existing `BroadcastService` emits a
 import json
 import logging
 import socket
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from aio_pika.abc import AbstractIncomingMessage, AbstractQueue
 
@@ -30,7 +30,6 @@ from .core import Service
 from .decorators import with_logger
 from .message_queue_service import MessageQueueService
 from .player_service import PlayerService
-
 
 PLAYER_AVATAR_UPDATE_ROUTING_KEY = "success.player_avatar.update"
 
@@ -91,7 +90,15 @@ class AvatarChangeQueueService(Service):
                 )
                 return
 
-            raw_player_id = payload.get("player_id")
+            raw_player_id: Any = payload.get("player_id")
+            # Reject bool explicitly: int(True) == 1 would otherwise sneak
+            # through and refresh player 1 on every truthy payload.
+            if isinstance(raw_player_id, bool):
+                self._logger.warning(
+                    "Dropping avatar-update message: invalid player_id %r",
+                    raw_player_id,
+                )
+                return
             try:
                 player_id = int(raw_player_id)
             except (TypeError, ValueError):

--- a/server/avatar_change_queue_service.py
+++ b/server/avatar_change_queue_service.py
@@ -1,22 +1,4 @@
-"""
-Consume "player avatar changed" events from trusted microservices.
-
-# Wire contract
-Publishers post to the `MQ_EXCHANGE_NAME` topic exchange with routing key
-`success.player_avatar.update`. The body is a UTF-8 JSON object:
-
-- `player_id` (int, required): the player whose selected avatar changed.
-- `avatar_id` (int or null, optional): the newly selected avatar id, or
-  null if the player cleared their avatar. The lobby itself ignores
-  this field — it always re-reads the DB so it gets the matching
-  `url`/`tooltip` and applies the ownership check. The field is
-  shipped for the benefit of *other* subscribers that may want to act
-  on the change without an extra DB roundtrip.
-
-On receipt the lobby re-reads the affected player's avatar from the DB
-and marks them dirty so the existing `BroadcastService` emits a
-`player_info` to every connected client on its next tick.
-"""
+"""RabbitMQ consumer that refreshes player avatars from DB on update events."""
 
 import json
 import logging
@@ -36,7 +18,27 @@ PLAYER_AVATAR_UPDATE_ROUTING_KEY = "success.player_avatar.update"
 
 @with_logger
 class AvatarChangeQueueService(Service):
-    """Consume `success.player_avatar.update` messages and refresh players."""
+
+    """
+    Consume `success.player_avatar.update` messages and refresh players.
+
+    Wire contract
+    -------------
+    Publishers post to the `MQ_EXCHANGE_NAME` topic exchange with routing
+    key `success.player_avatar.update`. The body is a UTF-8 JSON object:
+
+    - `player_id` (int, required): the player whose selected avatar changed.
+    - `avatar_id` (int or null, optional): the newly selected avatar id, or
+      null if the player cleared their avatar. The lobby itself ignores this
+      field — it always re-reads the DB so it gets the matching url/tooltip
+      and applies the ownership check. The field is shipped for the benefit
+      of other subscribers that may want to act on the change without an
+      extra DB roundtrip.
+
+    On receipt the lobby re-reads the affected player's avatar from the DB
+    and marks them dirty so the existing `BroadcastService` emits a
+    `player_info` to every connected client on its next tick.
+    """
 
     _logger: ClassVar[logging.Logger]
 
@@ -45,6 +47,7 @@ class AvatarChangeQueueService(Service):
         message_queue_service: MessageQueueService,
         player_service: PlayerService,
     ):
+        """Wire dependencies; consumer is started in `initialize`."""
         self.message_queue_service = message_queue_service
         self.player_service = player_service
         self._queue: Optional[AbstractQueue] = None

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -184,7 +184,8 @@ login = Table(
     Column("create_time",   TIMESTAMP,  nullable=False),
     Column("update_time",   TIMESTAMP,  nullable=False),
     Column("user_agent",    String),
-    Column("last_login",    TIMESTAMP)
+    Column("last_login",    TIMESTAMP),
+    Column("avatar_id",     Integer,    ForeignKey("avatars_list.id")),
 )
 
 leaderboard = Table(

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -957,6 +957,7 @@ class LobbyConnection:
                 )
                 self.player.avatar = None
 
+                new_avatar_id = row.id if avatar_url is not None else None
                 if avatar_url is not None:
                     await conn.execute(
                         avatars.update().where(
@@ -972,6 +973,15 @@ class LobbyConnection:
                         "url": avatar_url,
                         "tooltip": row.tooltip
                     }
+                # Mirror the selection to login.avatar_id so reads via the new
+                # authoritative column stay consistent with the legacy flag.
+                await conn.execute(
+                    t_login.update().where(
+                        t_login.c.id == self.player.id
+                    ).values(
+                        avatar_id=new_avatar_id
+                    )
+                )
                 self.player_service.mark_dirty(self.player)
         else:
             raise KeyError("invalid action")

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -982,6 +982,14 @@ class LobbyConnection:
                         avatar_id=new_avatar_id
                     )
                 )
+                avatar_tooltip = (
+                    self.player.avatar["tooltip"] if self.player.avatar else None
+                )
+                self._logger.info(
+                    "Player %s changed avatar via client connection: "
+                    "avatar_id=%s tooltip=%s",
+                    self.player.id, new_avatar_id, avatar_tooltip
+                )
                 self.player_service.mark_dirty(self.player)
         else:
             raise KeyError("invalid action")

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, Optional, ValuesView
 
 import aiocron
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 
 import server.metrics as metrics
 from server.config import config
@@ -90,6 +90,9 @@ class PlayerService(Service):
             )
             player.user_groups = {row.technical_name for row in result}
 
+            # Avatar lookup: `login.avatar_id` is the new authoritative FK,
+            # but for backwards compatibility we still fall back to the
+            # legacy `avatars.selected = 1` row if `avatar_id` is null.
             sql = select(
                 avatars_list.c.url,
                 avatars_list.c.tooltip,
@@ -105,7 +108,12 @@ class PlayerService(Service):
                         avatars.c.selected == 1
                     )
                 )
-                .outerjoin(avatars_list)
+                .outerjoin(
+                    avatars_list,
+                    onclause=avatars_list.c.id == func.coalesce(
+                        login.c.avatar_id, avatars.c.idAvatar
+                    )
+                )
             ).where(login.c.id == player.id)  # yapf: disable
 
             result = await conn.execute(sql)

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, Optional, ValuesView
 
 import aiocron
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, or_, select
 
 import server.metrics as metrics
 from server.config import config
@@ -91,8 +91,11 @@ class PlayerService(Service):
             player.user_groups = {row.technical_name for row in result}
 
             # Avatar lookup: `login.avatar_id` is the new authoritative FK,
-            # but for backwards compatibility we still fall back to the
-            # legacy `avatars.selected = 1` row if `avatar_id` is null.
+            # with a fallback to the legacy `avatars.selected = 1` row when
+            # `avatar_id` is null. In both cases we route through the
+            # `avatars` grant table so ownership is enforced — a stale
+            # `login.avatar_id` pointing at a no-longer-granted avatar
+            # yields no row here.
             sql = select(
                 avatars_list.c.url,
                 avatars_list.c.tooltip,
@@ -105,15 +108,16 @@ class PlayerService(Service):
                     avatars,
                     onclause=and_(
                         avatars.c.idUser == login.c.id,
-                        avatars.c.selected == 1
+                        or_(
+                            avatars.c.idAvatar == login.c.avatar_id,
+                            and_(
+                                login.c.avatar_id.is_(None),
+                                avatars.c.selected == 1
+                            )
+                        )
                     )
                 )
-                .outerjoin(
-                    avatars_list,
-                    onclause=avatars_list.c.id == func.coalesce(
-                        login.c.avatar_id, avatars.c.idAvatar
-                    )
-                )
+                .outerjoin(avatars_list)
             ).where(login.c.id == player.id)  # yapf: disable
 
             result = await conn.execute(sql)

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -81,6 +81,25 @@ class PlayerService(Service):
 
         return dirty_players
 
+    @staticmethod
+    def _avatar_grant_join_onclause():
+        # ON clause for joining `avatars` against `login` to pick a
+        # player's currently worn avatar with ownership enforced.
+        # Prefer the new authoritative `login.avatar_id` column; fall
+        # back to the legacy `avatars.selected = 1` row only when
+        # `avatar_id` is null. Either way the row must be a real grant
+        # in `avatars`, so revoked grants resolve to no avatar.
+        return and_(
+            avatars.c.idUser == login.c.id,
+            or_(
+                avatars.c.idAvatar == login.c.avatar_id,
+                and_(
+                    login.c.avatar_id.is_(None),
+                    avatars.c.selected == 1
+                )
+            )
+        )
+
     async def fetch_player_data(self, player: Player) -> None:
         async with self._db.acquire() as conn:
             result = await conn.execute(
@@ -90,12 +109,6 @@ class PlayerService(Service):
             )
             player.user_groups = {row.technical_name for row in result}
 
-            # Avatar lookup: `login.avatar_id` is the new authoritative FK,
-            # with a fallback to the legacy `avatars.selected = 1` row when
-            # `avatar_id` is null. In both cases we route through the
-            # `avatars` grant table so ownership is enforced — a stale
-            # `login.avatar_id` pointing at a no-longer-granted avatar
-            # yields no row here.
             sql = select(
                 avatars_list.c.url,
                 avatars_list.c.tooltip,
@@ -106,16 +119,7 @@ class PlayerService(Service):
                 .outerjoin(clan)
                 .outerjoin(
                     avatars,
-                    onclause=and_(
-                        avatars.c.idUser == login.c.id,
-                        or_(
-                            avatars.c.idAvatar == login.c.avatar_id,
-                            and_(
-                                login.c.avatar_id.is_(None),
-                                avatars.c.selected == 1
-                            )
-                        )
-                    )
+                    onclause=self._avatar_grant_join_onclause()
                 )
                 .outerjoin(avatars_list)
             ).where(login.c.id == player.id)  # yapf: disable
@@ -142,9 +146,6 @@ class PlayerService(Service):
             await self._fetch_player_ratings(player, conn)
 
     async def _fetch_player_avatar(self, player: Player, conn) -> None:
-        # Same ownership-checked join as `fetch_player_data`'s avatar block:
-        # trust `login.avatar_id` only when a matching grant row exists in
-        # `avatars`, with a fallback to the legacy `selected = 1` flag.
         sql = select(
             avatars_list.c.url,
             avatars_list.c.tooltip,
@@ -152,16 +153,7 @@ class PlayerService(Service):
             login
             .outerjoin(
                 avatars,
-                onclause=and_(
-                    avatars.c.idUser == login.c.id,
-                    or_(
-                        avatars.c.idAvatar == login.c.avatar_id,
-                        and_(
-                            login.c.avatar_id.is_(None),
-                            avatars.c.selected == 1
-                        )
-                    )
-                )
+                onclause=self._avatar_grant_join_onclause()
             )
             .outerjoin(avatars_list)
         ).where(login.c.id == player.id)

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -145,8 +145,12 @@ class PlayerService(Service):
 
             await self._fetch_player_ratings(player, conn)
 
-    async def _fetch_player_avatar(self, player: Player, conn) -> None:
+    async def _fetch_player_avatar(
+        self, player: Player, conn
+    ) -> Optional[int]:
+        """Refresh `player.avatar` from DB; return the avatar id, if any."""
         sql = select(
+            avatars_list.c.id,
             avatars_list.c.url,
             avatars_list.c.tooltip,
         ).select_from(
@@ -162,14 +166,17 @@ class PlayerService(Service):
         row = result.fetchone()
         if row is None:
             player.avatar = None
-            return
+            return None
 
         row_mapping = row._mapping
+        avatar_id = row_mapping.get(avatars_list.c.id)
         url = row_mapping.get(avatars_list.c.url)
         tooltip = row_mapping.get(avatars_list.c.tooltip)
-        player.avatar = (
-            {"url": url, "tooltip": tooltip} if url and tooltip else None
-        )
+        if url and tooltip:
+            player.avatar = {"url": url, "tooltip": tooltip}
+            return avatar_id
+        player.avatar = None
+        return None
 
     async def refresh_player_avatar(self, player_id: int) -> bool:
         """
@@ -182,7 +189,13 @@ class PlayerService(Service):
         if player is None:
             return False
         async with self._db.acquire() as conn:
-            await self._fetch_player_avatar(player, conn)
+            avatar_id = await self._fetch_player_avatar(player, conn)
+        avatar_tooltip = player.avatar["tooltip"] if player.avatar else None
+        self._logger.info(
+            "Player %s avatar refreshed from RabbitMQ event: "
+            "avatar_id=%s tooltip=%s",
+            player_id, avatar_id, avatar_tooltip
+        )
         self.mark_dirty(player)
         return True
 

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -141,6 +141,57 @@ class PlayerService(Service):
 
             await self._fetch_player_ratings(player, conn)
 
+    async def _fetch_player_avatar(self, player: Player, conn) -> None:
+        # Same ownership-checked join as `fetch_player_data`'s avatar block:
+        # trust `login.avatar_id` only when a matching grant row exists in
+        # `avatars`, with a fallback to the legacy `selected = 1` flag.
+        sql = select(
+            avatars_list.c.url,
+            avatars_list.c.tooltip,
+        ).select_from(
+            login
+            .outerjoin(
+                avatars,
+                onclause=and_(
+                    avatars.c.idUser == login.c.id,
+                    or_(
+                        avatars.c.idAvatar == login.c.avatar_id,
+                        and_(
+                            login.c.avatar_id.is_(None),
+                            avatars.c.selected == 1
+                        )
+                    )
+                )
+            )
+            .outerjoin(avatars_list)
+        ).where(login.c.id == player.id)
+
+        result = await conn.execute(sql)
+        row = result.fetchone()
+        if row is None:
+            player.avatar = None
+            return
+
+        row_mapping = row._mapping
+        url = row_mapping.get(avatars_list.c.url)
+        tooltip = row_mapping.get(avatars_list.c.tooltip)
+        player.avatar = (
+            {"url": url, "tooltip": tooltip} if url and tooltip else None
+        )
+
+    async def refresh_player_avatar(self, player_id: int) -> bool:
+        """Re-read avatar from DB for one player and mark them dirty so
+        BroadcastService emits a `player_info` on the next tick. Returns
+        True if the player is connected to this instance, False otherwise.
+        """
+        player = self._players.get(player_id)
+        if player is None:
+            return False
+        async with self._db.acquire() as conn:
+            await self._fetch_player_avatar(player, conn)
+        self.mark_dirty(player)
+        return True
+
     async def _fetch_player_ratings(self, player: Player, conn):
         sql = select(
             leaderboard_rating.c.mean,

--- a/server/player_service.py
+++ b/server/player_service.py
@@ -172,8 +172,10 @@ class PlayerService(Service):
         )
 
     async def refresh_player_avatar(self, player_id: int) -> bool:
-        """Re-read avatar from DB for one player and mark them dirty so
-        BroadcastService emits a `player_info` on the next tick. Returns
+        """
+        Re-read avatar for one player and mark them dirty.
+
+        `BroadcastService` emits a `player_info` on the next tick. Returns
         True if the player is connected to this instance, False otherwise.
         """
         player = self._players.get(player_id)

--- a/tests/unit_tests/test_avatar_change_queue_service.py
+++ b/tests/unit_tests/test_avatar_change_queue_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from server.avatar_change_queue_service import (
     PLAYER_AVATAR_UPDATE_ROUTING_KEY,
-    AvatarChangeQueueService,
+    AvatarChangeQueueService
 )
 from server.config import config
 
@@ -175,6 +175,21 @@ async def test_non_int_player_id_is_dropped(
 ):
     msg = make_incoming_message(
         json.dumps({"player_id": "not-an-int", "avatar_id": 5}).encode()
+    )
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_not_awaited()
+    assert any("invalid player_id" in m for m in caplog.messages)
+
+
+async def test_bool_player_id_is_dropped(
+    avatar_queue_service, fake_player_service, caplog
+):
+    # int(True) == 1, so without an explicit bool check this would refresh
+    # player 1. Guard against that surprise.
+    msg = make_incoming_message(
+        json.dumps({"player_id": True, "avatar_id": 5}).encode()
     )
 
     await avatar_queue_service._on_message(msg)

--- a/tests/unit_tests/test_avatar_change_queue_service.py
+++ b/tests/unit_tests/test_avatar_change_queue_service.py
@@ -1,0 +1,183 @@
+import json
+from unittest import mock
+
+import pytest
+
+from server.avatar_change_queue_service import (
+    PLAYER_AVATAR_UPDATE_ROUTING_KEY,
+    AvatarChangeQueueService,
+)
+from server.config import config
+
+
+def make_incoming_message(body: bytes):
+    """Build a stand-in for aio_pika's IncomingMessage."""
+    message = mock.Mock()
+    message.body = body
+
+    process_cm = mock.MagicMock()
+    process_cm.__aenter__ = mock.AsyncMock(return_value=None)
+    process_cm.__aexit__ = mock.AsyncMock(return_value=False)
+    message.process = mock.Mock(return_value=process_cm)
+    return message
+
+
+@pytest.fixture
+def fake_player_service():
+    service = mock.Mock()
+    service.refresh_player_avatar = mock.AsyncMock(return_value=True)
+    return service
+
+
+@pytest.fixture
+async def avatar_queue_service(fake_player_service):
+    queue = mock.Mock()
+    queue.cancel = mock.AsyncMock()
+    mq_service = mock.Mock()
+    mq_service.declare_queue_and_consume = mock.AsyncMock(
+        return_value=(queue, "consumer-tag-avatar")
+    )
+    service = AvatarChangeQueueService(
+        message_queue_service=mq_service,
+        player_service=fake_player_service,
+    )
+    await service.initialize()
+    yield service
+    await service.shutdown()
+
+
+async def test_shutdown_cancels_consumer(fake_player_service):
+    queue = mock.Mock()
+    queue.cancel = mock.AsyncMock()
+    mq_service = mock.Mock()
+    mq_service.declare_queue_and_consume = mock.AsyncMock(
+        return_value=(queue, "consumer-tag-xyz")
+    )
+    service = AvatarChangeQueueService(
+        message_queue_service=mq_service,
+        player_service=fake_player_service,
+    )
+    await service.initialize()
+    await service.shutdown()
+
+    queue.cancel.assert_awaited_once_with("consumer-tag-xyz")
+    assert service._queue is None
+    assert service._consumer_tag is None
+
+
+async def test_shutdown_noop_when_broker_unavailable(fake_player_service):
+    mq_service = mock.Mock()
+    mq_service.declare_queue_and_consume = mock.AsyncMock(return_value=None)
+    service = AvatarChangeQueueService(
+        message_queue_service=mq_service,
+        player_service=fake_player_service,
+    )
+    await service.initialize()
+    await service.shutdown()
+
+
+async def test_initialize_declares_consumer(avatar_queue_service):
+    mq = avatar_queue_service.message_queue_service
+    mq.declare_queue_and_consume.assert_awaited_once()
+    kwargs = mq.declare_queue_and_consume.await_args.kwargs
+    assert kwargs["exchange_name"] == config.MQ_EXCHANGE_NAME
+    assert kwargs["routing_key"] == PLAYER_AVATAR_UPDATE_ROUTING_KEY
+    assert kwargs["callback"] == avatar_queue_service._on_message
+
+
+async def test_refresh_called_for_valid_payload(
+    avatar_queue_service, fake_player_service
+):
+    msg = make_incoming_message(
+        json.dumps({"player_id": 42, "avatar_id": 5}).encode()
+    )
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_awaited_once_with(42)
+
+
+async def test_refresh_called_when_avatar_cleared(
+    avatar_queue_service, fake_player_service
+):
+    msg = make_incoming_message(
+        json.dumps({"player_id": 42, "avatar_id": None}).encode()
+    )
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_awaited_once_with(42)
+
+
+async def test_extra_fields_are_tolerated(
+    avatar_queue_service, fake_player_service
+):
+    msg = make_incoming_message(
+        json.dumps({"player_id": 7, "avatar_id": 1, "future_field": "ok"}).encode()
+    )
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_awaited_once_with(7)
+
+
+async def test_player_not_connected_is_logged(
+    avatar_queue_service, fake_player_service, caplog
+):
+    fake_player_service.refresh_player_avatar = mock.AsyncMock(return_value=False)
+
+    msg = make_incoming_message(
+        json.dumps({"player_id": 999, "avatar_id": 1}).encode()
+    )
+
+    import logging
+    with caplog.at_level(logging.DEBUG):
+        await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_awaited_once_with(999)
+    assert any("not connected here" in m for m in caplog.messages)
+
+
+async def test_malformed_json_body_is_dropped(
+    avatar_queue_service, fake_player_service, caplog
+):
+    msg = make_incoming_message(b"definitely not json")
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_not_awaited()
+    assert any("non-JSON body" in m for m in caplog.messages)
+
+
+async def test_non_object_json_body_is_dropped(
+    avatar_queue_service, fake_player_service
+):
+    msg = make_incoming_message(b"[1, 2, 3]")
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_not_awaited()
+
+
+async def test_missing_player_id_is_dropped(
+    avatar_queue_service, fake_player_service, caplog
+):
+    msg = make_incoming_message(json.dumps({"avatar_id": 5}).encode())
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_not_awaited()
+    assert any("invalid player_id" in m for m in caplog.messages)
+
+
+async def test_non_int_player_id_is_dropped(
+    avatar_queue_service, fake_player_service, caplog
+):
+    msg = make_incoming_message(
+        json.dumps({"player_id": "not-an-int", "avatar_id": 5}).encode()
+    )
+
+    await avatar_queue_service._on_message(msg)
+
+    fake_player_service.refresh_player_avatar.assert_not_awaited()
+    assert any("invalid player_id" in m for m in caplog.messages)

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -700,9 +700,38 @@ async def test_command_avatar_select(database, lobbyconnection: LobbyConnection)
     })
 
     async with database.acquire() as conn:
-        result = await conn.execute("SELECT selected from avatars where idUser=2")
+        result = await conn.execute(
+            "SELECT idAvatar, selected FROM avatars WHERE idUser=2 AND selected=1"
+        )
         row = result.fetchone()
+        assert row is not None
+        selected_avatar_id = row.idAvatar
         assert row.selected == 1
+
+        result = await conn.execute("SELECT avatar_id FROM login WHERE id=2")
+        row = result.fetchone()
+        assert row.avatar_id == selected_avatar_id
+
+
+async def test_command_avatar_select_clear(
+    database, lobbyconnection: LobbyConnection
+):
+    lobbyconnection.player.id = 2  # Dostya test user
+
+    await lobbyconnection.on_message_received({
+        "command": "avatar",
+        "action": "select",
+        "avatar": None,
+    })
+
+    async with database.acquire() as conn:
+        result = await conn.execute(
+            "SELECT COUNT(*) AS n FROM avatars WHERE idUser=2 AND selected=1"
+        )
+        assert result.fetchone().n == 0
+
+        result = await conn.execute("SELECT avatar_id FROM login WHERE id=2")
+        assert result.fetchone().avatar_id is None
 
 
 async def get_friends(player_id, database):

--- a/tests/unit_tests/test_player_service.py
+++ b/tests/unit_tests/test_player_service.py
@@ -64,6 +64,30 @@ async def test_fetch_player_data_non_existent(player_factory, player_service):
     await player_service.fetch_player_data(player)
 
 
+async def test_refresh_player_avatar_connected(
+    player_factory, player_service
+):
+    player = player_factory(player_id=50)
+    player.avatar = None  # simulate stale (e.g. just connected)
+    player_service[50] = player
+
+    refreshed = await player_service.refresh_player_avatar(50)
+
+    assert refreshed is True
+    assert player.avatar == {
+        "url": "https://content.faforever.com/faf/avatars/UEF.png",
+        "tooltip": "UEF",
+    }
+    assert player in player_service._dirty_players
+
+
+async def test_refresh_player_avatar_not_connected(player_service):
+    refreshed = await player_service.refresh_player_avatar(999)
+
+    assert refreshed is False
+    assert not player_service._dirty_players
+
+
 async def test_magic_methods(player_factory, player_service):
     player = player_factory(player_id=0)
     player_service[0] = player


### PR DESCRIPTION
## Summary
Two related pieces of work to support shifting avatar handling to the API while keeping the lobby fully functional during the transition:

### 1. Read & write `login.avatar_id` alongside legacy `avatars.selected`
The DB now has `login.avatar_id` as the authoritative single-avatar FK (added in [faf/db#331](https://github.com/FAForever/db/pull/331), released as v143). Until all writers move over, both columns must stay consistent.
- Add `avatar_id` to the `login` Table definition (`server/db/models.py`).
- `PlayerService.fetch_player_data` joins through the `avatars` grant table on `login.avatar_id` (with ownership check), with a fallback to the legacy `selected = 1` row. A stale `avatar_id` pointing at a no-longer-granted avatar resolves to no row.
- `command_avatar` (select action) now also writes `login.avatar_id` whenever it touches `avatars.selected`, so the lobby never produces drift between the two columns going forward.
- Bumps `FAF_DB_VERSION` to `v143` in CI and `compose.yaml`.

### 2. New `AvatarChangeQueueService` consumer
When the API changes a player's avatar (e.g. via the website), the lobby has no idea — its in-memory `Player.avatar` stays stale until the player reconnects. New consumer reacts to a fresh routing key, re-reads the DB, and marks the player dirty so the existing `BroadcastService` emits the usual `player_info` to all connected clients.

**Wire contract for publishers (API side, separate PR):**
- exchange: `MQ_EXCHANGE_NAME` (`faf-lobby`)
- routing key: `success.player_avatar.update` — past-tense event; fan-out friendly so future services can subscribe.
- payload: `{"player_id": <int>, "avatar_id": <int|null>}` — `avatar_id` is included so downstream subscribers don't need a DB roundtrip; the lobby itself re-reads from DB to enforce ownership and pick up url/tooltip.

Implementation:
- `PlayerService.refresh_player_avatar(player_id)` public method + extracted `_fetch_player_avatar` helper sharing the ownership-checked join with `fetch_player_data`.
- `AvatarChangeQueueService` follows the `ClientMessageQueueService` pattern; auto-registered via `Service.__init_subclass__`.

## Why
End state we're working toward: API is the single writer for selected avatar; lobby reacts to API-driven changes and broadcasts via existing machinery. This PR is the lobby half — it keeps reading/writing the legacy column today, and it'll listen for API-driven changes once they start arriving.

## Test plan
- [ ] Player with `login.avatar_id` set → fetch returns that avatar's url/tooltip.
- [ ] Player with `login.avatar_id` NULL but a legacy `avatars.selected = 1` row → fetch returns the legacy avatar (backwards compatibility).
- [ ] Player with `login.avatar_id` pointing at an avatar no longer granted in `avatars` → resolves to no avatar (ownership enforced).
- [ ] `command_avatar { action: "select", avatar: <url> }` → both `avatars.selected = 1` AND `login.avatar_id` updated to that avatar.
- [ ] `command_avatar { action: "select", avatar: null }` → `avatars.selected` cleared AND `login.avatar_id` set to NULL.
- [ ] Publish `success.player_avatar.update` for a connected player → avatar refreshed, `player_info` broadcast emitted on the next `BroadcastService` tick.
- [ ] Publish for a disconnected player → logged, no crash.
- [ ] Malformed payloads (non-JSON, missing `player_id`, non-int `player_id`) → logged and acked.

## Out of scope / follow-ups
- API-side publish of `success.player_avatar.update` — separate PR on `faf-java-api`.
- Phasing out the SQL-write branch from `command_avatar` — wait until the API is the sole writer and legacy clients have migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a queue-driven avatar update mechanism that refreshes connected players’ displayed avatars from trusted update events.
* **Bug Fixes**
  * Avatar selection is now stored on the login record (including clearing it when no avatar is selected), improving consistency across sessions.
  * Player avatar retrieval and live refresh now prioritize the stored avatar while maintaining legacy fallback behavior.
* **Chores**
  * Updated the database migration baseline version used by CI and the compose migration service.
* **Tests**
  * Expanded unit test coverage for avatar selection, queue-driven updates, and avatar refresh (connected vs. not connected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->