### PR TITLE
Feature/#1103 Accept replay review requests and publish them to the broker

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -136,6 +136,7 @@ from .oauth_service import OAuthService
 from .party_service import PartyService
 from .player_service import PlayerService
 from .rating_service.rating_service import RatingService
+from .replay_review_service import ReplayReviewService
 from .servercontext import ServerContext
 from .stats.game_stats_service import GameStatsService
 
@@ -160,6 +161,7 @@ __all__ = (
     "PlayerService",
     "RatingService",
     "RatingService",
+    "ReplayReviewService",
     "ServerInstance",
     "VetoService",
     "ViolationService",
@@ -210,6 +212,7 @@ class ServerInstance(object):
             rating_service=self.services["rating_service"],
             oauth_service=self.services["oauth_service"],
             veto_service=self.services["veto_service"],
+            replay_review_service=self.services["replay_review_service"],
         )
 
     def write_broadcast(

--- a/server/config.py
+++ b/server/config.py
@@ -102,6 +102,11 @@ class ConfigurationStore:
         # How many seconds a connection has to authenticate before being killed
         self.LOGIN_TIMEOUT = 5 * 60
 
+        # How long a player must wait between replay review requests. Kept in
+        # memory per lobby instance, so this is a spam guard rather than a
+        # quota; see `ReplayReviewService`.
+        self.REPLAY_REVIEW_COOLDOWN_SECONDS = 24 * 60 * 60
+
         self.NEWBIE_BASE_MEAN = 500
         self.NEWBIE_MIN_GAMES = 10
         self.START_RATING_MEAN = 1500

--- a/server/lobbyconnection.py
+++ b/server/lobbyconnection.py
@@ -61,6 +61,7 @@ from .players import Player, PlayerState
 from .protocol import DisconnectedError, Protocol
 from .rating import InclusiveRange, RatingType
 from .rating_service import RatingService
+from .replay_review_service import ReplayReviewService, parse_review_request
 from .types import Address, GameLaunchOptions
 
 
@@ -111,6 +112,7 @@ class LobbyConnection:
         rating_service: RatingService,
         oauth_service: OAuthService,
         veto_service: VetoService,
+        replay_review_service: ReplayReviewService,
     ):
         self._db = database
         self.geoip_service = geoip
@@ -121,6 +123,7 @@ class LobbyConnection:
         self.rating_service = rating_service
         self.oauth_service = oauth_service
         self.veto_service = veto_service
+        self.replay_review_service = replay_review_service
         self._authenticated = False
         self.player: Optional[Player] = None
         self.game_connection: Optional[GameConnection] = None
@@ -1422,6 +1425,24 @@ class LobbyConnection:
             vetoes[matchmaker_queue_map_pool][map_pool_map_version_id] = veto_tokens_applied
 
         await self.veto_service.set_player_vetoes(self.player, vetoes)
