### PR TITLE
Use map_version.folder_name instead of filename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  FAF_DB_VERSION: v143
+  FAF_DB_VERSION: v144
   FLYWAY_VERSION: 7.5.4
 
 jobs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       - "3306:3306"
 
   faf-db-migrations:
-    image: faforever/faf-db-migrations:v143
+    image: faforever/faf-db-migrations:v144
     command: migrate
     environment:
       FLYWAY_URL: jdbc:mysql://faf-db/faf?useSSL=false

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -267,7 +267,6 @@ map_version = Table(
     Column("height",        Integer,        nullable=False),
     Column("version",       Integer,        nullable=False),
     Column("folder_name",   String(200),    nullable=False),
-    Column("filename",      String(200),    nullable=False),
     Column("ranked",        Boolean,        nullable=False),
     Column("hidden",        Boolean,        nullable=False),
     Column("map_id",        ForeignKey("map.id"), nullable=False),

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -266,6 +266,7 @@ map_version = Table(
     Column("width",         Integer,        nullable=False),
     Column("height",        Integer,        nullable=False),
     Column("version",       Integer,        nullable=False),
+    Column("folder_name",   String(200),    nullable=False),
     Column("filename",      String(200),    nullable=False),
     Column("ranked",        Boolean,        nullable=False),
     Column("hidden",        Boolean,        nullable=False),

--- a/server/game_service.py
+++ b/server/game_service.py
@@ -135,9 +135,8 @@ class GameService(Service):
 
     async def get_map(self, folder_name: str) -> Map:
         folder_name = folder_name.lower()
-        filename = f"maps/{folder_name}.zip"
 
-        map = self.map_info_cache.get(filename)
+        map = self.map_info_cache.get(folder_name)
         if map is not None:
             return map
 
@@ -145,11 +144,10 @@ class GameService(Service):
             result = await conn.execute(
                 select(
                     map_version.c.id,
-                    map_version.c.filename,
                     map_version.c.ranked,
                 )
                 .where(
-                    func.lower(map_version.c.filename) == filename
+                    func.lower(map_version.c.folder_name) == folder_name
                 )
             )
             row = result.fetchone()
@@ -168,7 +166,7 @@ class GameService(Service):
                 folder_name=folder_name,
                 ranked=row.ranked
             )
-            self.map_info_cache[filename] = map
+            self.map_info_cache[folder_name] = map
             return map
 
     def mark_dirty(self, obj: Union[Game, MatchmakerQueue]):

--- a/server/ladder_service/ladder_service.py
+++ b/server/ladder_service/ladder_service.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import logging
 import random
-import re
 import statistics
 from collections import defaultdict
 from typing import (
@@ -162,7 +161,7 @@ class LadderService(Service):
                 map_pool_map_version.c.weight,
                 map_pool_map_version.c.map_params,
                 map_version.c.id.label("map_id"),
-                map_version.c.filename,
+                map_version.c.folder_name,
                 map_version.c.ranked,
             ).select_from(
                 map_pool.outerjoin(map_pool_map_version)
@@ -177,18 +176,11 @@ class LadderService(Service):
                 map_pool_maps[id_] = (name, list())
             _, map_list = map_pool_maps[id_]
             if row.map_id is not None:
-                # Database filenames contain the maps/ prefix and .zip suffix.
-                # This comes from the content server which hosts the files at
-                # https://content.faforever.com/maps/name.zip
-                m = re.match(r"maps/(.+)\.zip", row.filename)
-                if m is None:
-                    raise RuntimeError(f"malformed map filename {row.filename}")
-                folder_name = m.group(1)
                 map_list.append(
                     Map(
                         id=row.map_id,
                         map_pool_map_version_id=row.map_pool_map_version_id,
-                        folder_name=folder_name,
+                        folder_name=row.folder_name,
                         ranked=row.ranked,
                         weight=row.weight,
                     )

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -174,25 +174,25 @@ insert into map (id, display_name, map_type, battle_type, author, license) value
   (15, 'SCMP_015', 'FFA', 'skirmish', 3, 1),
   (16, 'neroxis_map_generator_sneaky_map', 'FFA', 'skirmish', 1, 1);
 
-insert into map_version (id, description, max_players, width, height, version, filename, hidden, ranked, map_id) values
-  (1, 'SCMP 001', 8, 1024, 1024, 1, 'maps/scmp_001.zip', 0, 1, 1),
-  (2, 'SCMP 002', 8, 1024, 1024, 1, 'maps/scmp_002.zip', 0, 1, 2),
-  (3, 'SCMP 003', 8, 1024, 1024, 1, 'maps/scmp_003.zip', 0, 1, 3),
-  (4, 'SCMP 004', 8, 1024, 1024, 1, 'maps/scmp_004.zip', 0, 1, 4),
-  (5, 'SCMP 005', 8, 2048, 2048, 1, 'maps/scmp_005.zip', 0, 1, 5),
-  (6, 'SCMP 006', 8, 1024, 1024, 1, 'maps/scmp_006.zip', 0, 1, 6),
-  (7, 'SCMP 007', 8, 512, 512, 1, 'maps/scmp_007.zip', 0, 1, 7),
-  (8, 'SCMP 008', 8, 1024, 1024, 1, 'maps/scmp_008.zip', 0, 1, 8),
-  (9, 'SCMP 009', 8, 1024, 1024, 1, 'maps/scmp_009.zip', 0, 1, 9),
-  (10, 'SCMP 010', 8, 1024, 1024, 1, 'maps/scmp_010.zip', 0, 1, 10),
-  (11, 'SCMP 011', 8, 2048, 2048, 1, 'maps/scmp_011.zip', 0, 1, 11),
-  (12, 'SCMP 012', 8, 256, 256, 1, 'maps/scmp_012.zip', 0, 1, 12),
-  (13, 'SCMP 013', 8, 256, 256, 1, 'maps/scmp_013.zip', 0, 1, 13),
-  (14, 'SCMP 014', 8, 1024, 1024, 1, 'maps/scmp_014.zip', 0, 1, 14),
-  (15, 'SCMP 015', 8, 512, 512, 1, 'maps/scmp_015.zip', 0, 1, 15),
-  (16, 'SCMP 015', 8, 512, 512, 2, 'maps/scmp_015.v0002.zip', 0, 1, 15),
-  (17, 'SCMP 015', 8, 512, 512, 3, 'maps/scmp_015.v0003.zip', 0, 1, 15),
-  (18, 'Sneaky_Map', 8, 512, 512, 1, 'maps/neroxis_map_generator_sneaky_map.zip', 0, 0, 16);
+insert into map_version (id, description, max_players, width, height, version, folder_name, hidden, ranked, map_id) values
+  (1, 'SCMP 001', 8, 1024, 1024, 1, 'scmp_001', 0, 1, 1),
+  (2, 'SCMP 002', 8, 1024, 1024, 1, 'scmp_002', 0, 1, 2),
+  (3, 'SCMP 003', 8, 1024, 1024, 1, 'scmp_003', 0, 1, 3),
+  (4, 'SCMP 004', 8, 1024, 1024, 1, 'scmp_004', 0, 1, 4),
+  (5, 'SCMP 005', 8, 2048, 2048, 1, 'scmp_005', 0, 1, 5),
+  (6, 'SCMP 006', 8, 1024, 1024, 1, 'scmp_006', 0, 1, 6),
+  (7, 'SCMP 007', 8, 512, 512, 1, 'scmp_007', 0, 1, 7),
+  (8, 'SCMP 008', 8, 1024, 1024, 1, 'scmp_008', 0, 1, 8),
+  (9, 'SCMP 009', 8, 1024, 1024, 1, 'scmp_009', 0, 1, 9),
+  (10, 'SCMP 010', 8, 1024, 1024, 1, 'scmp_010', 0, 1, 10),
+  (11, 'SCMP 011', 8, 2048, 2048, 1, 'scmp_011', 0, 1, 11),
+  (12, 'SCMP 012', 8, 256, 256, 1, 'scmp_012', 0, 1, 12),
+  (13, 'SCMP 013', 8, 256, 256, 1, 'scmp_013', 0, 1, 13),
+  (14, 'SCMP 014', 8, 1024, 1024, 1, 'scmp_014', 0, 1, 14),
+  (15, 'SCMP 015', 8, 512, 512, 1, 'scmp_015', 0, 1, 15),
+  (16, 'SCMP 015', 8, 512, 512, 2, 'scmp_015.v0002', 0, 1, 15),
+  (17, 'SCMP 015', 8, 512, 512, 3, 'scmp_015.v0003', 0, 1, 15),
+  (18, 'Sneaky_Map', 8, 512, 512, 1, 'neroxis_map_generator_sneaky_map', 0, 0, 16);
 
 INSERT INTO `coop_map` (`type`, `name`, `description`, `version`, `filename`) VALUES
   (0, 'FA Campaign map', 'A map from the FA campaign', 2, 'maps/scmp_coop_123.v0002.zip'),


### PR DESCRIPTION
## Why

faf-db **V144** (FAForever/db#332, already deployed) makes `map_version.folder_name` the source-of-truth column and turns `filename` into a generated column (`CONCAT('maps/', folder_name, '.zip')`). This PR adapts the server's test data to the new schema **and** switches the server to read `folder_name` directly, dropping its dependence on `filename` entirely.

## What

**Test fixture**
- `tests/data/test-data.sql`: the `map_version` insert now provides `folder_name` (e.g. `scmp_001`) instead of `filename` (now generated, so it can't be inserted). `coop_map` keeps its own real `filename` column and is untouched.
- `compose.yaml`: bump `faf-db-migrations` image to `v144`.

**Production code — read `folder_name` directly**
- `game_service.get_map()`: matches on `func.lower(map_version.folder_name)` and caches by `folder_name`, dropping the `maps/<folder>.zip` round-trip and the `filename` lower-compare.
- `ladder_service.fetch_map_pools()`: selects `folder_name` directly, removing the `re.match(r"maps/(.+)\.zip", ...)` parsing (and the now-unused `import re`).
- `db/models.py`: removed the `filename` column from the reflected `map_version` table — nothing reads it anymore. `coop_map.filename` (a separate table) remains.

## Not changed

Coop map lookups (`coop_map.filename`, a different table) and any client-facing coop `filename` payloads are untouched. The DB still has a generated `map_version.filename` column for other consumers; the server simply no longer references it.

## Validation

`pipenv run isort --check` and `pipenv run mypy` clean (only pre-existing missing-stub warnings); `py_compile` clean. Schema + fixture verified to load against the v144 migrations image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)