### PR TITLE
Replace hardcoded ban text with localizable key #640

### DIFF
--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -32,12 +32,13 @@ class BanError(Exception):
         self.ban_reason = ban_reason
 
     def message(self):
-        return (
-            f"You are banned from FAF {self._ban_duration_text()}. <br>"
-            f"Reason: <br>{self.ban_reason}<br><br>"
-            "<i>If you would like to appeal this ban, please send an email to: "
-            "moderation@faforever.com</i>"
-        )
+        return {
+            "key": "SERVER_ERROR_BANNED_FROM_FAF",
+            "args": {
+                "ban_duration": self._ban_duration_text(),
+                "ban_reason": self.ban_reason
+            }
+        }
 
     def _ban_duration_text(self):
         ban_duration = self.ban_expiry - datetime_now()

--- a/server/exceptions.py
+++ b/server/exceptions.py
@@ -32,13 +32,15 @@ class BanError(Exception):
         self.ban_reason = ban_reason
 
     def message(self):
+        """Return the structured localizable ban message with an ISO 8601 timestamp."""
         return {
             "key": "SERVER_ERROR_BANNED_FROM_FAF",
             "args": {
-                "ban_duration": self._ban_duration_text(),
+                "expires_at": self.ban_expiry.isoformat() if self.ban_expiry else "forever",
                 "ban_reason": self.ban_reason
             }
         }
+
 
     def _ban_duration_text(self):
         ban_duration = self.ban_expiry - datetime_now()


### PR DESCRIPTION
Closes FAForever/server#640


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ban notifications now use a structured error format, including the ban duration and reason.
  * Removed the previous HTML-formatted message and appeal email instruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->