+
+    async def command_request_replay_review(self, message):
+        """
+        Ask for a replay of yours to be reviewed by someone.
+
+        The lobby does not answer the request and does not know who will. It
+        validates the content, stamps the sender from this connection, and puts
+        the result on the message queue for whichever service is bound to it.
+
+        The identity stamp is the whole reason this goes through the lobby.
+        Anywhere else a client could name any player it liked; here the socket
+        has already been authenticated, so `player_id` and `login` are the
+        server's word rather than the client's.
+        """
+        assert self.player is not None
+
+        request = parse_review_request(message)
+        await self.replay_review_service.submit(self.player, request)
 
     async def send_warning(self, message: str, fatal: bool = False):
         """

--- a/server/replay_review_service.py
+++ b/server/replay_review_service.py
@@ -1,0 +1,208 @@
+"""
+Accept replay review requests from clients and publish them to the broker.
+
+# Wire contract
+The service publishes to the `MQ_EXCHANGE_NAME` topic exchange with routing
+key `request.replay_review.create`. The body is a UTF-8 JSON object:
+
+- `player_id` (int): the requesting player. **Stamped from the authenticated
+  connection**, never taken from the client message.
+- `login` (str): that player's name, stamped from the same place.
+- `replay_id` (int): the replay to review.
+- `map`, `game_mode`, `faction`, `rating`, `played_at` (str, may be empty):
+  context the reviewer sees before opening the replay.
+- `goal` (str, non-empty): what the player wants out of the review.
+- `struggle` (str, may be empty): what went wrong from the player's view.
+- `requested_at` (str): ISO 8601 UTC timestamp of when the lobby accepted it.
+
+Consumers render this into whatever their destination wants. The lobby does
+not compose prose, so the shape of a review post can change without a client
+release, and a second consumer can use the same request differently.
+
+# Why the lobby is involved at all
+The point of the detour is identity. A client posting straight to a chat
+service can claim to be anyone; a client sending this command is already
+authenticated on the lobby socket, so the player id on the request is one the
+server vouches for. Nothing else here needs the lobby.
+"""
+
+import logging
+import time
+from typing import Any, ClassVar, Optional
+
+from .config import config
+from .core import Service
+from .decorators import with_logger
+from .exceptions import ClientError
+from .message_queue_service import MessageQueueService
+from .players import Player
+from .timing import datetime_now
+
+REPLAY_REVIEW_ROUTING_KEY = "request.replay_review.create"
+
+# Free text the reviewer reads. Long enough for someone to explain a game,
+# short enough that a single request cannot fill a channel.
+MAX_GOAL_LENGTH = 1000
+MAX_STRUGGLE_LENGTH = 1000
+# Everything else is a label, not prose.
+MAX_LABEL_LENGTH = 100
+
+_LABEL_FIELDS = ("map", "game_mode", "faction", "rating", "played_at")
+
+
+def _clean_text(value: Any, field: str, max_length: int) -> str:
+    """
+    A trimmed string, or a `ClientError` naming the field that was wrong.
+
+    Rejects non-strings rather than coercing them: a client sending a number
+    where prose belongs has a bug, and silently stringifying it would put that
+    bug in front of a reviewer instead of in front of its author.
+    """
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ClientError(f"Invalid replay review request: {field} must be text")
+
+    # Newlines and tabs are kept - an explanation is allowed to have
+    # paragraphs - but the rest of the control range is stripped. None of it
+    # can be typed deliberately, and some of it can make a rendered post look
+    # like something the player did not write.
+    value = "".join(
+        char for char in value
+        if char in ("\n", "\t") or ord(char) >= 0x20
+    ).strip()
+
+    if len(value) > max_length:
+        raise ClientError(
+            f"Invalid replay review request: {field} is longer than "
+            f"{max_length} characters"
+        )
+    return value
+
+
+def parse_review_request(message: dict) -> dict:
+    """
+    The content fields of a review request, validated.
+
+    Deliberately excludes identity: the caller stamps `player_id` and `login`
+    from the connection. Whatever the client says about who it is is dropped
+    here rather than overwritten afterwards, so there is no ordering in which
+    the client's version survives.
+
+    A replay is named by id only. The client also knows how to name one by
+    link or by a local file, but neither belongs on the bus: a link would let
+    the client choose what a review post points at, and a file nobody else can
+    fetch is not a review request. Those two cases keep using the client's own
+    copy-and-paste path.
+    """
+    replay_id = message.get("replay_id")
+    # bool is an int in Python, and `True` would otherwise sail through as
+    # replay 1.
+    if isinstance(replay_id, bool) or not isinstance(replay_id, int):
+        raise ClientError(
+            "Invalid replay review request: replay_id must be a replay number"
+        )
+    if replay_id <= 0:
+        raise ClientError(
+            "Invalid replay review request: replay_id must be positive"
+        )
+
+    goal = _clean_text(message.get("goal"), "goal", MAX_GOAL_LENGTH)
+    if not goal:
+        raise ClientError(
+            "Invalid replay review request: say what you would like help with"
+        )
+
+    request = {
+        "replay_id": replay_id,
+        "goal": goal,
+        "struggle": _clean_text(
+            message.get("struggle"), "struggle", MAX_STRUGGLE_LENGTH
+        ),
+    }
+    for field in _LABEL_FIELDS:
+        request[field] = _clean_text(message.get(field), field, MAX_LABEL_LENGTH)
+
+    return request
+
+
+@with_logger
+class ReplayReviewService(Service):
+    """
+    Rate limit replay review requests and publish the ones that get through.
+
+    The limit is per player and held in memory, which makes it a spam guard
+    rather than a quota: it does not survive a restart and each lobby instance
+    counts on its own. That is deliberate. The cost of a duplicate request is a
+    duplicate post, and the alternative is a schema migration plus a database
+    write on a path that has no other reason to touch the database. A consumer
+    that needs a hard guarantee can deduplicate on `player_id` itself.
+    """
+
+    _logger: ClassVar[logging.Logger]
+
+    def __init__(self, message_queue_service: MessageQueueService):
+        self.message_queue_service = message_queue_service
+        # player id -> monotonic timestamp of their last accepted request
+        self._last_accepted: dict[int, float] = {}
+
+    def _prune(self, now: float) -> None:
+        cooldown = config.REPLAY_REVIEW_COOLDOWN_SECONDS
+        self._last_accepted = {
+            player_id: at
+            for player_id, at in self._last_accepted.items()
+            if now - at < cooldown
+        }
+
+    def seconds_until_allowed(self, player_id: int, now: float) -> float:
+        """How long this player still has to wait; `0` if they may request."""
+        last = self._last_accepted.get(player_id)
+        if last is None:
+            return 0.0
+        remaining = config.REPLAY_REVIEW_COOLDOWN_SECONDS - (now - last)
+        return max(0.0, remaining)
+
+    async def submit(
+        self,
+        player: Player,
+        request: dict,
+        now: Optional[float] = None,
+    ) -> None:
+        """
+        Publish one validated request on behalf of an authenticated player.
+
+        Raises `ClientError` if the player is still inside their cooldown, and
+        does so before anything is published: a rejected request never reaches
+        the bus, so abuse costs a consumer nothing.
+        """
+        if now is None:
+            now = time.monotonic()
+        self._prune(now)
+
+        remaining = self.seconds_until_allowed(player.id, now)
+        if remaining > 0:
+            hours = int(remaining // 3600) + 1
+            raise ClientError(
+                "You have already requested a replay review recently. You can "
+                f"request another one in about {hours} hour(s).",
+                recoverable=True,
+            )
+
+        payload = {
+            "player_id": player.id,
+            "login": player.login,
+            "requested_at": datetime_now().isoformat(),
+            **request,
+        }
+
+        await self.message_queue_service.publish(
+            config.MQ_EXCHANGE_NAME,
+            REPLAY_REVIEW_ROUTING_KEY,
+            payload,
+        )
+        self._last_accepted[player.id] = now
+        self._logger.info(
+            "Published replay review request for player %s, replay %s",
+            player.id,
+            request["replay_id"],
+        )

--- a/server/replay_review_service.py
+++ b/server/replay_review_service.py
@@ -142,6 +142,7 @@ class ReplayReviewService(Service):
     _logger: ClassVar[logging.Logger]
 
     def __init__(self, message_queue_service: MessageQueueService):
+        """Wire the broker; the cooldown table starts empty."""
         self.message_queue_service = message_queue_service
         # player id -> monotonic timestamp of their last accepted request
         self._last_accepted: dict[int, float] = {}

--- a/server/replay_review_service.py
+++ b/server/replay_review_service.py
@@ -195,12 +195,22 @@ class ReplayReviewService(Service):
             **request,
         }
 
-        await self.message_queue_service.publish(
-            config.MQ_EXCHANGE_NAME,
-            REPLAY_REVIEW_ROUTING_KEY,
-            payload,
-        )
+        # Claimed before the publish rather than after it. A connection's
+        # messages are dispatched one at a time, so the window only exists
+        # while one player has two connections, but ordering it this way costs
+        # nothing and the rollback is worth having on its own: a request that
+        # never reached the broker should not cost the player their turn.
         self._last_accepted[player.id] = now
+        try:
+            await self.message_queue_service.publish(
+                config.MQ_EXCHANGE_NAME,
+                REPLAY_REVIEW_ROUTING_KEY,
+                payload,
+            )
+        except BaseException:
+            self._last_accepted.pop(player.id, None)
+            raise
+
         self._logger.info(
             "Published replay review request for player %s, replay %s",
             player.id,

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -27,6 +27,7 @@ from server import (
     LadderService,
     OAuthService,
     PartyService,
+    ReplayReviewService,
     ServerInstance,
     VetoService,
     ViolationService
@@ -76,6 +77,14 @@ async def violation_service():
 @pytest.fixture
 async def veto_service(player_service):
     service = VetoService(player_service)
+    await service.initialize()
+    yield service
+    await service.shutdown()
+
+
+@pytest.fixture
+async def replay_review_service(message_queue_service):
+    service = ReplayReviewService(message_queue_service)
     await service.initialize()
     yield service
     await service.shutdown()
@@ -159,6 +168,7 @@ async def lobby_server_factory(
     oauth_service,
     violation_service,
     veto_service,
+    replay_review_service,
     policy_server,
     jwks_server,
 ):
@@ -181,6 +191,7 @@ async def lobby_server_factory(
                 "oauth_service": oauth_service,
                 "violation_service": violation_service,
                 "veto_service": veto_service,
+                "replay_review_service": replay_review_service,
             })
         # Set up the back reference
         broadcast_service.server = instance

--- a/tests/integration_tests/test_server_instance.py
+++ b/tests/integration_tests/test_server_instance.py
@@ -33,6 +33,7 @@ async def test_multiple_contexts(
     rating_service,
     oauth_service,
     veto_service,
+    replay_review_service,
 ):
     """Verify multiple ServerContexts on one ServerInstance share state."""
     config.USE_POLICY_SERVER = False
@@ -52,6 +53,7 @@ async def test_multiple_contexts(
             "party_service": party_service,
             "oauth_service": oauth_service,
             "veto_service": veto_service,
+            "replay_review_service": replay_review_service,
         }
     )
     broadcast_service.server = instance

--- a/tests/integration_tests/test_servercontext.py
+++ b/tests/integration_tests/test_servercontext.py
@@ -77,6 +77,7 @@ async def context(mock_service):
             rating_service=mock.Mock(),
             oauth_service=mock.Mock(),
             veto_service=mock.Mock(),
+            replay_review_service=mock.Mock(),
         )
 
     ctx = ServerContext("TestServer", make_connection, [mock_service])

--- a/tests/unit_tests/test_lobbyconnection.py
+++ b/tests/unit_tests/test_lobbyconnection.py
@@ -24,6 +24,7 @@ from server.player_service import PlayerService
 from server.players import PlayerState
 from server.protocol import DisconnectedError, QDataStreamProtocol
 from server.rating import InclusiveRange, RatingType
+from server.replay_review_service import ReplayReviewService
 from server.team_matchmaker import PlayerParty
 from server.types import Address
 
@@ -99,6 +100,7 @@ async def lobbyconnection(
         rating_service=rating_service,
         oauth_service=mock.create_autospec(OAuthService),
         veto_service=mock.create_autospec(VetoService),
+        replay_review_service=mock.create_autospec(ReplayReviewService),
     )
 
     lc.player = mock_player
@@ -1346,4 +1348,102 @@ async def test_abort_connection_if_banned(
         r"You are banned from FAF for 1 day and 2[12]\.[0-9]+ hours. <br>"
         "Reason: <br>Test ongoing ban with 46 hours left",
         banned_error.value.message()
+    )
+
+
+async def test_command_request_replay_review(lobbyconnection: LobbyConnection):
+    lobbyconnection.player.id = 4242
+
+    await lobbyconnection.on_message_received({
+        "command": "request_replay_review",
+        "replay_id": 22334455,
+        "map": "Setons Clutch",
+        "goal": "Why does my eco stall at eight minutes?",
+    })
+
+    lobbyconnection.replay_review_service.submit.assert_called_once()
+    player, request = (
+        lobbyconnection.replay_review_service.submit.call_args[0]
+    )
+    assert player is lobbyconnection.player
+    assert request["replay_id"] == 22334455
+    assert request["goal"] == "Why does my eco stall at eight minutes?"
+    assert request["map"] == "Setons Clutch"
+
+
+async def test_command_request_replay_review_ignores_claimed_identity(
+    lobbyconnection: LobbyConnection
+):
+    """The sender is the connection's player, whatever the message says."""
+    lobbyconnection.player.id = 4242
+
+    await lobbyconnection.on_message_received({
+        "command": "request_replay_review",
+        "replay_id": 22334455,
+        "player_id": 1,
+        "login": "SomeoneElse",
+        "goal": "help",
+    })
+
+    _, request = lobbyconnection.replay_review_service.submit.call_args[0]
+    assert "player_id" not in request
+    assert "login" not in request
+
+
+async def test_command_request_replay_review_invalid(
+    lobbyconnection: LobbyConnection
+):
+    """A malformed request is answered, not published."""
+    lobbyconnection.send = mock.AsyncMock()
+
+    await lobbyconnection.on_message_received({
+        "command": "request_replay_review",
+        "goal": "help",
+    })
+
+    lobbyconnection.replay_review_service.submit.assert_not_called()
+    lobbyconnection.send.assert_called_once_with({
+        "command": "notice",
+        "style": "error",
+        "text": "Invalid replay review request: replay_id must be a replay number"
+    })
+
+
+async def test_command_request_replay_review_rate_limited(
+    lobbyconnection: LobbyConnection
+):
+    """A throttled request reaches the player as a notice, not the bus."""
+    lobbyconnection.send = mock.AsyncMock()
+    lobbyconnection.replay_review_service.submit.side_effect = ClientError(
+        "You have already requested a replay review recently."
+    )
+
+    await lobbyconnection.on_message_received({
+        "command": "request_replay_review",
+        "replay_id": 22334455,
+        "goal": "help",
+    })
+
+    lobbyconnection.send.assert_called_once_with({
+        "command": "notice",
+        "style": "error",
+        "text": "You have already requested a replay review recently."
+    })
+
+
+async def test_command_request_replay_review_requires_authentication(
+    lobbyconnection: LobbyConnection
+):
+    lobbyconnection._authenticated = False
+    lobbyconnection.abort = mock.AsyncMock()
+
+    await lobbyconnection.on_message_received({
+        "command": "request_replay_review",
+        "replay_id": 22334455,
+        "goal": "help",
+    })
+
+    lobbyconnection.replay_review_service.submit.assert_not_called()
+    lobbyconnection.abort.assert_called_once_with(
+        "Message invalid for unauthenticated connection: request_replay_review"
     )

--- a/tests/unit_tests/test_replay_review_service.py
+++ b/tests/unit_tests/test_replay_review_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -233,3 +234,46 @@ async def test_expired_entries_do_not_accumulate(
         now=config.REPLAY_REVIEW_COOLDOWN_SECONDS + 100,
     )
     assert len(service._last_accepted) == 1
+
+
+async def test_a_publish_that_fails_does_not_cost_the_player_their_turn(
+    service, message_queue_service, player_factory, valid_message
+):
+    player = player_factory("Rhiza", player_id=4242)
+    request = parse_review_request(valid_message)
+    message_queue_service.publish.side_effect = ConnectionError("broker down")
+
+    with pytest.raises(ConnectionError):
+        await service.submit(player, request, now=0.0)
+
+    message_queue_service.publish.side_effect = None
+    await service.submit(player, request, now=1.0)
+
+    assert message_queue_service.publish.call_count == 2
+
+
+async def test_two_requests_in_flight_at_once_publish_once(
+    service, message_queue_service, player_factory, valid_message
+):
+    """The cooldown is claimed before publishing, not after it returns."""
+    player = player_factory("Rhiza", player_id=4242)
+    request = parse_review_request(valid_message)
+
+    release = asyncio.Event()
+
+    async def block(*args, **kwargs):
+        await release.wait()
+
+    message_queue_service.publish.side_effect = block
+
+    first = asyncio.create_task(service.submit(player, request, now=0.0))
+    # Let the first request reach the publish and suspend there.
+    await asyncio.sleep(0)
+
+    with pytest.raises(ClientError):
+        await service.submit(player, request, now=1.0)
+
+    release.set()
+    await first
+
+    assert message_queue_service.publish.call_count == 1

--- a/tests/unit_tests/test_replay_review_service.py
+++ b/tests/unit_tests/test_replay_review_service.py
@@ -1,0 +1,235 @@
+from unittest import mock
+
+import pytest
+
+from server.config import config
+from server.exceptions import ClientError
+from server.message_queue_service import MessageQueueService
+from server.replay_review_service import (
+    MAX_GOAL_LENGTH,
+    MAX_LABEL_LENGTH,
+    REPLAY_REVIEW_ROUTING_KEY,
+    ReplayReviewService,
+    parse_review_request
+)
+
+
+@pytest.fixture
+def message_queue_service():
+    return mock.create_autospec(MessageQueueService)
+
+
+@pytest.fixture
+def service(message_queue_service):
+    return ReplayReviewService(message_queue_service)
+
+
+@pytest.fixture
+def valid_message():
+    return {
+        "command": "request_replay_review",
+        "replay_id": 22334455,
+        "map": "Seton's Clutch",
+        "game_mode": "faf",
+        "faction": "UEF",
+        "rating": "1100",
+        "played_at": "2026-09-05T19:12:00Z",
+        "goal": "I want to know why my eco stalls at eight minutes.",
+        "struggle": "I never have mass for the second land factory.",
+    }
+
+
+# --- parsing -----------------------------------------------------------------
+
+def test_parse_keeps_the_content_fields(valid_message):
+    request = parse_review_request(valid_message)
+
+    assert request == {
+        "replay_id": 22334455,
+        "goal": "I want to know why my eco stalls at eight minutes.",
+        "struggle": "I never have mass for the second land factory.",
+        "map": "Seton's Clutch",
+        "game_mode": "faf",
+        "faction": "UEF",
+        "rating": "1100",
+        "played_at": "2026-09-05T19:12:00Z",
+    }
+
+
+def test_parse_drops_client_supplied_identity(valid_message):
+    """The client does not get to say who it is, at any point."""
+    valid_message.update({
+        "player_id": 1,
+        "login": "Brutus5000",
+        "command": "request_replay_review",
+    })
+
+    request = parse_review_request(valid_message)
+
+    assert "player_id" not in request
+    assert "login" not in request
+    assert "command" not in request
+
+
+def test_parse_fills_missing_labels_with_empty_strings():
+    request = parse_review_request({"replay_id": 1, "goal": "help"})
+
+    assert request["map"] == ""
+    assert request["struggle"] == ""
+
+
+@pytest.mark.parametrize("replay_id", [None, "22334455", 0, -1, True, 1.5])
+def test_parse_rejects_bad_replay_id(replay_id):
+    with pytest.raises(ClientError):
+        parse_review_request({"replay_id": replay_id, "goal": "help"})
+
+
+@pytest.mark.parametrize("goal", [None, "", "   ", "\n\n"])
+def test_parse_requires_a_goal(goal):
+    with pytest.raises(ClientError):
+        parse_review_request({"replay_id": 1, "goal": goal})
+
+
+def test_parse_rejects_non_text_where_text_belongs():
+    with pytest.raises(ClientError):
+        parse_review_request({"replay_id": 1, "goal": "help", "map": 5})
+
+
+def test_parse_rejects_overlong_free_text():
+    with pytest.raises(ClientError):
+        parse_review_request({
+            "replay_id": 1,
+            "goal": "a" * (MAX_GOAL_LENGTH + 1),
+        })
+
+
+def test_parse_rejects_overlong_labels():
+    with pytest.raises(ClientError):
+        parse_review_request({
+            "replay_id": 1,
+            "goal": "help",
+            "map": "a" * (MAX_LABEL_LENGTH + 1),
+        })
+
+
+def test_parse_strips_control_characters_but_keeps_paragraphs():
+    request = parse_review_request({
+        "replay_id": 1,
+        "goal": "first line\n\nsecond line\x07\x00",
+    })
+
+    assert request["goal"] == "first line\n\nsecond line"
+
+
+# --- publishing --------------------------------------------------------------
+
+async def test_submit_publishes_with_server_stamped_identity(
+    service, message_queue_service, player_factory, valid_message
+):
+    player = player_factory("Rhiza", player_id=4242)
+
+    await service.submit(player, parse_review_request(valid_message))
+
+    message_queue_service.publish.assert_called_once()
+    exchange, routing_key, payload = message_queue_service.publish.call_args[0]
+
+    assert exchange == config.MQ_EXCHANGE_NAME
+    assert routing_key == REPLAY_REVIEW_ROUTING_KEY
+    assert payload["player_id"] == 4242
+    assert payload["login"] == "Rhiza"
+    assert payload["replay_id"] == 22334455
+    assert "requested_at" in payload
+
+
+async def test_submit_ignores_identity_the_client_tried_to_set(
+    service, message_queue_service, player_factory, valid_message
+):
+    """
+    A client that sends its own `player_id` gets the connection's anyway.
+
+    This is the property the whole design rests on, so it is asserted end to
+    end rather than only at the parser.
+    """
+    valid_message["player_id"] = 1
+    valid_message["login"] = "Brutus5000"
+    player = player_factory("Rhiza", player_id=4242)
+
+    await service.submit(player, parse_review_request(valid_message))
+
+    payload = message_queue_service.publish.call_args[0][2]
+    assert payload["player_id"] == 4242
+    assert payload["login"] == "Rhiza"
+
+
+async def test_submit_rate_limits_per_player(
+    service, message_queue_service, player_factory, valid_message
+):
+    player = player_factory("Rhiza", player_id=4242)
+    request = parse_review_request(valid_message)
+
+    await service.submit(player, request, now=0.0)
+    with pytest.raises(ClientError):
+        await service.submit(player, request, now=60.0)
+
+    assert message_queue_service.publish.call_count == 1
+
+
+async def test_a_rejected_request_never_reaches_the_bus(
+    service, message_queue_service, player_factory, valid_message
+):
+    player = player_factory("Rhiza", player_id=4242)
+    request = parse_review_request(valid_message)
+
+    await service.submit(player, request, now=0.0)
+    message_queue_service.publish.reset_mock()
+
+    with pytest.raises(ClientError):
+        await service.submit(player, request, now=1.0)
+
+    message_queue_service.publish.assert_not_called()
+
+
+async def test_other_players_are_not_rate_limited(
+    service, message_queue_service, player_factory, valid_message
+):
+    request = parse_review_request(valid_message)
+
+    await service.submit(player_factory("Rhiza", player_id=1), request, now=0.0)
+    await service.submit(player_factory("Sheikah", player_id=2), request, now=1.0)
+
+    assert message_queue_service.publish.call_count == 2
+
+
+async def test_the_cooldown_expires(
+    service, message_queue_service, player_factory, valid_message
+):
+    player = player_factory("Rhiza", player_id=4242)
+    request = parse_review_request(valid_message)
+
+    await service.submit(player, request, now=0.0)
+    await service.submit(
+        player, request, now=config.REPLAY_REVIEW_COOLDOWN_SECONDS + 1
+    )
+
+    assert message_queue_service.publish.call_count == 2
+
+
+async def test_expired_entries_do_not_accumulate(
+    service, player_factory, valid_message
+):
+    request = parse_review_request(valid_message)
+
+    for player_id in range(10):
+        await service.submit(
+            player_factory(f"Player{player_id}", player_id=player_id),
+            request,
+            now=float(player_id),
+        )
+    assert len(service._last_accepted) == 10
+
+    await service.submit(
+        player_factory("Latecomer", player_id=99),
+        request,
+        now=config.REPLAY_REVIEW_COOLDOWN_SECONDS + 100,
+    )
+    assert len(service._last_accepted) == 1

--- a/tests/unit_tests/test_replay_review_service.py
+++ b/tests/unit_tests/test_replay_review_service.py
@@ -145,12 +145,9 @@ async def test_submit_publishes_with_server_stamped_identity(
 async def test_submit_ignores_identity_the_client_tried_to_set(
     service, message_queue_service, player_factory, valid_message
 ):
-    """
-    A client that sends its own `player_id` gets the connection's anyway.
-
-    This is the property the whole design rests on, so it is asserted end to
-    end rather than only at the parser.
-    """
+    """A client that sends its own `player_id` gets the connection's anyway."""
+    # The property the whole design rests on, so it is asserted end to end
+    # rather than only at the parser.
     valid_message["player_id"] = 1
     valid_message["login"] = "Brutus5000"
     player = player_factory("Rhiza", player_id=4242)


### PR DESCRIPTION
Closes FAForever/faf-java-api#1181

Adds a `request_replay_review` lobby command. It validates the content fields of a replay review request, stamps the requesting player from the authenticated connection, and publishes the result to the topic exchange with routing key `request.replay_review.create`.

The lobby neither answers the request nor knows who will. A consumer bound to that key turns it into a post wherever reviews are actually answered — the intended first one is a forum post by faf-qai, which is a separate PR and not required for this one to be safe to merge.

## Why this goes through the lobby at all

Identity. A client posting straight to a chat service can claim to be anyone, which is what sank the earlier proposals. A client on this socket has already authenticated, so `player_id` and `login` are the server's word rather than the client's. Nothing else in the feature needs the lobby.

## What is in here

- `server/replay_review_service.py` — validation, the rate limit, and the publish. The wire contract is documented in the module docstring.
- `command_request_replay_review` on `LobbyConnection`, next to the other party/veto commands.
- `REPLAY_REVIEW_COOLDOWN_SECONDS` in `config.py`.

## Three decisions worth looking at

**The client cannot name a replay by url.** The payload takes `replay_id` only. The client also knows how to name a replay by link or by a local file, but a link would let the client decide what a review post points at, and a file nobody else can fetch is not a review request. Those keep using the client's existing copy-and-paste path.

**Identity is dropped at the parser, not overwritten later.** `parse_review_request` returns content fields only, and the caller adds `player_id`/`login`. There is deliberately no ordering of operations in which a client-supplied value survives — `test_submit_ignores_identity_the_client_tried_to_set` pins that end to end.

**The rate limit is in memory.** One request per player per 24h, per lobby instance, lost on restart. That makes it a spam guard rather than a quota. The cost of a duplicate is a duplicate post, and the alternative is a schema migration plus a database write on a path that has no other reason to touch the database. Rejections happen before publishing, so an over-limit request never reaches the bus. Happy to change this if you would rather have it durable — it is contained in one service.

## Deploying this alone is a no-op

With no queue bound to the routing key, published messages go nowhere and cost nothing. That makes the rollout order lobby-first, and unbinding the queue later is the off switch — no client release, no code change.

## Not covered

The lobby sends nothing back on success and answers a rejection through the existing `notice` path, the same as `command_invite_to_party`, so a client shows success optimistically. If an explicit acknowledgement is wanted that is a new server→client command, and better decided before clients are written against it. Noted as the fifth question in FAForever/faf-java-api#1181.

## Tests

- `tests/unit_tests/test_replay_review_service.py` — parsing, the identity stamp, the rate limit, and that a rejected request never reaches the broker.
- `tests/unit_tests/test_lobbyconnection.py` — the command wiring, including that an unauthenticated connection never reaches the handler.

`flake8` and `isort` are clean on the changed files. The suite itself I could not run locally — it wants Python 3.13 plus MySQL and RabbitMQ — so CI here is the first full run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a replay review request flow from authenticated lobby players.
  * Replay review submissions are validated, sanitized, and queued for processing.
  * Added protection against repeated submissions with a one-day per-player cooldown.
  * Server-assigned identity and timestamps help ensure request information is trustworthy.

* **Bug Fixes**
  * Invalid or unauthenticated replay review requests now receive appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->